### PR TITLE
Improved error handling on PT create page

### DIFF
--- a/src/app/datasources/[datasourceId]/participants/create/page.tsx
+++ b/src/app/datasources/[datasourceId]/participants/create/page.tsx
@@ -89,7 +89,11 @@ export default function CreateParticipantTypePage() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const tableIsSelected = selectedTable !== '';
-  const { data: tableData, isLoading: loadingTableData } = useInspectTableInDatasource(
+  const {
+    data: tableData,
+    isLoading: loadingTableData,
+    error: tableError,
+  } = useInspectTableInDatasource(
     datasourceId,
     selectedTable,
     { refresh },
@@ -304,6 +308,8 @@ export default function CreateParticipantTypePage() {
 
             {loadingTableData ? (
               <XSpinner message="Loading table data..." />
+            ) : tableError ? (
+              <GenericErrorCallout title="Failed to load table fields" error={tableError} />
             ) : selectedTable === '' ? (
               <></>
             ) : (


### PR DESCRIPTION
## Ticket

Fixes: [#112](https://github.com/agency-fund/evidential-sprint/issues/112)

## Description
- Catches backend errors and displays them with generic-error.tsx

### Goal
- Provide users a more helpful and informative error message in the UI when backend returns errors

### Changes
- Pulling error out of useInspectTableInDatasource
- Dynamically displaying generic-error.tsx component when error exists.
<img width="1193" height="651" alt="Screenshot 2025-09-19 at 10 32 46 AM" src="https://github.com/user-attachments/assets/d169bc30-4434-4bc1-9d90-2accb7073d59" />

## How has this been tested?
- Hard coded bad datasourceId in useInspectTableInDatasource to produce error and display generic-error in UI

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
