### PR TITLE
BUG FIX: Add Datasource form data being lost when switching between drivers

### DIFF
--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -117,7 +117,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                   Name
                 </Text>
                 <TextField.Root
-                  name="name"
                   placeholder="Enter datasource name"
                   required
                   value={formData.name}
@@ -162,7 +161,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       Host
                     </Text>
                     <TextField.Root
-                      name="host"
                       required
                       value={formData.host}
                       onChange={(e) => setFormData((prev) => ({ ...prev, host: e.target.value }))}
@@ -178,7 +176,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       </Text>
                     )}
                     <TextField.Root
-                      name="port"
                       type="number"
                       required
                       value={formData.port}
@@ -190,7 +187,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       Database
                     </Text>
                     <TextField.Root
-                      name="database"
                       required
                       value={formData.database}
                       onChange={(e) => setFormData((prev) => ({ ...prev, database: e.target.value }))}
@@ -201,7 +197,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       User
                     </Text>
                     <TextField.Root
-                      name="user"
                       required
                       value={formData.user}
                       onChange={(e) => setFormData((prev) => ({ ...prev, user: e.target.value }))}
@@ -213,7 +208,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                     </Text>
                     <Flex gap="2">
                       <TextField.Root
-                        name="password"
                         type={showPassword ? 'text' : 'password'}
                         required
                         value={formData.password}
@@ -230,7 +224,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         SSL Mode
                       </Text>
                       <select
-                        name="sslmode"
                         value={formData.sslmode}
                         onChange={(e) => setFormData((prev) => ({ ...prev, sslmode: e.target.value }))}
                       >
@@ -254,7 +247,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       </a>
                     </Text>
                     <TextField.Root
-                      name="search_path"
                       value={formData.search_path}
                       onChange={(e) => setFormData((prev) => ({ ...prev, search_path: e.target.value }))}
                     />
@@ -268,7 +260,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                     </Text>
                     <TextField.Root
                       key={'project_id'}
-                      name="project_id"
                       required
                       value={formData.project_id}
                       onChange={(e) => setFormData((prev) => ({ ...prev, project_id: e.target.value }))}
@@ -279,7 +270,6 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       Dataset
                     </Text>
                     <TextField.Root
-                      name="dataset"
                       required
                       key={'dataset'}
                       value={formData.dataset}

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -5,11 +5,27 @@ import { Button, Dialog, Flex, RadioGroup, Text, TextField } from '@radix-ui/the
 import { ServiceAccountJsonField } from '@/components/features/datasources/service-account-json-field';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { EyeClosedIcon, EyeOpenIcon, InfoCircledIcon, PlusIcon } from '@radix-ui/react-icons';
-import { BqDsnInput, PostgresDsn, RedshiftDsn } from '@/api/methods.schemas';
+import { ApiOnlyDsn, BqDsnInput, DsnInput, PostgresDsn, PostgresDsnSslmode, RedshiftDsn } from '@/api/methods.schemas';
 import { mutate } from 'swr';
 import { PostgresSslModes } from '@/services/typehelper';
 
-const defaultFormData = {
+type AllowedDwhTypes = Exclude<DsnInput['type'], ApiOnlyDsn['type']>;
+
+interface FormFields {
+  name: string;
+  host: string;
+  port: string;
+  database: string;
+  user: string;
+  password: string;
+  sslmode: PostgresDsnSslmode;
+  search_path: string;
+  project_id: string;
+  dataset: string;
+  credentials_json: string;
+}
+
+const defaultFormData: FormFields = {
   name: '',
   host: '',
   port: '5432',
@@ -34,7 +50,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
     },
   });
   const [open, setOpen] = useState(false);
-  const [dwhType, setDwhType] = useState<'postgres' | 'redshift' | 'bigquery'>('postgres');
+  const [dwhType, setDwhType] = useState<AllowedDwhTypes>('postgres');
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState(defaultFormData);
 
@@ -225,7 +241,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       </Text>
                       <select
                         value={formData.sslmode}
-                        onChange={(e) => setFormData((prev) => ({ ...prev, sslmode: e.target.value }))}
+                        onChange={(e) => setFormData((prev) => ({ ...prev, sslmode: e.target.value as PostgresDsnSslmode }))}
                       >
                         <option value="disable">disable</option>
                         <option value="require">require</option>

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -9,6 +9,20 @@ import { BqDsnInput, PostgresDsn, RedshiftDsn } from '@/api/methods.schemas';
 import { mutate } from 'swr';
 import { PostgresSslModes } from '@/services/typehelper';
 
+const defaultFormData = {
+  name: '',
+  host: '',
+  port: '5432',
+  database: '',
+  user: '',
+  password: '',
+  sslmode: 'verify-ca',
+  search_path: '',
+  project_id: '',
+  dataset: '',
+  credentials_json: ''
+};
+
 export function AddDatasourceDialog({ organizationId }: { organizationId: string }) {
   const { trigger, isMutating } = useCreateDatasource({
     swr: {
@@ -21,12 +35,14 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
   });
   const [open, setOpen] = useState(false);
   const [dwhType, setDwhType] = useState<'postgres' | 'redshift' | 'bigquery'>('postgres');
-  const [projectId, setProjectId] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [credentialsJson, setCredentialsJson] = useState('');
+  const [formData, setFormData] = useState(defaultFormData);
 
   const visibilityToggle = (open: boolean) => {
-    setDwhType('postgres');
+    if (!open) {
+      setDwhType('postgres');
+      setFormData(defaultFormData);
+    }
     setOpen(open);
   };
 
@@ -45,49 +61,48 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
           <form
             onSubmit={async (event) => {
               event.preventDefault();
-              const fd = new FormData(event.currentTarget);
-              const name = fd.get('name') as string;
 
               let dsn: PostgresDsn | RedshiftDsn | BqDsnInput;
               if (dwhType === 'postgres') {
                 dsn = {
                   type: 'postgres',
-                  host: fd.get('host') as string,
-                  port: parseInt(fd.get('port') as string),
-                  dbname: fd.get('database') as string,
-                  user: fd.get('user') as string,
-                  password: { type: 'revealed', value: fd.get('password') as string },
-                  sslmode: fd.get('sslmode') as PostgresSslModes,
-                  search_path: (fd.get('search_path') as string) || null,
+                  host: formData.host,
+                  port: parseInt(formData.port),
+                  dbname: formData.database,
+                  user: formData.user,
+                  password: { type: 'revealed', value: formData.password },
+                  sslmode: formData.sslmode as PostgresSslModes,
+                  search_path: formData.search_path || null,
                 };
               } else if (dwhType === 'redshift') {
                 dsn = {
                   type: 'redshift',
-                  host: fd.get('host') as string,
-                  port: parseInt(fd.get('port') as string),
-                  dbname: fd.get('database') as string,
-                  user: fd.get('user') as string,
-                  password: { type: 'revealed', value: fd.get('password') as string },
-                  search_path: (fd.get('search_path') as string) || null,
+                  host: formData.host,
+                  port: parseInt(formData.port),
+                  dbname: formData.database,
+                  user: formData.user,
+                  password: { type: 'revealed', value: formData.password },
+                  search_path: formData.search_path || null,
                 };
               } else {
                 dsn = {
                   type: 'bigquery',
-                  project_id: fd.get('project_id') as string,
-                  dataset_id: fd.get('dataset') as string,
+                  project_id: formData.project_id,
+                  dataset_id: formData.dataset,
                   credentials: {
                     type: 'serviceaccountinfo',
-                    content: fd.get('credentials_json') as string,
+                    content: formData.credentials_json,
                   },
                 };
               }
-
+          
               await trigger({
                 organization_id: organizationId,
-                name,
+                name: formData.name,
                 dsn,
               });
               setDwhType('postgres');
+              setFormData(defaultFormData);
               setOpen(false);
             }}
           >
@@ -101,7 +116,13 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                 <Text as="div" size="2" mb="1" weight="bold">
                   Name
                 </Text>
-                <TextField.Root name="name" placeholder="Enter datasource name" required></TextField.Root>
+                <TextField.Root 
+                  name="name" 
+                  placeholder="Enter datasource name" 
+                  required
+                  value={formData.name}
+                  onChange={(e) => setFormData(prev => ({...prev, name: e.target.value}))}
+                />
               </label>
 
               <label>
@@ -111,8 +132,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                 <RadioGroup.Root
                   defaultValue="postgres"
                   onValueChange={(value) => {
-                    setDwhType(value as 'postgres' | 'bigquery');
-                    setProjectId(''); // Reset projectId when switching form types
+                    setDwhType(value as 'postgres' | 'redshift' | 'bigquery');
                   }}
                 >
                   <Flex gap="2" direction="column">
@@ -141,7 +161,12 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                     <Text as="div" size="2" mb="1" weight="bold">
                       Host
                     </Text>
-                    <TextField.Root name="host" required />
+                    <TextField.Root 
+                      name="host" 
+                      required
+                      value={formData.host}
+                      onChange={(e) => setFormData(prev => ({...prev, host: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
@@ -152,26 +177,48 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         Tip: Redshift default port is 5439.
                       </Text>
                     )}
-                    <TextField.Root name="port" type="number" defaultValue="5432" required />
+                    <TextField.Root 
+                      name="port" 
+                      type="number" 
+                      required
+                      value={formData.port}
+                      onChange={(e) => setFormData(prev => ({...prev, port: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Database
                     </Text>
-                    <TextField.Root name="database" required />
+                    <TextField.Root 
+                      name="database" 
+                      required
+                      value={formData.database}
+                      onChange={(e) => setFormData(prev => ({...prev, database: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       User
                     </Text>
-                    <TextField.Root name="user" required />
+                    <TextField.Root 
+                      name="user" 
+                      required
+                      value={formData.user}
+                      onChange={(e) => setFormData(prev => ({...prev, user: e.target.value}))}
+                    />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Password
                     </Text>
                     <Flex gap="2">
-                      <TextField.Root name="password" type={showPassword ? 'text' : 'password'} required />
+                      <TextField.Root 
+                        name="password" 
+                        type={showPassword ? 'text' : 'password'} 
+                        required
+                        value={formData.password}
+                        onChange={(e) => setFormData(prev => ({...prev, password: e.target.value}))}
+                      />
                       <Button type="button" variant="soft" onClick={() => setShowPassword(!showPassword)}>
                         {showPassword ? <EyeOpenIcon /> : <EyeClosedIcon />}
                       </Button>
@@ -182,7 +229,11 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       <Text as="div" size="2" mb="1" weight="bold">
                         SSL Mode
                       </Text>
-                      <select name="sslmode" defaultValue="verify-ca">
+                      <select 
+                        name="sslmode" 
+                        value={formData.sslmode}
+                        onChange={(e) => setFormData(prev => ({...prev, sslmode: e.target.value}))}
+                      >
                         <option value="disable">disable</option>
                         <option value="require">require</option>
                         <option value="verify-ca">verify-ca</option>
@@ -202,7 +253,11 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         <InfoCircledIcon style={{ verticalAlign: 'middle' }} />
                       </a>
                     </Text>
-                    <TextField.Root name="search_path" />
+                    <TextField.Root 
+                      name="search_path"
+                      value={formData.search_path}
+                      onChange={(e) => setFormData(prev => ({...prev, search_path: e.target.value}))}
+                    />
                   </label>
                 </>
               ) : (
@@ -215,21 +270,27 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       key={'project_id'}
                       name="project_id"
                       required
-                      value={projectId}
-                      onChange={(e) => setProjectId(e.target.value)}
+                      value={formData.project_id}
+                      onChange={(e) => setFormData(prev => ({...prev, project_id: e.target.value}))}
                     />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Dataset
                     </Text>
-                    <TextField.Root name="dataset" required key={'dataset'} />
+                    <TextField.Root 
+                      name="dataset" 
+                      required 
+                      key={'dataset'}
+                      value={formData.dataset}
+                      onChange={(e) => setFormData(prev => ({...prev, dataset: e.target.value}))}
+                    />
                   </label>
                   <ServiceAccountJsonField
                     required
-                    value={credentialsJson}
-                    onChange={setCredentialsJson}
-                    onProjectIdFound={setProjectId}
+                    value={formData.credentials_json}
+                    onChange={(value) => setFormData(prev => ({...prev, credentials_json: value}))}
+                    onProjectIdFound={(projectId) => setFormData(prev => ({...prev, project_id: projectId}))}
                   />
                 </>
               )}

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -241,7 +241,9 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       </Text>
                       <select
                         value={formData.sslmode}
-                        onChange={(e) => setFormData((prev) => ({ ...prev, sslmode: e.target.value as PostgresDsnSslmode }))}
+                        onChange={(e) =>
+                          setFormData((prev) => ({ ...prev, sslmode: e.target.value as PostgresDsnSslmode }))
+                        }
                       >
                         <option value="disable">disable</option>
                         <option value="require">require</option>

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -20,7 +20,7 @@ const defaultFormData = {
   search_path: '',
   project_id: '',
   dataset: '',
-  credentials_json: ''
+  credentials_json: '',
 };
 
 export function AddDatasourceDialog({ organizationId }: { organizationId: string }) {
@@ -95,7 +95,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                   },
                 };
               }
-          
+
               await trigger({
                 organization_id: organizationId,
                 name: formData.name,
@@ -116,12 +116,12 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                 <Text as="div" size="2" mb="1" weight="bold">
                   Name
                 </Text>
-                <TextField.Root 
-                  name="name" 
-                  placeholder="Enter datasource name" 
+                <TextField.Root
+                  name="name"
+                  placeholder="Enter datasource name"
                   required
                   value={formData.name}
-                  onChange={(e) => setFormData(prev => ({...prev, name: e.target.value}))}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
                 />
               </label>
 
@@ -161,11 +161,11 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                     <Text as="div" size="2" mb="1" weight="bold">
                       Host
                     </Text>
-                    <TextField.Root 
-                      name="host" 
+                    <TextField.Root
+                      name="host"
                       required
                       value={formData.host}
-                      onChange={(e) => setFormData(prev => ({...prev, host: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, host: e.target.value }))}
                     />
                   </label>
                   <label>
@@ -177,34 +177,34 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         Tip: Redshift default port is 5439.
                       </Text>
                     )}
-                    <TextField.Root 
-                      name="port" 
-                      type="number" 
+                    <TextField.Root
+                      name="port"
+                      type="number"
                       required
                       value={formData.port}
-                      onChange={(e) => setFormData(prev => ({...prev, port: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, port: e.target.value }))}
                     />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Database
                     </Text>
-                    <TextField.Root 
-                      name="database" 
+                    <TextField.Root
+                      name="database"
                       required
                       value={formData.database}
-                      onChange={(e) => setFormData(prev => ({...prev, database: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, database: e.target.value }))}
                     />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       User
                     </Text>
-                    <TextField.Root 
-                      name="user" 
+                    <TextField.Root
+                      name="user"
                       required
                       value={formData.user}
-                      onChange={(e) => setFormData(prev => ({...prev, user: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, user: e.target.value }))}
                     />
                   </label>
                   <label>
@@ -212,12 +212,12 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       Password
                     </Text>
                     <Flex gap="2">
-                      <TextField.Root 
-                        name="password" 
-                        type={showPassword ? 'text' : 'password'} 
+                      <TextField.Root
+                        name="password"
+                        type={showPassword ? 'text' : 'password'}
                         required
                         value={formData.password}
-                        onChange={(e) => setFormData(prev => ({...prev, password: e.target.value}))}
+                        onChange={(e) => setFormData((prev) => ({ ...prev, password: e.target.value }))}
                       />
                       <Button type="button" variant="soft" onClick={() => setShowPassword(!showPassword)}>
                         {showPassword ? <EyeOpenIcon /> : <EyeClosedIcon />}
@@ -229,10 +229,10 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       <Text as="div" size="2" mb="1" weight="bold">
                         SSL Mode
                       </Text>
-                      <select 
-                        name="sslmode" 
+                      <select
+                        name="sslmode"
                         value={formData.sslmode}
-                        onChange={(e) => setFormData(prev => ({...prev, sslmode: e.target.value}))}
+                        onChange={(e) => setFormData((prev) => ({ ...prev, sslmode: e.target.value }))}
                       >
                         <option value="disable">disable</option>
                         <option value="require">require</option>
@@ -253,10 +253,10 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                         <InfoCircledIcon style={{ verticalAlign: 'middle' }} />
                       </a>
                     </Text>
-                    <TextField.Root 
+                    <TextField.Root
                       name="search_path"
                       value={formData.search_path}
-                      onChange={(e) => setFormData(prev => ({...prev, search_path: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, search_path: e.target.value }))}
                     />
                   </label>
                 </>
@@ -271,26 +271,26 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
                       name="project_id"
                       required
                       value={formData.project_id}
-                      onChange={(e) => setFormData(prev => ({...prev, project_id: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, project_id: e.target.value }))}
                     />
                   </label>
                   <label>
                     <Text as="div" size="2" mb="1" weight="bold">
                       Dataset
                     </Text>
-                    <TextField.Root 
-                      name="dataset" 
-                      required 
+                    <TextField.Root
+                      name="dataset"
+                      required
                       key={'dataset'}
                       value={formData.dataset}
-                      onChange={(e) => setFormData(prev => ({...prev, dataset: e.target.value}))}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, dataset: e.target.value }))}
                     />
                   </label>
                   <ServiceAccountJsonField
                     required
                     value={formData.credentials_json}
-                    onChange={(value) => setFormData(prev => ({...prev, credentials_json: value}))}
-                    onProjectIdFound={(projectId) => setFormData(prev => ({...prev, project_id: projectId}))}
+                    onChange={(value) => setFormData((prev) => ({ ...prev, credentials_json: value }))}
+                    onProjectIdFound={(projectId) => setFormData((prev) => ({ ...prev, project_id: projectId }))}
                   />
                 </>
               )}


### PR DESCRIPTION
## Ticket

Fixes: [#121](https://github.com/agency-fund/evidential-sprint/issues/121)

## Description
Fixes bug where form data is lost in add-datasource-dialog when switching between drivers (i.e. Postgresql, BigQuery, Redshift)

### Goal
Persist form data for user so that switching between drivers does not reset the form and require the user to reenter form data.

### Changes
- Created single defaultFormData object to house form state across the 3 drivers, and added controlled inputs so form data is stored in state and persists when switching between providers. 
- Single unrelated linter cleanup of unused import in confirmation-form.tsx

## How has this been tested?
Tested on form by filling out all fields with Postgres selected as driver then switched to BigQuery and filled out all related fields, then switched to Postgres and then Redshift. All form data persists between driver changes. Submission logic remains unchanged.

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
