### PR TITLE
add searchable dropdown for table selection in participant type

### DIFF
--- a/src/app/datasources/[datasourceId]/participants/create/page.tsx
+++ b/src/app/datasources/[datasourceId]/participants/create/page.tsx
@@ -188,28 +188,19 @@ export default function CreateParticipantTypePage() {
                 Please select the name of the data warehouse table.
               </Text>
               <Box style={{ position: 'relative' }} ref={dropdownRef}>
-                <div style={{ position: 'relative' }}>
-                  <TextField.Root
-                    placeholder="Search for a table..."
-                    value={searchQuery}
-                    onChange={(e) => {
-                      setSearchQuery(e.target.value);
-                      setIsDropdownOpen(true);
-                    }}
-                    onFocus={() => setIsDropdownOpen(true)}
-                    style={{ paddingRight: '2rem' }}
-                  />
-                  <ChevronDownIcon
-                    style={{
-                      position: 'absolute',
-                      right: '0.75rem',
-                      top: '50%',
-                      transform: 'translateY(-50%)',
-                      cursor: 'pointer',
-                      pointerEvents: 'none'
-                    }}
-                  />
-                </div>
+                <TextField.Root
+                  placeholder="Search for a table..."
+                  value={searchQuery}
+                  onChange={(e) => {
+                    setSearchQuery(e.target.value);
+                    setIsDropdownOpen(true);
+                  }}
+                  onFocus={() => setIsDropdownOpen(true)}
+                >
+                  <TextField.Slot side="right">
+                    <ChevronDownIcon />
+                  </TextField.Slot>
+                </TextField.Root>
 
                 {isDropdownOpen && (
                   <div


### PR DESCRIPTION
## Ticket

[Fixes: 96](https://github.com/agency-fund/evidential-sprint/issues/96)

## Description

### Goal

Implement a searchable dropdown for table selection in the participant type creation page to improve user experience when dealing with large numbers of database tables.

### Changes

- Replaced static Select component with custom searchable TextField dropdown
- Added real-time table filtering as user types
- Implemented click-outside-to-close and hover interactions
- Maintained form compatibility with hidden input field

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts

<img width="3127" height="1672" alt="image" src="https://github.com/user-attachments/assets/a1c91743-105e-4a24-9f86-4ef9310a8255" />
<img width="3127" height="1672" alt="image" src="https://github.com/user-attachments/assets/cb35c42b-1dd2-4e7a-924d-2ce18e9da18d" />

