### PR TITLE
fix AddParticipantTypeDialog: don't revalidate table data when editing

### DIFF
--- a/src/app/datasourcedetails/add-participant-type-dialog.tsx
+++ b/src/app/datasourcedetails/add-participant-type-dialog.tsx
@@ -22,6 +22,9 @@ const AddParticipantTypeDialogInner = ({ datasourceId, tables }: { datasourceId:
     {
       swr: {
         enabled: tableIsSelected,
+        revalidateIfStale: false,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false
       },
     },
   );
@@ -100,7 +103,7 @@ const AddParticipantTypeDialogInner = ({ datasourceId, tables }: { datasourceId:
                 },
               });
               setOpen(false);
-              setFields([]);
+              updateSelectedTable('');
             }}
           >
             <Dialog.Title>Add Participant Type</Dialog.Title>


### PR DESCRIPTION
Disable revalidating of data due to stale/focus/reconnect events when the dialog is open, because we could be in mid-edit. But let explicit events (changing the selectedTable) still drive updates.

Also reset the dialog state on close by setting selectedTable to ''