### PR TITLE
For discussion: should we integrate code snippets into UI somewhere?

### DIFF
--- a/src/app/experiments/view/[id]/experiment-assignment-code-snippet.tsx
+++ b/src/app/experiments/view/[id]/experiment-assignment-code-snippet.tsx
@@ -1,0 +1,52 @@
+import { Box, Code, Flex, Tabs } from '@radix-ui/themes';
+import { CopyToClipBoard } from '@/app/components/buttons/copy-to-clipboard';
+import { API_BASE_URL } from '@/services/constants';
+
+const snippets = await import('./snippets.json');
+
+export function ExperimentAssignmentCodeSnippet({
+  datasourceId,
+  experimentId,
+}: {
+  datasourceId: string;
+  experimentId: string;
+}) {
+  const curlExample = `curl -H "X-API-Key: my-api-key" -H "Datasource-ID: ${datasourceId}" ${API_BASE_URL}/v1/experiment/${experimentId}/assignments/participant-type-id`;
+
+  const Variant = ({ tabLabel, value }: { tabLabel: string; value: string }) => {
+    return (
+      <Tabs.Content value={tabLabel}>
+        <Flex direction={'row'} gap={'3'}>
+          <Code
+            style={{
+              whiteSpace: 'pre-wrap',
+              padding: '10px',
+              width: 'auto',
+            }}
+          >
+            {value}
+          </Code>
+          <CopyToClipBoard content={value} />
+        </Flex>
+      </Tabs.Content>
+    );
+  };
+  return (
+    <Tabs.Root defaultValue={'shell'}>
+      <Tabs.List>
+        <Tabs.Trigger value="shell">Shell</Tabs.Trigger>
+        <Tabs.Trigger value="python">Python</Tabs.Trigger>
+        <Tabs.Trigger value="php">PHP</Tabs.Trigger>
+        <Tabs.Trigger value="ruby">Ruby</Tabs.Trigger>
+        <Tabs.Trigger value="rust">Rust</Tabs.Trigger>
+      </Tabs.List>
+
+      <Box pt={'3'}>
+        <Variant tabLabel={'shell'} value={curlExample} />
+        <Variant tabLabel={'python'} value={snippets['python']} />
+        <Variant tabLabel={'php'} value={'TODO'} />
+        <Variant tabLabel={'rust'} value={'TODO'} />
+      </Box>
+    </Tabs.Root>
+  );
+}

--- a/src/app/experiments/view/[id]/page.tsx
+++ b/src/app/experiments/view/[id]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Button, Card, Flex, Grid, Heading, Separator, Table, Tabs, Text } from '@radix-ui/themes';
+import { Button, Card, Flex, Grid, Heading, Separator, Switch, Table, Tabs, Text } from '@radix-ui/themes';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { ArrowLeftIcon, CodeIcon } from '@radix-ui/react-icons';
 import { useAnalyzeExperiment, useGetExperiment } from '@/api/admin';
@@ -13,11 +13,14 @@ import * as Toast from '@radix-ui/react-toast';
 import { CodeSnippetCard } from '@/app/components/cards/code-snippet-card';
 import { ExperimentTypeBadge } from '../../experiment-type-badge';
 import Link from 'next/link';
+import { DownloadAssignmentsCsvButton } from '@/app/experiments/download-assignments-csv-button';
+import { ExperimentAssignmentCodeSnippet } from '@/app/experiments/view/[id]/experiment-assignment-code-snippet';
 
 export default function ExperimentViewPage() {
   const [openToast, setOpenToast] = useState(false);
   const params = useParams();
   const router = useRouter();
+  const [showExamples, setShowExamples] = useState<boolean>(false);
   const searchParams = useSearchParams();
   const experimentId = params.id as string;
   const datasourceId = searchParams.get('datasource_id');
@@ -138,6 +141,40 @@ export default function ExperimentViewPage() {
           </Table.Root>
         </Card>
       </Grid>
+
+      <Card>
+        <Heading size={'3'}>Assignments</Heading>
+        <Separator my={'3'} size={'4'} />
+        <Flex direction={'column'}>
+          <Flex>
+            <DownloadAssignmentsCsvButton
+              datasourceId={experiment.datasource_id}
+              experimentId={experiment.design_spec.experiment_id!}
+            />
+          </Flex>
+          {experiment.design_spec.experiment_type === 'online' && (
+            <>
+              <Text>This is an online experiment; assignments are generated on-demand.</Text>
+              <Text as="label" size="2">
+                <Flex gap="2">
+                  <Switch size="1" onCheckedChange={setShowExamples} /> Show API Usage Examples
+                </Flex>
+              </Text>
+              {showExamples && (
+                <>
+                  <ExperimentAssignmentCodeSnippet
+                    datasourceId={experiment.datasource_id}
+                    experimentId={experimentId}
+                  />
+                  <Text>
+                    Generate API keys in <Link href={`/datasourcedetails?id=${datasourceId}`}>Settings</Link>.
+                  </Text>
+                </>
+              )}
+            </>
+          )}
+        </Flex>
+      </Card>
 
       {/* Arms & Balance Section */}
       <Card>

--- a/src/app/experiments/view/[id]/page.tsx
+++ b/src/app/experiments/view/[id]/page.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import * as Toast from '@radix-ui/react-toast';
 import { CodeSnippetCard } from '@/app/components/cards/code-snippet-card';
 import { ExperimentTypeBadge } from '../../experiment-type-badge';
+import Link from 'next/link';
 
 export default function ExperimentViewPage() {
   const [openToast, setOpenToast] = useState(false);
@@ -38,7 +39,7 @@ export default function ExperimentViewPage() {
     experimentId,
     {},
     {
-      swr: { enabled: !!datasourceId && !!experiment },
+      swr: { enabled: !!datasourceId && !!experiment, shouldRetryOnError: false },
     },
   );
 
@@ -73,19 +74,24 @@ export default function ExperimentViewPage() {
           <Flex gap="2" align="center">
             <Heading>{experiment_name}</Heading>
             <CopyToClipBoard content={experimentId} tooltipContent="Copy experiment ID" />
+            <ExperimentStatusBadge status={state} />
           </Flex>
-          <Text color="gray" size="3">
-            on <strong>{experiment.audience_spec.participant_type}</strong>
-          </Text>
-          <ExperimentTypeBadge type={design_spec.experiment_type} />
-          <ExperimentStatusBadge status={state} />
+          <Flex direction={'column'}>
+            <Text color={'gray'}>
+              This <ExperimentTypeBadge type={design_spec.experiment_type} /> experiment is on{' '}
+              <Link
+                href={`/participanttypedetails?datasource_id=${experiment.datasource_id}&participant_type=${experiment.audience_spec.participant_type}`}
+              >
+                {experiment.audience_spec.participant_type}
+              </Link>
+              .
+            </Text>
+          </Flex>
         </Flex>
       </Flex>
 
       <Flex direction="row" gap="1" align="baseline">
-        <Heading size="3" color="purple">
-          Hypothesis:
-        </Heading>
+        <Heading size="3">Hypothesis:</Heading>
         <Text color="gray" size="3">
           {description}
         </Text>
@@ -94,9 +100,7 @@ export default function ExperimentViewPage() {
       <Grid columns="2" gap="4">
         {/* Timeline Section */}
         <Card>
-          <Heading size="3" color="purple">
-            Timeline
-          </Heading>
+          <Heading size="3">Timeline</Heading>
           <Separator my="3" size="4" />
           <Table.Root>
             <Table.Body>
@@ -114,9 +118,7 @@ export default function ExperimentViewPage() {
 
         {/* Parameters Section */}
         <Card>
-          <Heading size="3" color="purple">
-            Parameters
-          </Heading>
+          <Heading size="3">Parameters</Heading>
           <Separator my="3" size="4" />
           <Table.Root>
             <Table.Body>
@@ -139,9 +141,7 @@ export default function ExperimentViewPage() {
 
       {/* Arms & Balance Section */}
       <Card>
-        <Heading size="3" color="purple">
-          Arms & Balance
-        </Heading>
+        <Heading size="3">Arms & Balance</Heading>
         <Separator my="3" size="4" />
         <Flex gap="4">
           {arms.map((arm) => {
@@ -174,9 +174,7 @@ export default function ExperimentViewPage() {
 
       {/* Analysis Section */}
       <Card>
-        <Heading size="3" color="purple">
-          Analysis
-        </Heading>
+        <Heading size="3">Analysis</Heading>
         <Separator my="3" size="4" />
 
         {isLoadingAnalysis && <XSpinner message="Loading analysis data..." />}

--- a/src/app/experiments/view/[id]/snippets.json
+++ b/src/app/experiments/view/[id]/snippets.json
@@ -1,0 +1,7 @@
+{
+  "python": "async def get_participant_assignment(\n        api_key: str,\n        datasource_id: str,\n        experiment_id: str,\n        participant_id: str,\n        base_url: str = \"https://main.dev.agencyfund.org\"\n):\n    headers = {\n        \"X-API-Key\": api_key,\n        \"Datasource-ID\": datasource_id\n    }\n\n    url = f\"{base_url}/v1/experiments/{experiment_id}/assignments/{participant_id}\"\n\n    async with httpx.AsyncClient() as client:\n        response = await client.get(url, headers=headers)\n        response.raise_for_status()\n        data = response.json()",
+  "php": "TODO",
+  "ruby": "TODO",
+  "rust": "TODO",
+  "bash": "TODO"
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -187,8 +187,8 @@ export default function Page() {
                       <Table.Cell>
                         <ExperimentStatusBadge status={experiment.state} />
                       </Table.Cell>
-                      <Table.Cell>{experiment.design_spec.start_date}</Table.Cell>
-                      <Table.Cell>{experiment.design_spec.end_date}</Table.Cell>
+                      <Table.Cell>{new Date(experiment.design_spec.start_date).toLocaleDateString()}</Table.Cell>
+                      <Table.Cell>{new Date(experiment.design_spec.end_date).toLocaleDateString()}</Table.Cell>
                       <Table.Cell>{experiment.design_spec.description}</Table.Cell>
                       <Table.Cell>
                         <Flex direction={'row'} gap={'2'}>


### PR DESCRIPTION
This is a quick hacky PR to demonstrate that we can embed copy-pasteable code snippets into the UI. Does @qixotic think this would be useful to the customers? Should it be on this page, or on the settings page?

![image](https://github.com/user-attachments/assets/536cc235-b2d8-42be-a377-802ec1b16e62)