### PR TITLE
More consistently display filter & metric data types using the DataTypeBadge

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -27,10 +27,12 @@ import type {
 	CreateOrganizationResponse,
 	CreateParticipantsTypeRequest,
 	CreateParticipantsTypeResponse,
+	CreateSnapshotResponse,
 	DeleteApiKeyParams,
 	DeleteDatasourceParams,
 	DeleteExperimentParams,
 	DeleteParticipantParams,
+	DeleteSnapshotParams,
 	DeleteWebhookFromOrganizationParams,
 	GetDatasourceResponse,
 	GetExperimentAssignmentForParticipantParams,
@@ -38,6 +40,7 @@ import type {
 	GetExperimentResponse,
 	GetOrganizationResponse,
 	GetParticipantAssignmentResponse,
+	GetSnapshotResponse,
 	HTTPExceptionError,
 	HTTPValidationError,
 	InspectDatasourceParams,
@@ -52,6 +55,8 @@ import type {
 	ListOrganizationEventsResponse,
 	ListOrganizationsResponse,
 	ListParticipantsTypeResponse,
+	ListSnapshotsParams,
+	ListSnapshotsResponse,
 	ListWebhooksResponse,
 	ParticipantsConfig,
 	PowerRequest,
@@ -117,6 +122,449 @@ export const useCallerIdentity = <
 		swrFn,
 		swrOptions,
 	);
+
+	return {
+		swrKey,
+		...query,
+	};
+};
+/**
+ * Fetches a snapshot by ID.
+ * @summary Get Snapshot
+ */
+export const getGetSnapshotUrl = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+) => {
+	return `/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots/${snapshotId}`;
+};
+
+export const getSnapshot = async (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	options?: RequestInit,
+): Promise<GetSnapshotResponse> => {
+	return orvalFetch<GetSnapshotResponse>(
+		getGetSnapshotUrl(organizationId, datasourceId, experimentId, snapshotId),
+		{
+			...options,
+			method: "GET",
+		},
+	);
+};
+
+export const getGetSnapshotKey = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+) =>
+	[
+		`/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots/${snapshotId}`,
+	] as const;
+
+export type GetSnapshotQueryResult = NonNullable<
+	Awaited<ReturnType<typeof getSnapshot>>
+>;
+export type GetSnapshotQueryError = ErrorType<
+	HTTPExceptionError | HTTPValidationError
+>;
+
+/**
+ * @summary Get Snapshot
+ */
+export const useGetSnapshot = <
+	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
+>(
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	options?: {
+		swr?: SWRConfiguration<Awaited<ReturnType<typeof getSnapshot>>, TError> & {
+			swrKey?: Key;
+			enabled?: boolean;
+		};
+		request?: SecondParameter<typeof orvalFetch>;
+	},
+) => {
+	const { swr: swrOptions, request: requestOptions } = options ?? {};
+
+	const isEnabled =
+		swrOptions?.enabled !== false &&
+		!!(organizationId && datasourceId && experimentId && snapshotId);
+	const swrKey =
+		swrOptions?.swrKey ??
+		(() =>
+			isEnabled
+				? getGetSnapshotKey(
+						organizationId,
+						datasourceId,
+						experimentId,
+						snapshotId,
+					)
+				: null);
+	const swrFn = () =>
+		getSnapshot(
+			organizationId,
+			datasourceId,
+			experimentId,
+			snapshotId,
+			requestOptions,
+		);
+
+	const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(
+		swrKey,
+		swrFn,
+		swrOptions,
+	);
+
+	return {
+		swrKey,
+		...query,
+	};
+};
+/**
+ * Deletes a snapshot.
+ * @summary Delete Snapshot
+ */
+export const getDeleteSnapshotUrl = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	params?: DeleteSnapshotParams,
+) => {
+	const normalizedParams = new URLSearchParams();
+
+	Object.entries(params || {}).forEach(([key, value]) => {
+		if (value !== undefined) {
+			normalizedParams.append(key, value === null ? "null" : value.toString());
+		}
+	});
+
+	const stringifiedParams = normalizedParams.toString();
+
+	return stringifiedParams.length > 0
+		? `/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots/${snapshotId}?${stringifiedParams}`
+		: `/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots/${snapshotId}`;
+};
+
+export const deleteSnapshot = async (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	params?: DeleteSnapshotParams,
+	options?: RequestInit,
+): Promise<unknown> => {
+	return orvalFetch<unknown>(
+		getDeleteSnapshotUrl(
+			organizationId,
+			datasourceId,
+			experimentId,
+			snapshotId,
+			params,
+		),
+		{
+			...options,
+			method: "DELETE",
+		},
+	);
+};
+
+export const getDeleteSnapshotMutationFetcher = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	params?: DeleteSnapshotParams,
+	options?: SecondParameter<typeof orvalFetch>,
+) => {
+	return (_: Key, __: { arg: Arguments }): Promise<unknown> => {
+		return deleteSnapshot(
+			organizationId,
+			datasourceId,
+			experimentId,
+			snapshotId,
+			params,
+			options,
+		);
+	};
+};
+export const getDeleteSnapshotMutationKey = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	params?: DeleteSnapshotParams,
+) =>
+	[
+		`/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots/${snapshotId}`,
+		...(params ? [params] : []),
+	] as const;
+
+export type DeleteSnapshotMutationResult = NonNullable<
+	Awaited<ReturnType<typeof deleteSnapshot>>
+>;
+export type DeleteSnapshotMutationError = ErrorType<
+	HTTPExceptionError | HTTPValidationError
+>;
+
+/**
+ * @summary Delete Snapshot
+ */
+export const useDeleteSnapshot = <
+	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
+>(
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	snapshotId: string,
+	params?: DeleteSnapshotParams,
+	options?: {
+		swr?: SWRMutationConfiguration<
+			Awaited<ReturnType<typeof deleteSnapshot>>,
+			TError,
+			Key,
+			Arguments,
+			Awaited<ReturnType<typeof deleteSnapshot>>
+		> & { swrKey?: string };
+		request?: SecondParameter<typeof orvalFetch>;
+	},
+) => {
+	const { swr: swrOptions, request: requestOptions } = options ?? {};
+
+	const swrKey =
+		swrOptions?.swrKey ??
+		getDeleteSnapshotMutationKey(
+			organizationId,
+			datasourceId,
+			experimentId,
+			snapshotId,
+			params,
+		);
+	const swrFn = getDeleteSnapshotMutationFetcher(
+		organizationId,
+		datasourceId,
+		experimentId,
+		snapshotId,
+		params,
+		requestOptions,
+	);
+
+	const query = useSWRMutation(swrKey, swrFn, swrOptions);
+
+	return {
+		swrKey,
+		...query,
+	};
+};
+/**
+ * Lists snapshots for an experiment, ordered by timestamp.
+ * @summary List Snapshots
+ */
+export const getListSnapshotsUrl = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	params?: ListSnapshotsParams,
+) => {
+	const normalizedParams = new URLSearchParams();
+
+	Object.entries(params || {}).forEach(([key, value]) => {
+		if (value !== undefined) {
+			normalizedParams.append(key, value === null ? "null" : value.toString());
+		}
+	});
+
+	const stringifiedParams = normalizedParams.toString();
+
+	return stringifiedParams.length > 0
+		? `/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots?${stringifiedParams}`
+		: `/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots`;
+};
+
+export const listSnapshots = async (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	params?: ListSnapshotsParams,
+	options?: RequestInit,
+): Promise<ListSnapshotsResponse> => {
+	return orvalFetch<ListSnapshotsResponse>(
+		getListSnapshotsUrl(organizationId, datasourceId, experimentId, params),
+		{
+			...options,
+			method: "GET",
+		},
+	);
+};
+
+export const getListSnapshotsKey = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	params?: ListSnapshotsParams,
+) =>
+	[
+		`/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots`,
+		...(params ? [params] : []),
+	] as const;
+
+export type ListSnapshotsQueryResult = NonNullable<
+	Awaited<ReturnType<typeof listSnapshots>>
+>;
+export type ListSnapshotsQueryError = ErrorType<
+	HTTPExceptionError | HTTPValidationError
+>;
+
+/**
+ * @summary List Snapshots
+ */
+export const useListSnapshots = <
+	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
+>(
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	params?: ListSnapshotsParams,
+	options?: {
+		swr?: SWRConfiguration<
+			Awaited<ReturnType<typeof listSnapshots>>,
+			TError
+		> & { swrKey?: Key; enabled?: boolean };
+		request?: SecondParameter<typeof orvalFetch>;
+	},
+) => {
+	const { swr: swrOptions, request: requestOptions } = options ?? {};
+
+	const isEnabled =
+		swrOptions?.enabled !== false &&
+		!!(organizationId && datasourceId && experimentId);
+	const swrKey =
+		swrOptions?.swrKey ??
+		(() =>
+			isEnabled
+				? getListSnapshotsKey(
+						organizationId,
+						datasourceId,
+						experimentId,
+						params,
+					)
+				: null);
+	const swrFn = () =>
+		listSnapshots(
+			organizationId,
+			datasourceId,
+			experimentId,
+			params,
+			requestOptions,
+		);
+
+	const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(
+		swrKey,
+		swrFn,
+		swrOptions,
+	);
+
+	return {
+		swrKey,
+		...query,
+	};
+};
+/**
+ * Request the asynchronous creation of a snapshot for an experiment.
+
+Returns the ID of the snapshot. Poll get_snapshot until the job is completed.
+ * @summary Create Snapshot
+ */
+export const getCreateSnapshotUrl = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+) => {
+	return `/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots`;
+};
+
+export const createSnapshot = async (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	options?: RequestInit,
+): Promise<CreateSnapshotResponse> => {
+	return orvalFetch<CreateSnapshotResponse>(
+		getCreateSnapshotUrl(organizationId, datasourceId, experimentId),
+		{
+			...options,
+			method: "POST",
+		},
+	);
+};
+
+export const getCreateSnapshotMutationFetcher = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	options?: SecondParameter<typeof orvalFetch>,
+) => {
+	return (_: Key, __: { arg: Arguments }): Promise<CreateSnapshotResponse> => {
+		return createSnapshot(organizationId, datasourceId, experimentId, options);
+	};
+};
+export const getCreateSnapshotMutationKey = (
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+) =>
+	[
+		`/v1/m/organizations/${organizationId}/datasources/${datasourceId}/experiments/${experimentId}/snapshots`,
+	] as const;
+
+export type CreateSnapshotMutationResult = NonNullable<
+	Awaited<ReturnType<typeof createSnapshot>>
+>;
+export type CreateSnapshotMutationError = ErrorType<
+	HTTPExceptionError | HTTPValidationError
+>;
+
+/**
+ * @summary Create Snapshot
+ */
+export const useCreateSnapshot = <
+	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
+>(
+	organizationId: string,
+	datasourceId: string,
+	experimentId: string,
+	options?: {
+		swr?: SWRMutationConfiguration<
+			Awaited<ReturnType<typeof createSnapshot>>,
+			TError,
+			Key,
+			Arguments,
+			Awaited<ReturnType<typeof createSnapshot>>
+		> & { swrKey?: string };
+		request?: SecondParameter<typeof orvalFetch>;
+	},
+) => {
+	const { swr: swrOptions, request: requestOptions } = options ?? {};
+
+	const swrKey =
+		swrOptions?.swrKey ??
+		getCreateSnapshotMutationKey(organizationId, datasourceId, experimentId);
+	const swrFn = getCreateSnapshotMutationFetcher(
+		organizationId,
+		datasourceId,
+		experimentId,
+		requestOptions,
+	);
+
+	const query = useSWRMutation(swrKey, swrFn, swrOptions);
 
 	return {
 		swrKey,

--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -23,6 +23,136 @@ export const callerIdentityResponse = zod
 	);
 
 /**
+ * Fetches a snapshot by ID.
+ * @summary Get Snapshot
+ */
+export const getSnapshotParams = zod.object({
+	organization_id: zod.string(),
+	datasource_id: zod.string(),
+	experiment_id: zod.string(),
+	snapshot_id: zod.string(),
+});
+
+export const getSnapshotResponse = zod
+	.object({
+		snapshot: zod
+			.object({
+				experiment_id: zod
+					.string()
+					.describe("The experiment that this snapshot was captured for."),
+				id: zod.string().describe("The unique ID of the snapshot."),
+				status: zod
+					.enum(["success", "running", "failed"])
+					.describe("Describes the status of a snapshot."),
+				details: zod
+					.record(zod.string(), zod.any())
+					.or(zod.null())
+					.describe("Additional data about this snapshot."),
+				created_at: zod
+					.string()
+					.datetime({})
+					.describe("The time the snapshot was requested."),
+				updated_at: zod
+					.string()
+					.datetime({})
+					.describe("The time the snapshot was acquired."),
+				data: zod.record(zod.string(), zod.any()).or(zod.null()),
+			})
+			.or(zod.null())
+			.describe("The completed snapshot."),
+	})
+	.describe("Describes the status and content of a snapshot.");
+
+/**
+ * Deletes a snapshot.
+ * @summary Delete Snapshot
+ */
+export const deleteSnapshotParams = zod.object({
+	organization_id: zod.string(),
+	datasource_id: zod.string(),
+	experiment_id: zod.string(),
+	snapshot_id: zod.string(),
+});
+
+export const deleteSnapshotQueryAllowMissingDefault = false;
+
+export const deleteSnapshotQueryParams = zod.object({
+	allow_missing: zod
+		.boolean()
+		.optional()
+		.describe("If true, return a 204 even if the resource does not exist."),
+});
+
+export const deleteSnapshotResponse = zod.any();
+
+/**
+ * Lists snapshots for an experiment, ordered by timestamp.
+ * @summary List Snapshots
+ */
+export const listSnapshotsParams = zod.object({
+	organization_id: zod.string(),
+	datasource_id: zod.string(),
+	experiment_id: zod.string(),
+});
+
+export const listSnapshotsQueryParams = zod.object({
+	status: zod
+		.array(
+			zod
+				.enum(["success", "running", "failed"])
+				.describe("Describes the status of a snapshot."),
+		)
+		.or(zod.null())
+		.optional()
+		.describe(
+			"Filter the returned snapshots to only those of this status. May be specified multiple times.",
+		),
+});
+
+export const listSnapshotsResponse = zod.object({
+	items: zod.array(
+		zod.object({
+			experiment_id: zod
+				.string()
+				.describe("The experiment that this snapshot was captured for."),
+			id: zod.string().describe("The unique ID of the snapshot."),
+			status: zod
+				.enum(["success", "running", "failed"])
+				.describe("Describes the status of a snapshot."),
+			details: zod
+				.record(zod.string(), zod.any())
+				.or(zod.null())
+				.describe("Additional data about this snapshot."),
+			created_at: zod
+				.string()
+				.datetime({})
+				.describe("The time the snapshot was requested."),
+			updated_at: zod
+				.string()
+				.datetime({})
+				.describe("The time the snapshot was acquired."),
+			data: zod.record(zod.string(), zod.any()).or(zod.null()),
+		}),
+	),
+});
+
+/**
+ * Request the asynchronous creation of a snapshot for an experiment.
+
+Returns the ID of the snapshot. Poll get_snapshot until the job is completed.
+ * @summary Create Snapshot
+ */
+export const createSnapshotParams = zod.object({
+	organization_id: zod.string(),
+	datasource_id: zod.string(),
+	experiment_id: zod.string(),
+});
+
+export const createSnapshotResponse = zod.object({
+	id: zod.string(),
+});
+
+/**
  * Returns a list of organizations that the authenticated user is a member of.
  * @summary List Organizations
  */

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -791,6 +791,10 @@ export interface CreateParticipantsTypeResponse {
 	schema_def: ParticipantsSchemaOutput;
 }
 
+export interface CreateSnapshotResponse {
+	id: string;
+}
+
 /**
  * Defines the supported data types for fields in the data source.
  */
@@ -1368,6 +1372,19 @@ export interface GetParticipantAssignmentResponse {
 	assignment: GetParticipantAssignmentResponseAssignment;
 }
 
+/**
+ * The completed snapshot.
+ */
+export type GetSnapshotResponseSnapshot = Snapshot | null;
+
+/**
+ * Describes the status and content of a snapshot.
+ */
+export interface GetSnapshotResponse {
+	/** The completed snapshot. */
+	snapshot: GetSnapshotResponseSnapshot;
+}
+
 export type GetStrataResponseElementExtraAnyOf = { [key: string]: string };
 
 export type GetStrataResponseElementExtra =
@@ -1458,6 +1475,10 @@ export interface ListOrganizationsResponse {
 
 export interface ListParticipantsTypeResponse {
 	items: ParticipantsConfig[];
+}
+
+export interface ListSnapshotsResponse {
+	items: Snapshot[];
 }
 
 export interface ListWebhooksResponse {
@@ -2209,6 +2230,46 @@ export interface RevealedStr {
 	value: string;
 }
 
+export type SnapshotDetailsAnyOf = { [key: string]: unknown };
+
+/**
+ * Additional data about this snapshot.
+ */
+export type SnapshotDetails = SnapshotDetailsAnyOf | null;
+
+export type SnapshotDataAnyOf = { [key: string]: unknown };
+
+export type SnapshotData = SnapshotDataAnyOf | null;
+
+export interface Snapshot {
+	/** The experiment that this snapshot was captured for. */
+	experiment_id: string;
+	/** The unique ID of the snapshot. */
+	id: string;
+	/** The status of the snapshot. When not `success`, data will be null. */
+	status: SnapshotStatus;
+	/** Additional data about this snapshot. */
+	details: SnapshotDetails;
+	/** The time the snapshot was requested. */
+	created_at: string;
+	/** The time the snapshot was acquired. */
+	updated_at: string;
+	data: SnapshotData;
+}
+
+/**
+ * Describes the status of a snapshot.
+ */
+export type SnapshotStatus =
+	(typeof SnapshotStatus)[keyof typeof SnapshotStatus];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SnapshotStatus = {
+	success: "success",
+	running: "running",
+	failed: "failed",
+} as const;
+
 /**
  * The reason assignments were stopped.
  */
@@ -2343,6 +2404,20 @@ export interface WebhookSummary {
 	/** The value of the Webhook-Token: header that will be sent with the request to the configured URL. */
 	auth_token: WebhookSummaryAuthToken;
 }
+
+export type DeleteSnapshotParams = {
+	/**
+	 * If true, return a 204 even if the resource does not exist.
+	 */
+	allow_missing?: boolean;
+};
+
+export type ListSnapshotsParams = {
+	/**
+	 * Filter the returned snapshots to only those of this status. May be specified multiple times.
+	 */
+	status?: SnapshotStatus[] | null;
+};
 
 export type DeleteWebhookFromOrganizationParams = {
 	/**

--- a/src/app/datasources/[datasourceId]/experiments/create/containers/frequent_ab/design-form.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/create/containers/frequent_ab/design-form.tsx
@@ -93,7 +93,9 @@ export function DesignForm({ formData, onFormDataChange, onNext, onBack }: Desig
             <FilterBuilder
               availableFields={filterFields}
               filters={formData.filters}
-              onChange={(filters: FilterInput[]) => onFormDataChange({ ...formData, filters })}
+              onChange={(filters: FilterInput[]) =>
+                onFormDataChange({ ...formData, filters, availableFilterFields: filterFields })
+              }
             />
           </Flex>
         </SectionCard>

--- a/src/app/datasources/[datasourceId]/experiments/create/containers/frequent_ab/design-form.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/create/containers/frequent_ab/design-form.tsx
@@ -70,7 +70,7 @@ export function DesignForm({ formData, onFormDataChange, onNext, onBack }: Desig
 
   const supportsPowerCheck = formData.experimentType === 'freq_preassigned';
   const isNextButtonDisabled =
-    !formData.primaryMetric?.metricName ||
+    !formData.primaryMetric?.metric.field_name ||
     !formData.primaryMetric?.mde ||
     (supportsPowerCheck && (formData.powerCheckResponse === undefined || isMutating));
 

--- a/src/app/datasources/[datasourceId]/experiments/create/helpers.ts
+++ b/src/app/datasources/[datasourceId]/experiments/create/helpers.ts
@@ -41,18 +41,18 @@ function convertFrequentABFormData(formData: FrequentABFormData): CreateExperime
   const metrics: DesignSpecMetricRequest[] = [];
   const strata: Stratum[] = [];
 
-  if (formData.primaryMetric && formData.primaryMetric.metricName) {
+  if (formData.primaryMetric && formData.primaryMetric.metric.field_name) {
     zodMde.parse(formData.primaryMetric.mde, { path: ['primaryMetric', 'mde'] });
     metrics.push({
-      field_name: formData.primaryMetric.metricName,
+      field_name: formData.primaryMetric.metric.field_name,
       metric_pct_change: Number(formData.primaryMetric.mde) / 100.0,
     });
   }
 
   formData.secondaryMetrics.forEach((metric) => {
-    zodMde.parse(metric.mde, { path: ['secondaryMetrics', metric.metricName, 'mde'] });
+    zodMde.parse(metric.mde, { path: ['secondaryMetrics', metric.metric.field_name, 'mde'] });
     metrics.push({
-      field_name: metric.metricName,
+      field_name: metric.metric.field_name,
       metric_pct_change: Number(metric.mde) / 100.0,
     });
   });
@@ -77,7 +77,6 @@ function convertFrequentABFormData(formData: FrequentABFormData): CreateExperime
       strata: strata,
       power: Number(formData.power) / 100.0,
       alpha: 1 - Number(formData.confidence) / 100.0,
-      experiment_id: null,
     },
     power_analyses: formData.powerCheckResponse,
     webhooks: formData.selectedWebhookIds.length > 0 ? formData.selectedWebhookIds : [],

--- a/src/app/datasources/[datasourceId]/experiments/create/types.ts
+++ b/src/app/datasources/[datasourceId]/experiments/create/types.ts
@@ -10,6 +10,7 @@ import {
   Context as ContextSpec,
   MABExperimentSpecInputExperimentType,
   GetMetricsResponseElement,
+  GetFiltersResponseElement,
 } from '@/api/methods.schemas';
 
 export type ExperimentType = DesignSpecInput['experiment_type'];
@@ -72,6 +73,8 @@ export type FrequentABFormData = BaseExperimentFormData & {
   primaryMetric?: MetricWithMDE;
   secondaryMetrics: MetricWithMDE[];
   filters: FilterInput[];
+  // Cache of available filter fields (and their data types) for lookup/display/search
+  availableFilterFields?: GetFiltersResponseElement[];
   strata: Stratum[];
   // These next 2 Experiment Parameters are strings to allow for empty values,
   // which should be converted to numbers when making power or experiment creation requests.

--- a/src/app/datasources/[datasourceId]/experiments/create/types.ts
+++ b/src/app/datasources/[datasourceId]/experiments/create/types.ts
@@ -9,6 +9,7 @@ import {
   MABExperimentSpecInput,
   Context as ContextSpec,
   MABExperimentSpecInputExperimentType,
+  GetMetricsResponseElement,
 } from '@/api/methods.schemas';
 
 export type ExperimentType = DesignSpecInput['experiment_type'];
@@ -31,7 +32,7 @@ export type Stratum = {
 };
 
 export type MetricWithMDE = {
-  metricName: string;
+  metric: GetMetricsResponseElement;
   mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value
 };
 

--- a/src/components/features/experiments/clickable-badge.tsx
+++ b/src/components/features/experiments/clickable-badge.tsx
@@ -1,18 +1,30 @@
 'use client';
 
-import { GetMetricsResponseElement, GetStrataResponseElement } from '@/api/methods.schemas';
+import { GetMetricsResponseElement, GetStrataResponseElement, DataType } from '@/api/methods.schemas';
 import { Badge, Flex, HoverCard, Text } from '@radix-ui/themes';
 import { PlusIcon } from '@radix-ui/react-icons';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
 
-type ClickableBadgeProps = {
-  input: GetMetricsResponseElement | GetStrataResponseElement;
+type MinimalClickableBadgeInput = {
+  field_name: string;
+  data_type: DataType;
+  description: string;
+};
+type ClickableBadgeInput = MinimalClickableBadgeInput | GetMetricsResponseElement | GetStrataResponseElement;
+
+type ClickableBadgeProps<TInput extends ClickableBadgeInput> = {
+  input: TInput;
   color?: 'blue' | 'gray';
   showPlus?: boolean;
-  onClick: (field_name: string) => void;
+  onClick: (input: TInput) => void;
 };
 
-export function ClickableBadge({ input, onClick, color, showPlus: showPlus = true }: ClickableBadgeProps) {
+export function ClickableBadge<TInput extends ClickableBadgeInput>({
+  input,
+  onClick,
+  color,
+  showPlus: showPlus = true,
+}: ClickableBadgeProps<TInput>) {
   const badge = (
     <Badge
       key={input.field_name}
@@ -20,7 +32,7 @@ export function ClickableBadge({ input, onClick, color, showPlus: showPlus = tru
       variant={'soft'}
       {...(color ? { color } : {})}
       style={{ cursor: 'pointer' }}
-      onClick={() => onClick(input.field_name)}
+      onClick={() => onClick(input)}
     >
       {showPlus ? <PlusIcon /> : null} {input.field_name}
     </Badge>

--- a/src/components/features/experiments/confirmation-form.tsx
+++ b/src/components/features/experiments/confirmation-form.tsx
@@ -13,6 +13,7 @@ import { SectionCard } from '@/components/ui/cards/section-card';
 import { ReadMoreText } from '@/components/ui/read-more-text';
 import { ListSelectedWebhooksCard } from '@/components/features/experiments/list-selected-webhooks-card';
 import { MdeBadge } from '@/components/features/experiments/mde-badge';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
 
 interface ConfirmationFormProps {
   formData: FrequentABFormData;
@@ -127,9 +128,12 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
             <Flex direction="column" gap="1">
               <Text weight="bold">Primary Metric</Text>
               {formData.primaryMetric ? (
-                <Flex align="center" gap="2" wrap="wrap">
-                  <Text>{formData.primaryMetric.metricName}</Text>
-                  <MdeBadge value={formData.primaryMetric.mde} size="1" />
+                <Flex direction="row" gap="2" wrap="wrap" align="center" justify="between">
+                  <Text>{formData.primaryMetric.metric.field_name}</Text>
+                  <Flex direction="row" gap="2" align="center" justify="between">
+                    <DataTypeBadge type={formData.primaryMetric.metric.data_type} />
+                    <MdeBadge value={formData.primaryMetric.mde} size="1" />
+                  </Flex>
                 </Flex>
               ) : (
                 <Text>-</Text>
@@ -139,9 +143,12 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
               <Text weight="bold">Secondary Metrics</Text>
               {formData.secondaryMetrics.length > 0 ? (
                 formData.secondaryMetrics.map((metric) => (
-                  <Flex key={metric.metricName} align="center" gap="2" wrap="wrap">
-                    <Text>{metric.metricName}</Text>
-                    <MdeBadge value={metric.mde} size="1" />
+                  <Flex key={metric.metric.field_name} gap="2" wrap="wrap" align="center" justify="between">
+                    <Text>{metric.metric.field_name}</Text>
+                    <Flex direction="row" gap="2" align="center" justify="between">
+                      <DataTypeBadge type={metric.metric.data_type} />
+                      <MdeBadge value={metric.mde} size="1" />
+                    </Flex>
                   </Flex>
                 ))
               ) : (

--- a/src/components/features/experiments/confirmation-form.tsx
+++ b/src/components/features/experiments/confirmation-form.tsx
@@ -130,7 +130,7 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
               {formData.primaryMetric ? (
                 <Flex direction="row" gap="2" wrap="wrap" align="center" justify="between">
                   <Text>{formData.primaryMetric.metric.field_name}</Text>
-                  <Flex direction="row" gap="2" align="center" justify="between">
+                  <Flex direction="row" wrap="wrap" gap="2" align="center" justify="between">
                     <DataTypeBadge type={formData.primaryMetric.metric.data_type} />
                     <MdeBadge value={formData.primaryMetric.mde} size="1" />
                   </Flex>
@@ -145,7 +145,7 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
                 formData.secondaryMetrics.map((metric) => (
                   <Flex key={metric.metric.field_name} gap="2" wrap="wrap" align="center" justify="between">
                     <Text>{metric.metric.field_name}</Text>
-                    <Flex direction="row" gap="2" align="center" justify="between">
+                    <Flex direction="row" wrap="wrap" gap="2" align="center" justify="between">
                       <DataTypeBadge type={metric.metric.data_type} />
                       <MdeBadge value={metric.mde} size="1" />
                     </Flex>
@@ -170,18 +170,23 @@ export function ConfirmationForm({ formData, onBack, onFormDataChange }: Confirm
             <Table.Header>
               <Table.Row>
                 <Table.ColumnHeaderCell>Field</Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell>Data Type</Table.ColumnHeaderCell>
                 <Table.ColumnHeaderCell>Operator</Table.ColumnHeaderCell>
                 <Table.ColumnHeaderCell>Values</Table.ColumnHeaderCell>
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {formData.filters.map((filter, index) => (
-                <Table.Row key={index}>
-                  <Table.Cell>{filter.field_name}</Table.Cell>
-                  <Table.Cell>{filter.relation}</Table.Cell>
-                  <Table.Cell>{filter.value.map((v) => (v === null ? '(null)' : v)).join(', ')}</Table.Cell>
-                </Table.Row>
-              ))}
+              {formData.filters.map((filter, index) => {
+                const dt = formData.availableFilterFields?.find((f) => f.field_name === filter.field_name)?.data_type;
+                return (
+                  <Table.Row key={index}>
+                    <Table.Cell>{filter.field_name}</Table.Cell>
+                    <Table.Cell>{dt ? <DataTypeBadge type={dt} /> : <Text>-</Text>}</Table.Cell>
+                    <Table.Cell>{filter.relation}</Table.Cell>
+                    <Table.Cell>{filter.value.map((v) => (v === null ? '(null)' : v)).join(', ')}</Table.Cell>
+                  </Table.Row>
+                );
+              })}
             </Table.Body>
           </Table.Root>
         ) : (

--- a/src/components/features/experiments/metric-builder.tsx
+++ b/src/components/features/experiments/metric-builder.tsx
@@ -15,10 +15,10 @@ type MetricBuilderProps = {
 };
 
 export function MetricBuilder({ formData, onFormDataChange, metricFields }: MetricBuilderProps) {
-  const handlePrimaryMetricSelect = (metricName: string) => {
+  const handlePrimaryMetricSelect = (metric: GetMetricsResponseElement) => {
     onFormDataChange({
       ...formData,
-      primaryMetric: { metricName, mde: DEFAULT_MDE },
+      primaryMetric: { metric, mde: DEFAULT_MDE },
     });
   };
 
@@ -29,13 +29,13 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
     });
   };
 
-  const handleSecondaryMetricAdd = (metricName: string) => {
-    const newSecondaryMetrics = [...formData.secondaryMetrics, { metricName, mde: DEFAULT_MDE }];
+  const handleSecondaryMetricAdd = (metric: GetMetricsResponseElement) => {
+    const newSecondaryMetrics = [...formData.secondaryMetrics, { metric, mde: DEFAULT_MDE }];
     onFormDataChange({ ...formData, secondaryMetrics: newSecondaryMetrics });
   };
 
   const handleSecondaryMetricRemove = (metricName: string) => {
-    const newSecondaryMetrics = formData.secondaryMetrics.filter((m) => m.metricName !== metricName);
+    const newSecondaryMetrics = formData.secondaryMetrics.filter((m) => m.metric.field_name !== metricName);
     onFormDataChange({ ...formData, secondaryMetrics: newSecondaryMetrics });
   };
 
@@ -44,13 +44,13 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
       onFormDataChange({
         ...formData,
         primaryMetric: {
-          metricName: formData.primaryMetric?.metricName || '',
+          metric: formData.primaryMetric.metric,
           mde: mde || '',
         },
       });
     } else if (type === 'secondary') {
       const newSecondaryMetrics = formData.secondaryMetrics.map((m) =>
-        m.metricName === metricName ? { ...m, mde } : m,
+        m.metric.field_name === metricName ? { ...m, mde } : m,
       );
       onFormDataChange({ ...formData, secondaryMetrics: newSecondaryMetrics });
     }
@@ -58,15 +58,15 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
 
   // Determine metrics available for primary selection (all metrics not in secondaryMetrics)
   const availablePrimaryMetricBadges = metricFields
-    .filter((m) => !formData.secondaryMetrics.some((sm) => sm.metricName === m.field_name))
+    .filter((m) => !formData.secondaryMetrics.some((sm) => sm.metric.field_name === m.field_name))
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
 
   // Determine metrics available for secondary selection
   const availableSecondaryMetricBadges = metricFields
     .filter(
       (m) =>
-        m.field_name !== formData.primaryMetric?.metricName &&
-        !formData.secondaryMetrics.some((sm) => sm.metricName === m.field_name),
+        m.field_name !== formData.primaryMetric?.metric.field_name &&
+        !formData.secondaryMetrics.some((sm) => sm.metric.field_name === m.field_name),
     )
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
 
@@ -76,12 +76,8 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>
-              Minimum Effect
-              <br />
-              (% change)
-            </Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell> </Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell width="140px">Minimum Effect (% change)</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell width="64px"> </Table.ColumnHeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -96,13 +92,15 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
             {formData.primaryMetric && (
               <Table.Row>
                 <Table.Cell>
-                  {formData.primaryMetric?.metricName} <Badge color={'green'}>Primary</Badge>
+                  {formData.primaryMetric.metric.field_name} <Badge color={'green'}>Primary</Badge>
                 </Table.Cell>
                 <Table.Cell>
                   <TextField.Root
                     type={'number'}
                     value={formData.primaryMetric?.mde}
-                    onChange={(e) => handleMdeChange('primary', formData.primaryMetric!.metricName, e.target.value)}
+                    onChange={(e) =>
+                      handleMdeChange('primary', formData.primaryMetric!.metric.field_name, e.target.value)
+                    }
                     placeholder="MDE %"
                   />
                 </Table.Cell>
@@ -121,17 +119,17 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
               </Table.Row>
             )}
             {formData.secondaryMetrics
-              .toSorted((a, b) => a.metricName.localeCompare(b.metricName))
+              .toSorted((a, b) => a.metric.field_name.localeCompare(b.metric.field_name))
               .map((selectedMetric) => (
-                <Table.Row key={selectedMetric.metricName}>
+                <Table.Row key={selectedMetric.metric.field_name}>
                   <Table.Cell>
-                    <Text size="3">{selectedMetric.metricName}</Text>
+                    <Text size="3">{selectedMetric.metric.field_name}</Text>
                   </Table.Cell>
                   <Table.Cell>
                     <TextField.Root
                       type="number"
                       value={selectedMetric.mde}
-                      onChange={(e) => handleMdeChange('secondary', selectedMetric.metricName, e.target.value)}
+                      onChange={(e) => handleMdeChange('secondary', selectedMetric.metric.field_name, e.target.value)}
                       placeholder="MDE %"
                     />
                   </Table.Cell>
@@ -141,7 +139,7 @@ export function MetricBuilder({ formData, onFormDataChange, metricFields }: Metr
                       color="red"
                       onClick={(event) => {
                         event.preventDefault();
-                        handleSecondaryMetricRemove(selectedMetric.metricName);
+                        handleSecondaryMetricRemove(selectedMetric.metric.field_name);
                       }}
                     >
                       <TrashIcon />

--- a/src/components/features/experiments/querybuilder/filter-row.tsx
+++ b/src/components/features/experiments/querybuilder/filter-row.tsx
@@ -5,6 +5,7 @@ import { TrashIcon } from '@radix-ui/react-icons';
 import { DataType, FilterInput } from '@/api/methods.schemas';
 import { TypeSpecificFilterInput } from '@/components/features/experiments/querybuilder/type-specific-filter-input';
 import { getDefaultFilterForType } from '@/components/features/experiments/querybuilder/utils';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
 
 export interface FilterRowProps {
   filter: FilterInput;
@@ -68,7 +69,7 @@ export function FilterRow({ filter, availableFields, onChange, onRemove }: Filte
               <Select.Item key={field.field_name} value={field.field_name}>
                 <Flex gap={'2'}>
                   <Text>{field.field_name}</Text>
-                  <Badge size={'1'}>{field.data_type}</Badge>
+                  <DataTypeBadge type={field.data_type} />
                 </Flex>
               </Select.Item>
             ))}

--- a/src/components/features/experiments/strata-builder.tsx
+++ b/src/components/features/experiments/strata-builder.tsx
@@ -62,7 +62,7 @@ export function StrataBuilder({ availableStrata, selectedStrata, onStrataChange 
               key={stratum.field_name}
               input={stratum}
               {...(!selectedStrata.includes(stratum.field_name) ? { color: 'gray' } : {})}
-              onClick={() => handleStrataToggle(stratum.field_name, !selectedStrata.includes(stratum.field_name))}
+              onClick={(s) => handleStrataToggle(s.field_name, !selectedStrata.includes(s.field_name))}
               showPlus={false}
             ></ClickableBadge>
           ))}


### PR DESCRIPTION
## Description

* expose data type in frequentist exp filters summary
* refactor for consistent DataTypeBadge in filter dropdowns & metric summary
* task genapiclient (not required, but a holdover from the recent backend snapshot change)

## How has this been tested?

manually:

### filter selection dropdowns
<img width="1041" height="714" alt="Screenshot 2025-09-08 at 1 41 21 PM" src="https://github.com/user-attachments/assets/b4c8e9e0-2f70-400a-8d0d-479580716369" />

### metrics summary
<img width="446" height="419" alt="Screenshot 2025-09-08 at 1 54 06 PM" src="https://github.com/user-attachments/assets/61b41d72-43e0-4191-bbe5-f4895e785120" />

### filters summary
<img width="946" height="510" alt="image" src="https://github.com/user-attachments/assets/26dfe38d-60a5-41ea-b368-54dc5ac50665" />


## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts