### PR TITLE
Refactor datasource dialogs for consistency and improved error handling

### DIFF
--- a/src/app/datasources/[datasourceId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/page.tsx
@@ -17,9 +17,6 @@ export default function Page() {
   const orgContext = useCurrentOrganization();
   const currentOrgId = orgContext?.current?.id;
   const router = useRouter();
-  // State to pause some SWR requests when the dialog is open, which would otherwise inadvertently close the dialog.
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [wasDialogOpen, setWasDialogOpen] = useState(false);
 
   const {
     data: datasourceMetadata,
@@ -28,7 +25,6 @@ export default function Page() {
   } = useGetDatasource(datasourceId!, {
     swr: {
       enabled: datasourceId !== null,
-      isPaused: () => isDialogOpen,
     },
   });
 
@@ -36,24 +32,11 @@ export default function Page() {
     data: inspectDatasourceData,
     isLoading: inspectDatasourceLoading,
     error: inspectError,
-    mutate: mutateInspect,
   } = useInspectDatasource(datasourceId!, undefined, {
     swr: {
       enabled: datasourceId !== null,
-      // Don't trigger the inspection if we're possibly editing the datasource.
-      isPaused: () => isDialogOpen,
     },
   });
-
-  // Only trigger revalidation when dialog transitions from open to closed,
-  // while avoiding the initial load triggering a revalidation.
-  useEffect(() => {
-    if (datasourceId && wasDialogOpen && !isDialogOpen) {
-      mutateInspect();
-    }
-    // Update previous state for next render
-    setWasDialogOpen(isDialogOpen);
-  }, [datasourceId, isDialogOpen, wasDialogOpen, mutateInspect]);
 
   // Redirect if datasource doesn't belong to current organization
   useEffect(() => {
@@ -66,7 +49,7 @@ export default function Page() {
   const isLoading = inspectDatasourceLoading || datasourceDetailsLoading;
 
   const editDatasourceDialogComponent = (
-    <EditDatasourceDialog datasourceId={datasourceId!} variant="button" onOpenChange={setIsDialogOpen} />
+    <EditDatasourceDialog datasourceId={datasourceId!} variant="button" />
   );
 
   if (isLoading) {

--- a/src/app/datasources/[datasourceId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/page.tsx
@@ -7,7 +7,7 @@ import { useGetDatasource, useInspectDatasource } from '@/api/admin';
 import { useParams, useRouter } from 'next/navigation';
 import { EditDatasourceDialog } from '@/components/features/datasources/edit-datasource-dialog';
 import { useCurrentOrganization } from '@/providers/organization-provider';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
 
@@ -48,9 +48,7 @@ export default function Page() {
 
   const isLoading = inspectDatasourceLoading || datasourceDetailsLoading;
 
-  const editDatasourceDialogComponent = (
-    <EditDatasourceDialog datasourceId={datasourceId!} variant="button" />
-  );
+  const editDatasourceDialogComponent = <EditDatasourceDialog datasourceId={datasourceId!} variant="button" />;
 
   if (isLoading) {
     return <XSpinner message="Loading datasource details..." />;

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -3,7 +3,6 @@ import { getGetOrganizationKey, getListOrganizationDatasourcesKey, useCreateData
 import { useState } from 'react';
 import { Button, Dialog, Flex, RadioGroup, Text, TextField } from '@radix-ui/themes';
 import { ServiceAccountJsonField } from '@/components/features/datasources/service-account-json-field';
-import { XSpinner } from '@/components/ui/x-spinner';
 import { EyeClosedIcon, EyeOpenIcon, InfoCircledIcon, PlusIcon } from '@radix-ui/react-icons';
 import { ApiOnlyDsn, BqDsnInput, DsnInput, PostgresDsn, PostgresDsnSslmode, RedshiftDsn } from '@/api/methods.schemas';
 import { mutate } from 'swr';
@@ -40,7 +39,12 @@ const defaultFormData: FormFields = {
 };
 
 export function AddDatasourceDialog({ organizationId }: { organizationId: string }) {
-  const { trigger, isMutating } = useCreateDatasource({
+  const [open, setOpen] = useState(false);
+  const [dwhType, setDwhType] = useState<AllowedDwhTypes>('postgres');
+  const [showPassword, setShowPassword] = useState(false);
+  const [formData, setFormData] = useState(defaultFormData);
+  const [error, setError] = useState(false);
+  const { trigger, reset } = useCreateDatasource({
     swr: {
       onSuccess: () =>
         Promise.all([
@@ -49,21 +53,20 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
         ]),
     },
   });
-  const [open, setOpen] = useState(false);
-  const [dwhType, setDwhType] = useState<AllowedDwhTypes>('postgres');
-  const [showPassword, setShowPassword] = useState(false);
-  const [formData, setFormData] = useState(defaultFormData);
-
-  const visibilityToggle = (open: boolean) => {
-    if (!open) {
-      setDwhType('postgres');
-      setFormData(defaultFormData);
-    }
-    setOpen(open);
-  };
 
   return (
-    <Dialog.Root open={open} onOpenChange={visibilityToggle}>
+    <Dialog.Root
+      open={open}
+      onOpenChange={(op) => {
+        setOpen(op);
+        if (!op) {
+          setDwhType('postgres');
+          setFormData(defaultFormData);
+          setError(false);
+          reset();
+        }
+      }}
+    >
       <Dialog.Trigger>
         <Button>
           <PlusIcon /> Add Datasource
@@ -71,249 +74,262 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
       </Dialog.Trigger>
 
       <Dialog.Content>
-        {isMutating ? (
-          <XSpinner message="Adding datasource..." />
-        ) : (
-          <form
-            onSubmit={async (event) => {
-              event.preventDefault();
+        <form
+          onSubmit={async (event) => {
+            event.preventDefault();
 
-              let dsn: PostgresDsn | RedshiftDsn | BqDsnInput;
-              if (dwhType === 'postgres') {
-                dsn = {
-                  type: 'postgres',
-                  host: formData.host,
-                  port: parseInt(formData.port),
-                  dbname: formData.database,
-                  user: formData.user,
-                  password: { type: 'revealed', value: formData.password },
-                  sslmode: formData.sslmode as PostgresSslModes,
-                  search_path: formData.search_path || null,
-                };
-              } else if (dwhType === 'redshift') {
-                dsn = {
-                  type: 'redshift',
-                  host: formData.host,
-                  port: parseInt(formData.port),
-                  dbname: formData.database,
-                  user: formData.user,
-                  password: { type: 'revealed', value: formData.password },
-                  search_path: formData.search_path || null,
-                };
-              } else {
-                dsn = {
-                  type: 'bigquery',
-                  project_id: formData.project_id,
-                  dataset_id: formData.dataset,
-                  credentials: {
-                    type: 'serviceaccountinfo',
-                    content: formData.credentials_json,
-                  },
-                };
-              }
+            let dsn: PostgresDsn | RedshiftDsn | BqDsnInput;
+            if (dwhType === 'postgres') {
+              dsn = {
+                type: 'postgres',
+                host: formData.host,
+                port: parseInt(formData.port),
+                dbname: formData.database,
+                user: formData.user,
+                password: { type: 'revealed', value: formData.password },
+                sslmode: formData.sslmode as PostgresSslModes,
+                search_path: formData.search_path || null,
+              };
+            } else if (dwhType === 'redshift') {
+              dsn = {
+                type: 'redshift',
+                host: formData.host,
+                port: parseInt(formData.port),
+                dbname: formData.database,
+                user: formData.user,
+                password: { type: 'revealed', value: formData.password },
+                search_path: formData.search_path || null,
+              };
+            } else {
+              dsn = {
+                type: 'bigquery',
+                project_id: formData.project_id,
+                dataset_id: formData.dataset,
+                credentials: {
+                  type: 'serviceaccountinfo',
+                  content: formData.credentials_json,
+                },
+              };
+            }
 
+            try {
               await trigger({
                 organization_id: organizationId,
                 name: formData.name,
                 dsn,
               });
-              setDwhType('postgres');
-              setFormData(defaultFormData);
               setOpen(false);
-            }}
-          >
-            <Dialog.Title>Add Datasource</Dialog.Title>
-            <Dialog.Description size="2" mb="4">
-              <Text>Add a datasource to this organization.</Text>
-            </Dialog.Description>
+            } catch {
+              setError(true);
+            }
+          }}
+        >
+          <Dialog.Title>Add Datasource</Dialog.Title>
+          <Dialog.Description size="2" mb="4">
+            <Text>Add a datasource to this organization.</Text>
+          </Dialog.Description>
 
-            <Flex direction="column" gap="3">
-              <label>
-                <Text as="div" size="2" mb="1" weight="bold">
-                  Name
-                </Text>
-                <TextField.Root
-                  placeholder="Enter datasource name"
-                  required
-                  value={formData.name}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
-                />
-              </label>
+          <Flex direction="column" gap="3">
+            <label>
+              <Text as="div" size="2" mb="1" weight="bold">
+                Name
+              </Text>
+              <TextField.Root
+                placeholder="Enter datasource name"
+                required
+                value={formData.name}
+                onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+              />
+            </label>
 
-              <label>
-                <Text as="div" size="2" mb="1" weight="bold">
-                  Type
-                </Text>
-                <RadioGroup.Root
-                  defaultValue="postgres"
-                  onValueChange={(value) => {
-                    setDwhType(value as 'postgres' | 'redshift' | 'bigquery');
-                  }}
-                >
-                  <Flex gap="2" direction="column">
-                    <Text as="label" size="2">
-                      <Flex gap="2">
-                        <RadioGroup.Item value="postgres" /> PostgreSQL
-                      </Flex>
-                    </Text>
-                    <Text as="label" size="2">
-                      <Flex gap="2">
-                        <RadioGroup.Item value="redshift" /> Redshift
-                      </Flex>
-                    </Text>
-                    <Text as="label" size="2">
-                      <Flex gap="2">
-                        <RadioGroup.Item value="bigquery" /> Google BigQuery
-                      </Flex>
-                    </Text>
-                  </Flex>
-                </RadioGroup.Root>
-              </label>
+            <label>
+              <Text as="div" size="2" mb="1" weight="bold">
+                Type
+              </Text>
+              <RadioGroup.Root
+                defaultValue="postgres"
+                onValueChange={(value) => {
+                  setDwhType(value as 'postgres' | 'redshift' | 'bigquery');
+                }}
+              >
+                <Flex gap="2" direction="column">
+                  <Text as="label" size="2">
+                    <Flex gap="2">
+                      <RadioGroup.Item value="postgres" /> PostgreSQL
+                    </Flex>
+                  </Text>
+                  <Text as="label" size="2">
+                    <Flex gap="2">
+                      <RadioGroup.Item value="redshift" /> Redshift
+                    </Flex>
+                  </Text>
+                  <Text as="label" size="2">
+                    <Flex gap="2">
+                      <RadioGroup.Item value="bigquery" /> Google BigQuery
+                    </Flex>
+                  </Text>
+                </Flex>
+              </RadioGroup.Root>
+            </label>
 
-              {dwhType === 'postgres' || dwhType === 'redshift' ? (
-                <>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Host
-                    </Text>
+            {dwhType === 'postgres' || dwhType === 'redshift' ? (
+              <>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Host
+                  </Text>
+                  <Flex direction="column" gap="2">
                     <TextField.Root
                       required
                       value={formData.host}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, host: e.target.value }))}
+                      onChange={(e) => {
+                        setFormData((prev) => ({ ...prev, host: e.target.value }));
+                        setError(false);
+                      }}
+                      color={error ? 'red' : undefined}
+                      variant={error ? 'soft' : 'surface'}
                     />
-                  </label>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Port
-                    </Text>
-                    {dwhType === 'redshift' && (
-                      <Text size={'1'} mb={'1'}>
-                        Tip: Redshift default port is 5439.
-                      </Text>
+                    {error && (
+                      <Flex align="center" gap="1">
+                        <InfoCircledIcon color="red" />
+                        <Text size="1" color="red">
+                          This hostname does not resolve. Please try again.
+                        </Text>
+                      </Flex>
                     )}
-                    <TextField.Root
-                      type="number"
-                      required
-                      value={formData.port}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, port: e.target.value }))}
-                    />
-                  </label>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Database
+                  </Flex>
+                </label>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Port
+                  </Text>
+                  {dwhType === 'redshift' && (
+                    <Text size={'1'} mb={'1'}>
+                      Tip: Redshift default port is 5439.
                     </Text>
-                    <TextField.Root
-                      required
-                      value={formData.database}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, database: e.target.value }))}
-                    />
-                  </label>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      User
-                    </Text>
-                    <TextField.Root
-                      required
-                      value={formData.user}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, user: e.target.value }))}
-                    />
-                  </label>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Password
-                    </Text>
-                    <Flex gap="2">
-                      <TextField.Root
-                        type={showPassword ? 'text' : 'password'}
-                        required
-                        value={formData.password}
-                        onChange={(e) => setFormData((prev) => ({ ...prev, password: e.target.value }))}
-                      />
-                      <Button type="button" variant="soft" onClick={() => setShowPassword(!showPassword)}>
-                        {showPassword ? <EyeOpenIcon /> : <EyeClosedIcon />}
-                      </Button>
-                    </Flex>
-                  </label>
-                  {dwhType === 'postgres' && (
-                    <label>
-                      <Text as="div" size="2" mb="1" weight="bold">
-                        SSL Mode
-                      </Text>
-                      <select
-                        value={formData.sslmode}
-                        onChange={(e) =>
-                          setFormData((prev) => ({ ...prev, sslmode: e.target.value as PostgresDsnSslmode }))
-                        }
-                      >
-                        <option value="disable">disable</option>
-                        <option value="require">require</option>
-                        <option value="verify-ca">verify-ca</option>
-                        <option value="verify-full">verify-full</option>
-                      </select>
-                    </label>
                   )}
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Search Path{' '}
-                      <a
-                        href="https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        title="Learn more about the schema search path"
-                      >
-                        <InfoCircledIcon style={{ verticalAlign: 'middle' }} />
-                      </a>
-                    </Text>
-                    <TextField.Root
-                      value={formData.search_path}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, search_path: e.target.value }))}
-                    />
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Project ID
-                    </Text>
-                    <TextField.Root
-                      key={'project_id'}
-                      required
-                      value={formData.project_id}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, project_id: e.target.value }))}
-                    />
-                  </label>
-                  <label>
-                    <Text as="div" size="2" mb="1" weight="bold">
-                      Dataset
-                    </Text>
-                    <TextField.Root
-                      required
-                      key={'dataset'}
-                      value={formData.dataset}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, dataset: e.target.value }))}
-                    />
-                  </label>
-                  <ServiceAccountJsonField
+                  <TextField.Root
+                    type="number"
                     required
-                    value={formData.credentials_json}
-                    onChange={(value) => setFormData((prev) => ({ ...prev, credentials_json: value }))}
-                    onProjectIdFound={(projectId) => setFormData((prev) => ({ ...prev, project_id: projectId }))}
+                    value={formData.port}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, port: e.target.value }))}
                   />
-                </>
-              )}
-            </Flex>
+                </label>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Database
+                  </Text>
+                  <TextField.Root
+                    required
+                    value={formData.database}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, database: e.target.value }))}
+                  />
+                </label>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    User
+                  </Text>
+                  <TextField.Root
+                    required
+                    value={formData.user}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, user: e.target.value }))}
+                  />
+                </label>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Password
+                  </Text>
+                  <Flex gap="2">
+                    <TextField.Root
+                      type={showPassword ? 'text' : 'password'}
+                      required
+                      value={formData.password}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, password: e.target.value }))}
+                    />
+                    <Button type="button" variant="soft" onClick={() => setShowPassword(!showPassword)}>
+                      {showPassword ? <EyeOpenIcon /> : <EyeClosedIcon />}
+                    </Button>
+                  </Flex>
+                </label>
+                {dwhType === 'postgres' && (
+                  <label>
+                    <Text as="div" size="2" mb="1" weight="bold">
+                      SSL Mode
+                    </Text>
+                    <select
+                      value={formData.sslmode}
+                      onChange={(e) =>
+                        setFormData((prev) => ({ ...prev, sslmode: e.target.value as PostgresDsnSslmode }))
+                      }
+                    >
+                      <option value="disable">disable</option>
+                      <option value="require">require</option>
+                      <option value="verify-ca">verify-ca</option>
+                      <option value="verify-full">verify-full</option>
+                    </select>
+                  </label>
+                )}
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Search Path{' '}
+                    <a
+                      href="https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Learn more about the schema search path"
+                    >
+                      <InfoCircledIcon style={{ verticalAlign: 'middle' }} />
+                    </a>
+                  </Text>
+                  <TextField.Root
+                    value={formData.search_path}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, search_path: e.target.value }))}
+                  />
+                </label>
+              </>
+            ) : (
+              <>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Project ID
+                  </Text>
+                  <TextField.Root
+                    key={'project_id'}
+                    required
+                    value={formData.project_id}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, project_id: e.target.value }))}
+                  />
+                </label>
+                <label>
+                  <Text as="div" size="2" mb="1" weight="bold">
+                    Dataset
+                  </Text>
+                  <TextField.Root
+                    required
+                    key={'dataset'}
+                    value={formData.dataset}
+                    onChange={(e) => setFormData((prev) => ({ ...prev, dataset: e.target.value }))}
+                  />
+                </label>
+                <ServiceAccountJsonField
+                  required
+                  value={formData.credentials_json}
+                  onChange={(value) => setFormData((prev) => ({ ...prev, credentials_json: value }))}
+                  onProjectIdFound={(projectId) => setFormData((prev) => ({ ...prev, project_id: projectId }))}
+                />
+              </>
+            )}
+          </Flex>
 
-            <Flex gap="3" mt="4" justify="end">
-              <Dialog.Close>
-                <Button variant="soft" color="gray">
-                  Cancel
-                </Button>
-              </Dialog.Close>
-              <Button type="submit">Add Datasource</Button>
-            </Flex>
-          </form>
-        )}
+          <Flex gap="3" mt="4" justify="end">
+            <Dialog.Close>
+              <Button variant="soft" color="gray">
+                Cancel
+              </Button>
+            </Dialog.Close>
+            <Button type="submit">Add Datasource</Button>
+          </Flex>
+        </form>
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/src/components/features/datasources/edit-datasource-dialog.tsx
+++ b/src/components/features/datasources/edit-datasource-dialog.tsx
@@ -68,7 +68,6 @@ export const EditDatasourceDialog = ({
     },
   });
 
-
   useEffect(() => {
     if (open && data) {
       const dsn = data.dsn;


### PR DESCRIPTION
## Ticket

Fixes: [#61](https://github.com/agency-fund/evidential-sprint/issues/61)

## Description
- Introduces field level UI error feedback when hostname cannot resolve when creating/editing a datasource
- Cleans up dialog open status handling and unifies form data handling 
<img width="627" height="853" alt="Screenshot 2025-10-03 at 2 05 22 PM" src="https://github.com/user-attachments/assets/95fd330b-04ce-44c9-ac69-9fcc92b2d77c" />
<img width="613" height="726" alt="Screenshot 2025-10-03 at 2 07 22 PM" src="https://github.com/user-attachments/assets/4319b144-7204-4412-8d1d-386a0546aa2d" />


### Goal
- Provide the user field level validation error when datasource host cannot resolve

### Changes
- Added error UI feedback
- Unified formdata handling 
- Cleaned up dead code related to dialog open/close status

### Future Tasks (optional)
- Consider unifying edit/add datasource dialog into one single component similar to participant-fields-editor.tsx

## How has this been tested?
- Creating/editing postgres datasource with bad hostname (i.e foo.example) throws validation error and display error as expected in ui
- Creating/editing datasource with resolvable hostname (i.e. localhost) creates/edits data source as expected. 

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts