### PR TITLE
task genapiclient for BE #47 and read experiment_id from the ExperimentConfig directly

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1789,7 +1789,8 @@ export const useCreateParticipantType = <
 	};
 };
 /**
- * Returns filter, strata, and metric field metadata for a participant type, including exemplars for filter fields.
+ * Returns filter, strata, and metric field metadata for a participant type, including exemplars for
+filter fields.
  * @summary Inspect Participant Types
  */
 export const getInspectParticipantTypesUrl = (

--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -1225,7 +1225,8 @@ export const createParticipantTypeResponse = zod.object({
 });
 
 /**
- * Returns filter, strata, and metric field metadata for a participant type, including exemplars for filter fields.
+ * Returns filter, strata, and metric field metadata for a participant type, including exemplars for
+filter fields.
  * @summary Inspect Participant Types
  */
 export const inspectParticipantTypesParams = zod.object({
@@ -1888,7 +1889,7 @@ export const createExperimentBody = zod.object({
 				.or(zod.null())
 				.optional()
 				.describe(
-					"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+					"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 				),
 			experiment_type: zod.enum(["freq_preassigned"]),
 			experiment_name: zod
@@ -2022,7 +2023,7 @@ export const createExperimentBody = zod.object({
 				),
 		})
 		.describe(
-			"Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.",
+			"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
 		)
 		.or(
 			zod
@@ -2035,7 +2036,7 @@ export const createExperimentBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["freq_online"]),
 					experiment_name: zod
@@ -2173,7 +2174,7 @@ export const createExperimentBody = zod.object({
 						),
 				})
 				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+					"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 				),
 		)
 		.or(
@@ -2187,7 +2188,7 @@ export const createExperimentBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["mab_online"]),
 					experiment_name: zod
@@ -2328,7 +2329,7 @@ export const createExperimentBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["cmab_online"]),
 					experiment_name: zod
@@ -2455,7 +2456,7 @@ export const createExperimentBody = zod.object({
 						.describe("Enum for the likelihood distribution of the reward."),
 				})
 				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+					"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 				),
 		)
 		.or(
@@ -2469,7 +2470,7 @@ export const createExperimentBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["bayes_ab_online"]),
 					experiment_name: zod
@@ -2596,7 +2597,7 @@ export const createExperimentBody = zod.object({
 						.describe("Enum for the likelihood distribution of the reward."),
 				})
 				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+					"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 				),
 		)
 		.describe("The type of assignment and experiment design."),
@@ -2839,6 +2840,9 @@ export const createExperimentResponseWebhooksDefault = [];
 
 export const createExperimentResponse = zod
 	.object({
+		experiment_id: zod
+			.string()
+			.describe("Server-generated ID of the experiment."),
 		datasource_id: zod.string(),
 		state: zod
 			.enum(["designing", "assigned", "abandoned", "committed", "aborted"])
@@ -2869,7 +2873,7 @@ export const createExperimentResponse = zod
 					.or(zod.null())
 					.optional()
 					.describe(
-						"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+						"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 					),
 				experiment_type: zod.enum(["freq_preassigned"]),
 				experiment_name: zod
@@ -3007,7 +3011,7 @@ export const createExperimentResponse = zod
 					),
 			})
 			.describe(
-				"Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.",
+				"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
 			)
 			.or(
 				zod
@@ -3020,7 +3024,7 @@ export const createExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["freq_online"]),
 						experiment_name: zod
@@ -3160,7 +3164,7 @@ export const createExperimentResponse = zod
 							),
 					})
 					.describe(
-						"Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+						"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 					),
 			)
 			.or(
@@ -3174,7 +3178,7 @@ export const createExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["mab_online"]),
 						experiment_name: zod
@@ -3317,7 +3321,7 @@ export const createExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["cmab_online"]),
 						experiment_name: zod
@@ -3446,7 +3450,7 @@ export const createExperimentResponse = zod
 							.describe("Enum for the likelihood distribution of the reward."),
 					})
 					.describe(
-						"Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+						"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 					),
 			)
 			.or(
@@ -3460,7 +3464,7 @@ export const createExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["bayes_ab_online"]),
 						experiment_name: zod
@@ -3589,7 +3593,7 @@ export const createExperimentResponse = zod
 							.describe("Enum for the likelihood distribution of the reward."),
 					})
 					.describe(
-						"Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+						"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 					),
 			)
 			.describe("The type of assignment and experiment design."),
@@ -4111,6 +4115,9 @@ export const listOrganizationExperimentsResponse = zod.object({
 	items: zod.array(
 		zod
 			.object({
+				experiment_id: zod
+					.string()
+					.describe("Server-generated ID of the experiment."),
 				datasource_id: zod.string(),
 				state: zod
 					.enum(["designing", "assigned", "abandoned", "committed", "aborted"])
@@ -4143,7 +4150,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["freq_preassigned"]),
 						experiment_name: zod
@@ -4315,7 +4322,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 							),
 					})
 					.describe(
-						"Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.",
+						"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
 					)
 					.or(
 						zod
@@ -4330,7 +4337,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									.or(zod.null())
 									.optional()
 									.describe(
-										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 									),
 								experiment_type: zod.enum(["freq_online"]),
 								experiment_name: zod
@@ -4506,7 +4513,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									),
 							})
 							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+								"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 							),
 					)
 					.or(
@@ -4522,7 +4529,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									.or(zod.null())
 									.optional()
 									.describe(
-										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 									),
 								experiment_type: zod.enum(["mab_online"]),
 								experiment_name: zod
@@ -4683,7 +4690,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									.or(zod.null())
 									.optional()
 									.describe(
-										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 									),
 								experiment_type: zod.enum(["cmab_online"]),
 								experiment_name: zod
@@ -4828,7 +4835,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									),
 							})
 							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+								"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 							),
 					)
 					.or(
@@ -4844,7 +4851,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									.or(zod.null())
 									.optional()
 									.describe(
-										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+										"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 									),
 								experiment_type: zod.enum(["bayes_ab_online"]),
 								experiment_name: zod
@@ -4989,7 +4996,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 									),
 							})
 							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+								"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 							),
 					)
 					.describe("The type of assignment and experiment design."),
@@ -5334,6 +5341,9 @@ export const getExperimentResponseWebhooksDefault = [];
 
 export const getExperimentResponse = zod
 	.object({
+		experiment_id: zod
+			.string()
+			.describe("Server-generated ID of the experiment."),
 		datasource_id: zod.string(),
 		state: zod
 			.enum(["designing", "assigned", "abandoned", "committed", "aborted"])
@@ -5364,7 +5374,7 @@ export const getExperimentResponse = zod
 					.or(zod.null())
 					.optional()
 					.describe(
-						"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+						"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 					),
 				experiment_type: zod.enum(["freq_preassigned"]),
 				experiment_name: zod
@@ -5502,7 +5512,7 @@ export const getExperimentResponse = zod
 					),
 			})
 			.describe(
-				"Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.",
+				"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
 			)
 			.or(
 				zod
@@ -5515,7 +5525,7 @@ export const getExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["freq_online"]),
 						experiment_name: zod
@@ -5655,7 +5665,7 @@ export const getExperimentResponse = zod
 							),
 					})
 					.describe(
-						"Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+						"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 					),
 			)
 			.or(
@@ -5669,7 +5679,7 @@ export const getExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["mab_online"]),
 						experiment_name: zod
@@ -5812,7 +5822,7 @@ export const getExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["cmab_online"]),
 						experiment_name: zod
@@ -5941,7 +5951,7 @@ export const getExperimentResponse = zod
 							.describe("Enum for the likelihood distribution of the reward."),
 					})
 					.describe(
-						"Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+						"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 					),
 			)
 			.or(
@@ -5955,7 +5965,7 @@ export const getExperimentResponse = zod
 							.or(zod.null())
 							.optional()
 							.describe(
-								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+								"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 							),
 						experiment_type: zod.enum(["bayes_ab_online"]),
 						experiment_name: zod
@@ -6084,7 +6094,7 @@ export const getExperimentResponse = zod
 							.describe("Enum for the likelihood distribution of the reward."),
 					})
 					.describe(
-						"Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+						"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 					),
 			)
 			.describe("The type of assignment and experiment design."),
@@ -6700,7 +6710,7 @@ export const powerCheckBody = zod.object({
 				.or(zod.null())
 				.optional()
 				.describe(
-					"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+					"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 				),
 			experiment_type: zod.enum(["freq_preassigned"]),
 			experiment_name: zod
@@ -6828,7 +6838,7 @@ export const powerCheckBody = zod.object({
 				),
 		})
 		.describe(
-			"Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.",
+			"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
 		)
 		.or(
 			zod
@@ -6841,7 +6851,7 @@ export const powerCheckBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["freq_online"]),
 					experiment_name: zod
@@ -6977,7 +6987,7 @@ export const powerCheckBody = zod.object({
 						),
 				})
 				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+					"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 				),
 		)
 		.or(
@@ -6991,7 +7001,7 @@ export const powerCheckBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["mab_online"]),
 					experiment_name: zod
@@ -7128,7 +7138,7 @@ export const powerCheckBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["cmab_online"]),
 					experiment_name: zod
@@ -7253,7 +7263,7 @@ export const powerCheckBody = zod.object({
 						.describe("Enum for the likelihood distribution of the reward."),
 				})
 				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+					"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 				),
 		)
 		.or(
@@ -7267,7 +7277,7 @@ export const powerCheckBody = zod.object({
 						.or(zod.null())
 						.optional()
 						.describe(
-							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
+							"ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. \nDEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.",
 						),
 					experiment_type: zod.enum(["bayes_ab_online"]),
 					experiment_name: zod
@@ -7392,7 +7402,7 @@ export const powerCheckBody = zod.object({
 						.describe("Enum for the likelihood distribution of the reward."),
 				})
 				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
+					"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 				),
 		)
 		.describe("The type of assignment and experiment design."),

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -316,7 +316,9 @@ export interface BanditExperimentAnalysisResponse {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type BayesABExperimentSpecInputExperimentId = string | null;
 
@@ -334,14 +336,19 @@ export const BayesABExperimentSpecInputExperimentType = {
 export type BayesABExperimentSpecInputContexts = Context[] | null;
 
 /**
- * Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.
+ * Use this type to randomly assign participants into arms during live experiment execution with
+Bayesian A/B experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
  */
 export interface BayesABExperimentSpecInput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: BayesABExperimentSpecInputExperimentId;
 	experiment_type: BayesABExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
@@ -364,7 +371,9 @@ export interface BayesABExperimentSpecInput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type BayesABExperimentSpecOutputExperimentId = string | null;
 
@@ -382,14 +391,19 @@ export const BayesABExperimentSpecOutputExperimentType = {
 export type BayesABExperimentSpecOutputContexts = Context[] | null;
 
 /**
- * Use this type to randomly assign participants into arms during live experiment execution with Bayesian A/B experiments.
+ * Use this type to randomly assign participants into arms during live experiment execution with
+Bayesian A/B experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
  */
 export interface BayesABExperimentSpecOutput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: BayesABExperimentSpecOutputExperimentId;
 	experiment_type: BayesABExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
@@ -484,7 +498,9 @@ export interface BqDsnOutput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type CMABExperimentSpecInputExperimentId = string | null;
 
@@ -502,14 +518,19 @@ export const CMABExperimentSpecInputExperimentType = {
 export type CMABExperimentSpecInputContexts = Context[] | null;
 
 /**
- * Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.
+ * Use this type to randomly assign participants into arms during live experiment execution with
+contextual MAB experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
  */
 export interface CMABExperimentSpecInput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: CMABExperimentSpecInputExperimentId;
 	experiment_type: CMABExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
@@ -532,7 +553,9 @@ export interface CMABExperimentSpecInput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type CMABExperimentSpecOutputExperimentId = string | null;
 
@@ -550,14 +573,19 @@ export const CMABExperimentSpecOutputExperimentType = {
 export type CMABExperimentSpecOutputContexts = Context[] | null;
 
 /**
- * Use this type to randomly assign participants into arms during live experiment execution with contextual MAB experiments.
+ * Use this type to randomly assign participants into arms during live experiment execution with
+contextual MAB experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
  */
 export interface CMABExperimentSpecOutput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: CMABExperimentSpecOutputExperimentId;
 	experiment_type: CMABExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
@@ -725,6 +753,8 @@ export type CreateExperimentResponseAssignSummary = AssignSummary | null;
  * Same as the request but with ids filled for the experiment and arms, and summary info on the assignment.
  */
 export interface CreateExperimentResponse {
+	/** Server-generated ID of the experiment. */
+	experiment_id: string;
 	datasource_id: string;
 	/** Current state of this experiment. */
 	state: ExperimentState;
@@ -948,6 +978,8 @@ export type ExperimentConfigAssignSummary = AssignSummary | null;
  * Representation of our stored Experiment information.
  */
 export interface ExperimentConfig {
+	/** Server-generated ID of the experiment. */
+	experiment_id: string;
 	datasource_id: string;
 	/** Current state of this experiment. */
 	state: ExperimentState;
@@ -1212,6 +1244,8 @@ export type GetExperimentResponseAssignSummary = AssignSummary | null;
  * An experiment configuration capturing all info at design time when assignment was made.
  */
 export interface GetExperimentResponse {
+	/** Server-generated ID of the experiment. */
+	experiment_id: string;
 	datasource_id: string;
 	/** Current state of this experiment. */
 	state: ExperimentState;
@@ -1431,7 +1465,9 @@ export interface ListWebhooksResponse {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type MABExperimentSpecInputExperimentId = string | null;
 
@@ -1456,7 +1492,11 @@ For example, you may wish to experiment on new users. Assignments are issued via
 export interface MABExperimentSpecInput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: MABExperimentSpecInputExperimentId;
 	experiment_type: MABExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
@@ -1479,7 +1519,9 @@ export interface MABExperimentSpecInput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type MABExperimentSpecOutputExperimentId = string | null;
 
@@ -1504,7 +1546,11 @@ For example, you may wish to experiment on new users. Assignments are issued via
 export interface MABExperimentSpecOutput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: MABExperimentSpecOutputExperimentId;
 	experiment_type: MABExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
@@ -1671,7 +1717,9 @@ export const MetricType = {
 } as const;
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type OnlineFrequentistExperimentSpecInputExperimentId = string | null;
 
@@ -1684,14 +1732,19 @@ export const OnlineFrequentistExperimentSpecInputExperimentType = {
 } as const;
 
 /**
- * Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.
+ * Use this type to randomly assign participants into arms during live experiment execution with
+frequentist A/B experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
  */
 export interface OnlineFrequentistExperimentSpecInput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: OnlineFrequentistExperimentSpecInputExperimentId;
 	experiment_type: OnlineFrequentistExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
@@ -1742,7 +1795,9 @@ export interface OnlineFrequentistExperimentSpecInput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type OnlineFrequentistExperimentSpecOutputExperimentId = string | null;
 
@@ -1755,14 +1810,19 @@ export const OnlineFrequentistExperimentSpecOutputExperimentType = {
 } as const;
 
 /**
- * Use this type to randomly assign participants into arms during live experiment execution with frequentist A/B experiments.
+ * Use this type to randomly assign participants into arms during live experiment execution with
+frequentist A/B experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
  */
 export interface OnlineFrequentistExperimentSpecOutput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: OnlineFrequentistExperimentSpecOutputExperimentId;
 	experiment_type: OnlineFrequentistExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
@@ -1919,7 +1979,9 @@ export interface PowerResponseOutput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type PreassignedFrequentistExperimentSpecInputExperimentId =
 	| string
@@ -1934,12 +1996,17 @@ export const PreassignedFrequentistExperimentSpecInputExperimentType = {
 } as const;
 
 /**
- * Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.
+ * Use this type to randomly select and assign from existing participants at design time with
+frequentist A/B experiments.
  */
 export interface PreassignedFrequentistExperimentSpecInput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: PreassignedFrequentistExperimentSpecInputExperimentId;
 	experiment_type: PreassignedFrequentistExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
@@ -1990,7 +2057,9 @@ export interface PreassignedFrequentistExperimentSpecInput {
 }
 
 /**
- * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
+ * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+ * @deprecated
  */
 export type PreassignedFrequentistExperimentSpecOutputExperimentId =
 	| string
@@ -2005,12 +2074,17 @@ export const PreassignedFrequentistExperimentSpecOutputExperimentType = {
 } as const;
 
 /**
- * Use this type to randomly select and assign from existing participants at design time with frequentist A/B experiments.
+ * Use this type to randomly select and assign from existing participants at design time with
+frequentist A/B experiments.
  */
 export interface PreassignedFrequentistExperimentSpecOutput {
 	/** @maxLength 100 */
 	participant_type: string;
-	/** ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
+	/**
+   * ID of the experiment. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. 
+DEPRECATED: This field is no longer used and will be removed in a future release. Use the Create/GetExperimentResponse field directly.
+   * @deprecated
+   */
 	experiment_id?: PreassignedFrequentistExperimentSpecOutputExperimentId;
 	experiment_type: PreassignedFrequentistExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */

--- a/src/app/datasources/[datasourceId]/experiments/create/containers/frequent_ab/design-form.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/create/containers/frequent_ab/design-form.tsx
@@ -53,7 +53,7 @@ export function DesignForm({ formData, onFormDataChange, onNext, onBack }: Desig
       const response = await triggerCreateExperiment(request);
       onFormDataChange({
         ...formData,
-        experimentId: response.design_spec.experiment_id!,
+        experimentId: response.experiment_id,
         createExperimentResponse: response,
       });
       onNext();

--- a/src/app/datasources/[datasourceId]/experiments/create/containers/mab/mab-metadata-form.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/create/containers/mab/mab-metadata-form.tsx
@@ -92,7 +92,7 @@ export function MABMetadataForm({ webhooks, formData, onFormDataChange, onNext, 
       const response = await triggerCreateExperiment(request);
       onFormDataChange({
         ...formData,
-        experimentId: response.design_spec.experiment_id!,
+        experimentId: response.experiment_id,
         createExperimentResponse: response,
       });
       onNext();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,7 +158,7 @@ export default function Page() {
             <Grid columns={{ initial: '1', md: '2', lg: '3' }} gap="3">
               {filteredExperiments.map((experiment) => (
                 <ExperimentCard
-                  key={experiment.design_spec.experiment_id}
+                  key={experiment.experiment_id}
                   title={experiment.design_spec.experiment_name}
                   hypothesis={experiment.design_spec.description}
                   type={experiment.design_spec.experiment_type}
@@ -167,7 +167,7 @@ export default function Page() {
                   datasource={datasourcesToName.get(experiment.datasource_id) || ''}
                   datasourceId={experiment.datasource_id}
                   participantType={experiment.design_spec.participant_type}
-                  experimentId={experiment.design_spec.experiment_id!}
+                  experimentId={experiment.experiment_id}
                   organizationId={currentOrgId}
                 />
               ))}


### PR DESCRIPTION
Updates the api client to go along with https://github.com/agency-fund/evidential-be/pull/47
