### PR TITLE
Persist datasource form data when switching between driver in add datasource dialog

### DIFF
--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -9,6 +9,20 @@ import { BqDsnInput, PostgresDsn, RedshiftDsn } from '@/api/methods.schemas';
 import { mutate } from 'swr';
 import { PostgresSslModes } from '@/services/typehelper';
 
+const defaultFormData = {
+  name: '',
+  host: '',
+  port: '5432',
+  database: '',
+  user: '',
+  password: '',
+  sslmode: 'verify-ca',
+  search_path: '',
+  project_id: '',
+  dataset: '',
+  credentials_json: ''
+};
+
 export function AddDatasourceDialog({ organizationId }: { organizationId: string }) {
   const { trigger, isMutating } = useCreateDatasource({
     swr: {
@@ -21,12 +35,14 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
   });
   const [open, setOpen] = useState(false);
   const [dwhType, setDwhType] = useState<'postgres' | 'redshift' | 'bigquery'>('postgres');
-  const [projectId, setProjectId] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [credentialsJson, setCredentialsJson] = useState('');
+  const [formData, setFormData] = useState(defaultFormData);
 
   const visibilityToggle = (open: boolean) => {
-    setDwhType('postgres');
+    if (!open) {
+      setDwhType('postgres');
+      setFormData(defaultFormData);
+    }
     setOpen(open);
   };
 
@@ -45,49 +61,48 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
           <form
             onSubmit={async (event) => {
               event.preventDefault();
-              const fd = new FormData(event.currentTarget);
-              const name = fd.get('name') as string;
 
               let dsn: PostgresDsn | RedshiftDsn | BqDsnInput;
               if (dwhType === 'postgres') {
                 dsn = {
                   type: 'postgres',
-                  host: fd.get('host') as string,
-                  port: parseInt(fd.get('port') as string),
-                  dbname: fd.get('database') as string,
-                  user: fd.get('user') as string,
-                  password: { type: 'revealed', value: fd.get('password') as string },
-                  sslmode: fd.get('sslmode') as PostgresSslModes,
-                  search_path: (fd.get('search_path') as string) || null,
+                  host: formData.host,
+                  port: parseInt(formData.port),
+                  dbname: formData.database,
+                  user: formData.user,
+                  password: { type: 'revealed', value: formData.password },
+                  sslmode: formData.sslmode as PostgresSslModes,
+                  search_path: formData.search_path || null,
                 };
               } else if (dwhType === 'redshift') {
                 dsn = {
                   type: 'redshift',
-                  host: fd.get('host') as string,
-                  port: parseInt(fd.get('port') as string),
-                  dbname: fd.get('database') as string,
-                  user: fd.get('user') as string,
-                  password: { type: 'revealed', value: fd.get('password') as string },
-                  search_path: (fd.get('search_path') as string) || null,
+                  host: formData.host,
+                  port: parseInt(formData.port),
+                  dbname: formData.database,
+                  user: formData.user,
+                  password: { type: 'revealed', value: formData.password },
+                  search_path: formData.search_path || null,
                 };
               } else {
                 dsn = {
                   type: 'bigquery',
-                  project_id: fd.get('project_id') as string,
-                  dataset_id: fd.get('dataset') as string,
+                  project_id: formData.project_id,
+                  dataset_id: formData.dataset,
                   credentials: {
                     type: 'serviceaccountinfo',
-                    content: fd.get('credentials_json') as string,
+                    content: formData.credentials_json,
                   },
                 };
               }
 
               await trigger({
                 organization_id: organizationId,
-                name,
+                name: formData.name,
                 dsn,
               });
               setDwhType('postgres');
+              setFormData(defaultFormData);
               setOpen(false);
             }}
           >
@@ -101,7 +116,13 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                 <Text as="div" size="2" mb="1" weight="bold">
                   Name
                 </Text>
-                <TextField.Root name="name" placeholder="Enter datasource name" required></TextField.Root>
+                <TextField.Root 
+                  name="name" 
+                  placeholder="Enter datasource name" 
+                  required
+                  value={formData.name}
+                  onChange={(e) => setFormData(prev => ({...prev, name: e.target.value}))}
+                />
               </label>
 
               <label>
@@ -111,8 +132,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                 <RadioGroup.Root
                   defaultValue="postgres"
                   onValueChange={(value) => {
-                    setDwhType(value as 'postgres' | 'bigquery');
-                    setProjectId(''); // Reset projectId when switching form types
+                    setDwhType(value as 'postgres' | 'redshift' | 'bigquery');
                   }}
                 >
                   <Flex gap="2" direction="column">
@@ -141,7 +161,12 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                     <Text as="div" size="2" mb="1" weight="bold">
                       Host
                     </Text>
-                    <TextField.Root name="host" required />
+                    <TextField.Root 
+                      name="host" 
+                      required
+                      value={formData.host}
+                      onChange={(e) => setFormData(prev => ({...prev, host: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
@@ -152,26 +177,48 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         Tip: Redshift default port is 5439.
                       </Text>
                     )}
-                    <TextField.Root name="port" type="number" defaultValue="5432" required />
+                    <TextField.Root 
+                      name="port" 
+                      type="number" 
+                      required
+                      value={formData.port}
+                      onChange={(e) => setFormData(prev => ({...prev, port: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Database
                     </Text>
-                    <TextField.Root name="database" required />
+                    <TextField.Root 
+                      name="database" 
+                      required
+                      value={formData.database}
+                      onChange={(e) => setFormData(prev => ({...prev, database: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       User
                     </Text>
-                    <TextField.Root name="user" required />
+                    <TextField.Root 
+                      name="user" 
+                      required
+                      value={formData.user}
+                      onChange={(e) => setFormData(prev => ({...prev, user: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Password
                     </Text>
                     <Flex gap="2">
-                      <TextField.Root name="password" type={showPassword ? 'text' : 'password'} required />
+                      <TextField.Root 
+                        name="password" 
+                        type={showPassword ? 'text' : 'password'} 
+                        required
+                        value={formData.password}
+                        onChange={(e) => setFormData(prev => ({...prev, password: e.target.value}))}
+                      />
                       <Button type="button" variant="soft" onClick={() => setShowPassword(!showPassword)}>
                         {showPassword ? <EyeOpenIcon /> : <EyeClosedIcon />}
                       </Button>
@@ -182,7 +229,11 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       <Text as="div" size="2" mb="1" weight="bold">
                         SSL Mode
                       </Text>
-                      <select name="sslmode" defaultValue="verify-ca">
+                      <select 
+                        name="sslmode" 
+                        value={formData.sslmode}
+                        onChange={(e) => setFormData(prev => ({...prev, sslmode: e.target.value}))}
+                      >
                         <option value="disable">disable</option>
                         <option value="require">require</option>
                         <option value="verify-ca">verify-ca</option>
@@ -202,7 +253,11 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         <InfoCircledIcon style={{ verticalAlign: 'middle' }} />
                       </a>
                     </Text>
-                    <TextField.Root name="search_path" />
+                    <TextField.Root 
+                      name="search_path"
+                      value={formData.search_path}
+                      onChange={(e) => setFormData(prev => ({...prev, search_path: e.target.value}))}
+                    />
                   </label>
                 </>
               ) : (
@@ -215,21 +270,27 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       key={'project_id'}
                       name="project_id"
                       required
-                      value={projectId}
-                      onChange={(e) => setProjectId(e.target.value)}
+                      value={formData.project_id}
+                      onChange={(e) => setFormData(prev => ({...prev, project_id: e.target.value}))}
                     />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Dataset
                     </Text>
-                    <TextField.Root name="dataset" required key={'dataset'} />
+                    <TextField.Root 
+                      name="dataset" 
+                      required 
+                      key={'dataset'}
+                      value={formData.dataset}
+                      onChange={(e) => setFormData(prev => ({...prev, dataset: e.target.value}))}
+                    />
                   </label>
                   <ServiceAccountJsonField
                     required
-                    value={credentialsJson}
-                    onChange={setCredentialsJson}
-                    onProjectIdFound={setProjectId}
+                    value={formData.credentials_json}
+                    onChange={(value) => setFormData(prev => ({...prev, credentials_json: value}))}
+                    onProjectIdFound={(projectId) => setFormData(prev => ({...prev, project_id: projectId}))}
                   />
                 </>
               )}

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -95,7 +95,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                   },
                 };
               }
-
+          
               await trigger({
                 organization_id: organizationId,
                 name: formData.name,

--- a/src/components/features/datasources/datasources-table.tsx
+++ b/src/components/features/datasources/datasources-table.tsx
@@ -1,9 +1,133 @@
 'use client';
-import { Code, Flex, Table } from '@radix-ui/themes';
+import { Button, Flex, IconButton, Table, Text, Tooltip, Box } from '@radix-ui/themes';
 import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
 import Link from 'next/link';
 import { DeleteDatasourceDialog } from '@/components/features/datasources/delete-datasource-dialog';
 import { EditDatasourceDialog } from '@/components/features/datasources/edit-datasource-dialog';
+import { useListParticipantTypes } from '@/api/admin';
+import { PersonIcon, ChevronDownIcon, ChevronRightIcon, PlusIcon } from '@radix-ui/react-icons';
+import { useState } from 'react';
+
+function DatasourceRow({
+  datasource,
+  organizationId,
+}: {
+  datasource: {
+    id: string;
+    name: string;
+    driver: string;
+  };
+  organizationId: string;
+}) {
+  const { data: participantTypesData, isLoading, error } = useListParticipantTypes(datasource.id);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <>
+      <Table.Row key={datasource.id}>
+        <Table.Cell>
+          <Flex direction="column" gap="1">
+            <Flex align="center" gap="2">
+              <IconButton variant="ghost" size="1" onClick={() => setIsExpanded(!isExpanded)}>
+                {isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+              </IconButton>
+              <Link href={`/datasources/${datasource.id}`}>{datasource.name}</Link>
+              <CopyToClipBoard content={datasource.id} tooltipContent="Copy Datasource ID" />
+            </Flex>
+            {isLoading ? (
+              <Text size="1" color="gray">
+                Loading...
+              </Text>
+            ) : error ? (
+              <Text size="1" color="gray">
+                Error loading
+              </Text>
+            ) : participantTypesData?.items && participantTypesData.items.length > 0 ? (
+              <Button variant="ghost" size="1" color="blue" onClick={() => setIsExpanded(!isExpanded)}>
+                <PersonIcon /> {participantTypesData.items.length} participant type
+                {participantTypesData.items.length === 1 ? '' : 's'}
+              </Button>
+            ) : (
+              <Link href={`/datasources/${datasource.id}/participants/create`}>
+                <Button variant="ghost" size="1" color="blue">
+                  <PlusIcon /> Add participant type
+                </Button>
+              </Link>
+            )}
+          </Flex>
+        </Table.Cell>
+
+        <Table.Cell>
+          {datasource.driver === 'bigquery' && 'Google BigQuery'}
+          {datasource.driver === 'postgresql+psycopg' && 'PostgreSQL'}
+          {datasource.driver === 'postgresql+psycopg2' && 'Redshift'}
+          {datasource.driver === 'none' && <em>no warehouse</em>}
+        </Table.Cell>
+        <Table.Cell>
+          <Flex gap="2">
+            <Tooltip content="Add Participant Type">
+              <Link href={`/datasources/${datasource.id}/participants/create`}>
+                <IconButton variant="soft" color="blue">
+                  <PersonIcon />
+                </IconButton>
+              </Link>
+            </Tooltip>
+            <EditDatasourceDialog organizationId={organizationId} datasourceId={datasource.id} />
+            <DeleteDatasourceDialog organizationId={organizationId} datasourceId={datasource.id} />
+          </Flex>
+        </Table.Cell>
+      </Table.Row>
+      {/* Expanded row for actions - simple conditional rendering */}
+      {isExpanded && (
+        <Table.Row style={{ background: 'var(--blue-2)' }}>
+          <Table.Cell colSpan={4}>
+            <Box p="3">
+              <Flex direction="column" gap="2">
+                <Text size="2" weight="medium" color="gray">
+                  Participant Types:
+                </Text>
+                {isLoading ? (
+                  <Text size="2" color="gray">
+                    Loading...
+                  </Text>
+                ) : error ? (
+                  <Text size="2" color="gray">
+                    Error loading participant types
+                  </Text>
+                ) : (
+                  <Flex direction="column" gap="2">
+                    {participantTypesData?.items && participantTypesData.items.length > 0 && (
+                      <Flex gap="2" wrap="wrap">
+                        {participantTypesData.items.map((item, index) => (
+                          <Link
+                            key={index}
+                            href={`/datasources/${datasource.id}/participants/${item.participant_type}`}
+                          >
+                            <Button variant="surface" size="2" color="gray">
+                              <Flex align="center" gap="2">
+                                <PersonIcon />
+                                <Text size="2">{item.participant_type}</Text>
+                              </Flex>
+                            </Button>
+                          </Link>
+                        ))}
+                      </Flex>
+                    )}
+                    <Link href={`/datasources/${datasource.id}/participants/create`}>
+                      <Button variant="ghost" size="2" color="blue">
+                        <PlusIcon /> Add participant type
+                      </Button>
+                    </Link>
+                  </Flex>
+                )}
+              </Flex>
+            </Box>
+          </Table.Cell>
+        </Table.Row>
+      )}
+    </>
+  );
+}
 
 export function DatasourcesTable({
   datasources,
@@ -21,36 +145,13 @@ export function DatasourcesTable({
       <Table.Header>
         <Table.Row>
           <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Datasource ID</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell>Driver</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell>Actions</Table.ColumnHeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>
         {datasources.map((datasource) => (
-          <Table.Row key={datasource.id}>
-            <Table.Cell>
-              <Link href={`/datasources/${datasource.id}`}>{datasource.name}</Link>
-            </Table.Cell>
-            <Table.Cell>
-              <Flex align="center" gap="2">
-                <Code variant={'ghost'}>{datasource.id}</Code>
-                <CopyToClipBoard content={datasource.id} />
-              </Flex>
-            </Table.Cell>
-            <Table.Cell>
-              {datasource.driver === 'bigquery' && 'Google BigQuery'}
-              {datasource.driver === 'postgresql+psycopg' && 'PostgreSQL'}
-              {datasource.driver === 'postgresql+psycopg2' && 'Redshift'}
-              {datasource.driver === 'none' && <em>no warehouse</em>}
-            </Table.Cell>
-            <Table.Cell>
-              <Flex gap="2">
-                <EditDatasourceDialog organizationId={organizationId} datasourceId={datasource.id} />
-                <DeleteDatasourceDialog organizationId={organizationId} datasourceId={datasource.id} />
-              </Flex>
-            </Table.Cell>
-          </Table.Row>
+          <DatasourceRow key={datasource.id} datasource={datasource} organizationId={organizationId} />
         ))}
       </Table.Body>
     </Table.Root>

--- a/src/components/features/experiments/confirmation-form.tsx
+++ b/src/components/features/experiments/confirmation-form.tsx
@@ -12,7 +12,6 @@ import { ApiError } from '@/services/orval-fetch';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { ReadMoreText } from '@/components/ui/read-more-text';
 import { ListSelectedWebhooksCard } from '@/components/features/experiments/list-selected-webhooks-card';
-import { color } from 'motion';
 
 interface ConfirmationFormProps {
   formData: FrequentABFormData;


### PR DESCRIPTION
## Ticket

Fixes: [#121](https://github.com/agency-fund/evidential-sprint/issues/121)

## Description
Fixes bug where form data is lost in add-datasource-dialog when switching between drivers (i.e. Postgresql, BigQuery, Redshift)

### Goal
Persist form data for user so that switching between drivers does not reset the form and require the user to reenter form data.

### Changes
- Created single defaultFormData object to house form state across the 3 drivers, and added controlled inputs so form data is stored in state and persists when switching between providers. 
- Single unrelated linter cleanup of unused import in confirmation-form.tsx

## How has this been tested?
Tested on form by filling out all fields with Postgres selected as driver then switched to BigQuery and filled out all related fields, then switched to Postgres and then Redshift. All form data persists between driver changes. Submission logic remains unchanged.

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
