### PR TITLE
Forestplot fixes: fix overlapping long arm names and some x-axis sizing issues.

### DIFF
--- a/src/components/features/experiments/forest-plot.tsx
+++ b/src/components/features/experiments/forest-plot.tsx
@@ -159,11 +159,15 @@ export function ForestPlot({ analysis, designSpec, assignSummary }: ForestPlotPr
     let minX = Math.min(...effectSizes.map((d) => d.absCI95Lower));
     let maxX = Math.max(...effectSizes.map((d) => d.absCI95Upper));
     const viewportWidth = maxX - minX;
-    minX = minX - viewportWidth * 0.05;
-    maxX = maxX + viewportWidth * 0.05;
+    minX = minX - viewportWidth * 0.1;
+    maxX = maxX + viewportWidth * 0.1;
     if (Math.abs(minX) > 1 && Math.abs(maxX) > 1) {
       minX = Math.floor(minX);
       maxX = Math.ceil(maxX);
+    }
+    if (Math.abs(minX - maxX) < 0.0000001) {
+      minX = minX - 1;
+      maxX = maxX + 1;
     }
     return [minX, maxX];
   }
@@ -235,7 +239,9 @@ export function ForestPlot({ analysis, designSpec, assignSummary }: ForestPlotPr
               scale="linear"
               domain={[minX, maxX]}
               ticks={xGridPoints} // use our own ticks due to auto rendering issues
-              tickFormatter={(value) => (value >= 1 ? value.toFixed() : value.toFixed(2))}
+              tickFormatter={(value) =>
+                value >= 10 ? value.toFixed() : value >= 1 ? value.toFixed(1) : value.toFixed(2)
+              }
             />
             <YAxis
               type="category"
@@ -343,7 +349,7 @@ export function ForestPlot({ analysis, designSpec, assignSummary }: ForestPlotPr
                     x2={(centerX || 0) + scaleHalfIntervalToViewport(ci95, xAxisWidth)}
                     y2={centerY}
                     stroke={strokeColor}
-                    strokeWidth={4}
+                    strokeWidth={5}
                     strokeLinecap="round"
                   />
                 );


### PR DESCRIPTION
Arms could overlap due to a) having very long names, and b) having many arms within a fixed sized plot.
Tick marks also could be incorrect if the arms' means were nearly identical.

## Description

* truncates long arm names
* dynamically sets height based on # of arms
* improves x-axis tick formatting and min/max limits

Some examples:

* 5 arms, long names
<img width="1122" height="417" alt="image" src="https://github.com/user-attachments/assets/0470893c-3ecc-4646-bd66-0a11b1636e60" />

* 3 arms, long names
<img width="1097" height="289" alt="image" src="https://github.com/user-attachments/assets/6ae61cf4-7067-4c53-bafe-586175197b42" />

* target boolean metric, filtered to only users =True
<img width="730" height="326" alt="image" src="https://github.com/user-attachments/assets/5a648b23-5a68-4171-a73a-6eee59d46723" />

* similarly, target boolean metric, filtered to only users =False
<img width="1104" height="307" alt="image" src="https://github.com/user-attachments/assets/7dbee1ee-59de-424f-b05e-c3e20b575db5" />



## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
