### PR TITLE
Various small UI tweaks

### DIFF
--- a/src/app/datasources/[datasourceId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/page.tsx
@@ -10,6 +10,7 @@ import { ParticipantTypesSection } from '@/components/features/participants/part
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { useEffect, useState } from 'react';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
 
 export default function Page() {
   const params = useParams();
@@ -107,7 +108,10 @@ export default function Page() {
     <Flex direction="column" gap="6">
       <Flex align="start" direction="column" gap="3">
         <Flex justify="between" align="end" width="100%">
-          <Heading size="8">Datasource: {datasourceName}</Heading>
+          <Flex direction="row" align="center" gap="2">
+            <Heading size="8">Datasource: {datasourceName}</Heading>
+            <CopyToClipBoard content={datasourceId} />
+          </Flex>
           {editDatasourceDialogComponent}
         </Flex>
       </Flex>

--- a/src/app/datasources/[datasourceId]/participants/create/page.tsx
+++ b/src/app/datasources/[datasourceId]/participants/create/page.tsx
@@ -202,7 +202,7 @@ export default function CreateParticipantTypePage() {
               <Text as="div" size={'2'} color="gray">
                 Please select the name of the data warehouse table.
               </Text>
-              <Grid rows={'1'} columns={'2'}>
+              <Grid rows={'1'} columns={'2'} gap="1">
                 <Box style={{ position: 'relative' }} ref={dropdownRef}>
                   <TextField.Root
                     placeholder="Search for a table..."

--- a/src/app/organizations/[organizationId]/page.tsx
+++ b/src/app/organizations/[organizationId]/page.tsx
@@ -13,6 +13,7 @@ import { EventsTable } from '@/components/features/organizations/events-table';
 import { WebhooksTable } from '@/components/features/organizations/webhooks-table';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { EmptyStateCard } from '@/components/ui/cards/empty-state-card';
+import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
 
 const WEBHOOK_LIMIT = 10;
 
@@ -65,7 +66,10 @@ export default function Page() {
   return (
     <Flex direction="column" gap="6">
       <Flex justify="between" align="end" width="100%">
-        <Heading size="8">{organization.name}</Heading>
+        <Flex direction="row" align="center" gap="2">
+          <Heading size="8">{organization.name}</Heading>
+          <CopyToClipBoard content={organizationId} />
+        </Flex>
         <RenameOrganizationDialog organizationId={organizationId} currentName={organization.name} />
       </Flex>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { EmptyStateCard } from '@/components/ui/cards/empty-state-card';
 import { useRouter } from 'next/navigation';
-import { PRODUCT_NAME } from '@/services/constants';
+import { NO_DWH_DRIVER, PRODUCT_NAME } from '@/services/constants';
 import { CreateExperimentButton } from '@/components/features/experiments/create-experiment-button';
 import ExperimentCard from '@/components/features/experiments/experiment-card';
 import { useState } from 'react';
@@ -104,7 +104,13 @@ export default function Page() {
         </Flex>
       )}
 
-      {datasourcesData && datasourcesData.items.length === 0 ? (
+      {datasourcesData &&
+      (datasourcesData.items.length === 0 ||
+        (datasourcesData?.items.length === 1 &&
+          datasourcesData.items[0].driver === NO_DWH_DRIVER &&
+          committedExperiments.length === 0)) ? (
+        // If there are no non-api-only datasources and no experiments, show the ds setup message.
+        // One can still create api-only experiments from the create experiment button.
         <EmptyStateCard
           title={`Welcome to ${PRODUCT_NAME}`}
           description="To get started with experiments you'll need to first add a datasource in settings."
@@ -112,7 +118,7 @@ export default function Page() {
           buttonIcon={<GearIcon />}
           onClick={() => router.push(`/organizations/${currentOrgId}`)}
         />
-      ) : experimentsData && committedExperiments.length === 0 ? (
+      ) : committedExperiments.length === 0 ? (
         <EmptyStateCard
           title="Create your first experiment"
           description="Get started by creating your first experiment."

--- a/src/components/features/experiments/confirmation-form.tsx
+++ b/src/components/features/experiments/confirmation-form.tsx
@@ -12,7 +12,7 @@ import { ApiError } from '@/services/orval-fetch';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { ReadMoreText } from '@/components/ui/read-more-text';
 import { ListSelectedWebhooksCard } from '@/components/features/experiments/list-selected-webhooks-card';
-import { color } from 'motion';
+import { MdeBadge } from '@/components/features/experiments/mde-badge';
 
 interface ConfirmationFormProps {
   formData: FrequentABFormData;
@@ -127,9 +127,10 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
             <Flex direction="column" gap="1">
               <Text weight="bold">Primary Metric</Text>
               {formData.primaryMetric ? (
-                <Text>
-                  {formData.primaryMetric?.metricName} (min effect: {formData.primaryMetric?.mde}%)
-                </Text>
+                <Flex align="center" gap="2" wrap="wrap">
+                  <Text>{formData.primaryMetric.metricName}</Text>
+                  <MdeBadge value={formData.primaryMetric.mde} size="1" />
+                </Flex>
               ) : (
                 <Text>-</Text>
               )}
@@ -138,9 +139,10 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
               <Text weight="bold">Secondary Metrics</Text>
               {formData.secondaryMetrics.length > 0 ? (
                 formData.secondaryMetrics.map((metric) => (
-                  <Text key={metric.metricName}>
-                    {metric.metricName} (min effect: {metric.mde}%)
-                  </Text>
+                  <Flex key={metric.metricName} align="center" gap="2" wrap="wrap">
+                    <Text>{metric.metricName}</Text>
+                    <MdeBadge value={metric.mde} size="1" />
+                  </Flex>
                 ))
               ) : (
                 <Text>None</Text>

--- a/src/components/features/experiments/download-assignments-csv-button.tsx
+++ b/src/components/features/experiments/download-assignments-csv-button.tsx
@@ -41,7 +41,7 @@ export function DownloadAssignmentsCsvButton({ datasourceId, experimentId }: Dow
 
   return (
     <>
-      <Tooltip content="Download CSV">
+      <Tooltip content="Download CSV of participant arm assignments">
         <IconButton variant="soft" color="gray" size="2" onClick={handleDownload} loading={isDownloading}>
           <DownloadIcon width="16" height="16" />
         </IconButton>

--- a/src/components/features/experiments/forest-plot.tsx
+++ b/src/components/features/experiments/forest-plot.tsx
@@ -5,8 +5,9 @@ import {
   OnlineFrequentistExperimentSpecOutput,
   PreassignedFrequentistExperimentSpecOutput,
 } from '@/api/methods.schemas';
-import { ExclamationTriangleIcon, InfoCircledIcon } from '@radix-ui/react-icons';
-import { Badge, Box, Callout, Card, Flex, Heading, Text, Tooltip as RadixTooltip } from '@radix-ui/themes';
+import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
+import { Box, Callout, Card, Flex, Text } from '@radix-ui/themes';
+import { MdeBadge } from '@/components/features/experiments/mde-badge';
 import {
   CartesianGrid,
   ResponsiveContainer,
@@ -184,27 +185,17 @@ export function ForestPlot({ analysis, designSpec, assignSummary }: ForestPlotPr
     return (x / (maxX - minX)) * width;
   };
 
-  let mdePct: string;
+  let mdePct: string | null;
   if (analysis.metric?.metric_pct_change) {
     mdePct = (analysis.metric?.metric_pct_change * 100).toFixed(1);
   } else {
-    mdePct = 'unknown';
+    mdePct = null;
   }
   return (
     <Flex direction="column" gap="3">
       <Flex direction="row" align="baseline" wrap="wrap">
         <Text weight="bold">Effect of {analysis.metric_name || 'Unknown Metric'}&nbsp;</Text>
-        <Badge size="2">
-          <Flex gap="4" align="center">
-            <Heading size="2">MDE:</Heading>
-            <Flex gap="2" align="center">
-              <Text>{mdePct}%</Text>
-              <RadixTooltip content="This metric's minimum detectable effect as defined in the experiment's design that meets the confidence and power requirements.">
-                <InfoCircledIcon />
-              </RadixTooltip>
-            </Flex>
-          </Flex>
-        </Badge>
+        <MdeBadge value={mdePct} />
       </Flex>
 
       {effectSizes.some((e) => e.invalidStatTest) && (

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Badge, Flex, Heading, Text, Tooltip as RadixTooltip } from '@radix-ui/themes';
+
+type MdeBadgeProps = {
+  value?: string | number | null;
+  size?: '1' | '2' | '3';
+};
+
+export function MdeBadge({ value, size = '2' }: MdeBadgeProps) {
+  const displayValue = value === null || value === undefined ? 'unknown' : String(value);
+  return (
+    <Badge size={size}>
+      <Flex gap="4" align="center">
+        <Heading size={size}>MDE:</Heading>
+        <Flex gap="2" align="center">
+          <Text>{displayValue}%</Text>
+          <RadixTooltip content="This metric's minimum detectable effect as defined in the experiment's design that meets the confidence and power requirements.">
+            <InfoCircledIcon />
+          </RadixTooltip>
+        </Flex>
+      </Flex>
+    </Badge>
+  );
+}
+
+export default MdeBadge;

--- a/src/services/constants.ts
+++ b/src/services/constants.ts
@@ -6,3 +6,5 @@ export const OIDC_REDIRECT_URI = process.env.NEXT_PUBLIC_XNGIN_OIDC_REDIRECT_URI
 export const PRODUCT_NAME = 'Evidential';
 export const SUPPORT_EMAIL = process.env.NEXT_PUBLIC_XNGIN_SUPPORT_EMAIL ?? 'support@example.com';
 export const XNGIN_API_DOCS_LINK = process.env.NEXT_PUBLIC_XNGIN_API_DOCS ?? API_BASE_URL + '/docs';
+// Special driver name for Api Only datasource
+export const NO_DWH_DRIVER = 'none';


### PR DESCRIPTION
Assorted minor UI tweaks:
* show the "create a ds" card if no ds nor experiments were created yet
* tweak download csv tooltip
* allow copying datasource & org ids from their main pages
* extract MdeBadge component to also use on the confirmation page

## How has this been tested?

Manual testing: 

<img width="568" height="265" alt="image" src="https://github.com/user-attachments/assets/c464c300-df61-48a1-815c-44d4769a3537" />

- shows the welcome card again (as before the API Only ds addition, this time taking into account it and presence of experiments)


<img width="479" height="256" alt="image" src="https://github.com/user-attachments/assets/886bfb65-0717-404f-bf86-99e6e0736cc6" />

- more descriptive tip


<img width="555" height="138" alt="image" src="https://github.com/user-attachments/assets/8a5ed208-21d8-47ec-bc52-b56e567d93ea" />
<img width="579" height="156" alt="image" src="https://github.com/user-attachments/assets/2bc7facf-cb22-4598-a99b-21200cfd5504" />

- copy ids from within their respective page.tsx


<img width="407" height="339" alt="image" src="https://github.com/user-attachments/assets/063a5e71-93b2-4915-bc02-8609cd9c15c9" />

- use the same MDE badge as seen in the analysis card

## Checklist

Fill with `x` for completed.

- [x ] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts