### PR TITLE
Disable compact mode on navigation curtain

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { OrganizationProvider } from '@/providers/organization-provider';
 import GoogleAuthProvider from '@/providers/auth-provider';
 import OurSwrConfig from '@/providers/our-swr-config';
 import { Suspense } from 'react';
-import { NavigationBar } from '@/components/layout/nav/navigation-curtain';
+import { NavigationBarNoCompact } from '@/components/layout/nav/navigation-curtain-no-compact';
 import { HeaderBar } from '@/components/layout/header/header-bar';
 import * as Toast from '@radix-ui/react-toast';
 import RequireLogin from '@/components/require-login';
@@ -40,7 +40,8 @@ export default function RootLayout({
                       <Flex direction="column" height="100vh">
                         <HeaderBar />
                         <Flex flexGrow="1" overflow="hidden">
-                          <NavigationBar />
+                          {/*Temporary always open navigation curtain to experiments and settings nav links are always visible, please do not remove*/}
+                          <NavigationBarNoCompact />
                           <Flex direction="column" flexGrow="1" overflowY="auto" position="relative">
                             <Container
                               py="8"

--- a/src/components/layout/nav/navigation-curtain-no-compact.tsx
+++ b/src/components/layout/nav/navigation-curtain-no-compact.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Box, Flex, Tooltip } from '@radix-ui/themes';
+import { useAuth } from '@/providers/auth-provider';
+import { usePathname } from 'next/navigation';
+import { useCurrentOrganization } from '@/providers/organization-provider';
+import { GearIcon, LightningBoltIcon } from '@radix-ui/react-icons';
+import * as NavigationMenu from '@radix-ui/react-navigation-menu';
+import { NavLink } from '@/components/layout/nav/nav-link';
+
+export const NavigationBarNoCompact = () => {
+  // Manual overide of isOpen state as nav-link children control width of nav
+  const isOpen = true;
+  const { isAuthenticated } = useAuth();
+  const pathname = usePathname();
+  const org = useCurrentOrganization();
+
+  const isActive = (navHref: string) => {
+    if (navHref === '/') return pathname === '/';
+    const navHrefBase = navHref.split('?')[0];
+    const pathnameBase = pathname.split('?')[0];
+    return pathnameBase === navHrefBase || pathnameBase.startsWith(navHrefBase + '/');
+  };
+
+  if (!isAuthenticated || org === null) return null;
+
+  const mainNavItems = [{ label: 'Experiments', href: '/', icon: LightningBoltIcon }];
+
+  const utilityNavItems = [{ label: 'Settings', href: `/organizations/${org.current.id}`, icon: GearIcon }];
+
+  return (
+    <NavigationMenu.Root>
+      <Flex direction="column" width="100%" p="3" gap="4" height="100%" py="5">
+        {/* Top nav links defined in mainNavItems */}
+        <NavigationMenu.List asChild id="nav-content">
+          <Flex direction="column" gap="1" p="0" m="0" style={{ listStyle: 'none' }}>
+            {mainNavItems.map((item) => (
+              <NavigationMenu.Item key={item.href}>
+                <Tooltip content={item.label} side="right">
+                  <NavLink
+                    href={item.href}
+                    isActive={isActive(item.href)}
+                    label={item.label}
+                    icon={item.icon}
+                    isOpen={isOpen}
+                  />
+                </Tooltip>
+              </NavigationMenu.Item>
+            ))}
+          </Flex>
+        </NavigationMenu.List>
+
+        <Box flexGrow="1" />
+
+        {/* Utility nav links defined in utilityNavItems mainly used for settings */}
+        <NavigationMenu.List asChild>
+          <Flex direction="column" gap="1" p="0" m="0" style={{ listStyle: 'none' }}>
+            {utilityNavItems.map((item) => (
+              <NavigationMenu.Item key={item.href}>
+                <Tooltip content={item.label} side="right">
+                  <NavLink
+                    href={item.href}
+                    isActive={isActive(item.href)}
+                    label={item.label}
+                    icon={item.icon}
+                    isOpen={isOpen}
+                  />
+                </Tooltip>
+              </NavigationMenu.Item>
+            ))}
+          </Flex>
+        </NavigationMenu.List>
+      </Flex>
+    </NavigationMenu.Root>
+  );
+};


### PR DESCRIPTION
## Ticket

Fixes: [123](https://github.com/agency-fund/evidential-sprint/issues/123)

## Description
Created duplicate nav-curtain and removed compact mode functionality. 

### Goal
Make it easier for users to create an experiment by removing compact mode from nav-curtain and thereby make the Experiments link always visible. This is a temporary fix and will be addressed and reverted in a future PR as we improve the on-boarding flow. 

### Changes
- Created new navigation-curtain-no-compact.tsx component with compact mode functionality removed. 
- Retained existing navigation-curtain.tsx for later use
- Updated layout.tsx to use navigation-curtain-no-compact.tsx 

### Future Tasks (optional)
See [63](https://github.com/agency-fund/evidential-sprint/issues/63)

## How has this been tested?
Navigation appears expanded at all times and nav-links work as expectex

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts