### PR TITLE
add more null support in filters

### DIFF
--- a/src/app/components/querybuilder/date-filter-input.tsx
+++ b/src/app/components/querybuilder/date-filter-input.tsx
@@ -61,8 +61,8 @@ export function DateFilterInput({ filter, onChange, dataType }: DateFilterInputP
 
   const removeValue = (index: number) => {
     const newValues = filter.value.filter((_, i) => i !== index);
-    if (newValues.length === 0 || (newValues.length === 1 && newValues[0] === null)) {
-      // Don't allow removing all non-null values - add a default one
+    if (newValues.length === 0) {
+      // Don't allow removing all values - add a default one. A single null is allowed.
       const today = new Date().toISOString().split('T')[0];
       newValues.unshift(today);
     }
@@ -153,7 +153,9 @@ export function DateFilterInput({ filter, onChange, dataType }: DateFilterInputP
                   value={val as string}
                   onChange={(e) => handleValueChange(idx, e.target.value)}
                 />
-                {nonNullValues.length > 1 && (
+                {/* Only show the remove button if there are multiple non-null values or if null
+                    is included, since we allow a single null value. */}
+                {(nonNullValues.length > 1 || includesNull) && (
                   <IconButton
                     variant="soft"
                     size="1"
@@ -195,7 +197,7 @@ export function DateFilterInput({ filter, onChange, dataType }: DateFilterInputP
 
       {renderValueInputs()}
 
-      {(operator === 'on' || operator === 'in-list') && (
+      {(operator === 'on' || operator === 'in-list' || operator === 'not-in-list') && (
         <Flex gap="1" align="center">
           <Checkbox checked={includesNull} onCheckedChange={(checked) => handleNullChange(!!checked)} />
           <Text size="2">Include NULL</Text>

--- a/src/app/components/querybuilder/numeric-filter-input.tsx
+++ b/src/app/components/querybuilder/numeric-filter-input.tsx
@@ -166,8 +166,8 @@ export function NumericFilterInput({ filter, onChange, dataType }: NumericFilter
       (_, i) => i !== filter.value.findIndex((v, idx) => v !== null && idx === index),
     );
 
-    if (newValues.length === 0 || (newValues.length === 1 && newValues[0] === null)) {
-      // Don't allow removing all non-null values - add a default one
+    if (newValues.length === 0) {
+      // Don't allow removing all values - add a default one. A single null is allowed.
       const defaultValue = dataType === 'integer' || dataType === 'bigint' ? 0 : 0.0;
       newValues.unshift(defaultValue);
       setListValues([String(defaultValue)]);
@@ -361,7 +361,9 @@ export function NumericFilterInput({ filter, onChange, dataType }: NumericFilter
                     }
                   }}
                 />
-                {nonNullValues.length > 1 && (
+                {/* Only show the remove button if there are multiple non-null values or if null
+                    is included, since we allow a single null value. */}
+                {(nonNullValues.length > 1 || includesNull) && (
                   <IconButton
                     variant="soft"
                     size="1"
@@ -404,7 +406,9 @@ export function NumericFilterInput({ filter, onChange, dataType }: NumericFilter
 
       {renderValueInputs()}
 
-      {(operator === 'equals' || operator === 'in-list') && (
+      {(operator === 'equals' ||
+        operator === 'in-list' ||
+        operator === 'not-in-list') && (
         <Flex gap="1" align="center">
           <Checkbox checked={includesNull} onCheckedChange={(checked) => handleNullChange(!!checked)} />
           <Text size="2">Include NULL</Text>

--- a/src/app/components/querybuilder/string-filter-input.tsx
+++ b/src/app/components/querybuilder/string-filter-input.tsx
@@ -87,7 +87,9 @@ export function StringFilterInput({ filter, onChange, dataType }: StringFilterIn
         {nonNullValues.map((val, idx) => (
           <Flex key={idx} gap="1" align="center">
             <TextField.Root value={val as string} onChange={(e) => handleValueChange(idx, e.target.value)} />
-            {nonNullValues.length > 1 && (
+            {/* Only show the remove button if there are multiple non-null values or if null
+                is included, since we allow a single null value. */}
+            {(nonNullValues.length > 1 || includesNull) && (
               <IconButton
                 variant="soft"
                 size="1"
@@ -132,7 +134,9 @@ export function StringFilterInput({ filter, onChange, dataType }: StringFilterIn
 
       {renderValueInputs()}
 
-      {(operator === 'equals' || operator === 'in-list') && (
+      {(operator === 'equals' ||
+        operator === 'in-list' ||
+        operator === 'not-in-list') && (
         <Flex gap="1" align="center">
           <Checkbox checked={includesNull} onCheckedChange={(checked) => handleNullChange(!!checked)} />
           <Text size="2">Include NULL</Text>


### PR DESCRIPTION
This was motivated by NH, which has a `hash is not null` string check and `consented_at is not null` and `unsubscribe_at is null` date checks.