### PR TITLE
Add client-side OIDC nonce + state handling.

### DIFF
--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -772,7 +772,7 @@ export interface CMABExperimentSpecOutput {
 }
 
 /**
- * Contains the OIDC authorization code and PKCE verifier for the token exchange.
+ * Contains the OIDC authorization code, PKCE verifier, and nonce for the token exchange.
  */
 export interface CallbackRequest {
 	code: string;
@@ -782,6 +782,11 @@ export interface CallbackRequest {
 	 * @pattern ^[A-Za-z0-9._~-]+$
 	 */
 	code_verifier: string;
+	/**
+	 * @minLength 8
+	 * @maxLength 128
+	 */
+	nonce: string;
 }
 
 /**

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, PropsWithChildren, useCallback, useContext, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { z } from 'zod';
 import { exchangeCodeForTokens, generatePkceLoginInfo } from '@/services/pkce';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { useAuthStorage } from '@/providers/use-auth-storage';
@@ -10,7 +11,7 @@ import { useCustomEventListener } from '@/providers/use-custom-event-handler';
 import { getLogoutUrl } from '@/api/admin';
 
 export const API_401_EVENT = 'api_returned_401';
-const CODE_VERIFIER_KEY = 'code_verifier';
+const PENDING_AUTH_KEY = 'pending_auth';
 
 // User satisfied IDP and has been invited to the application.
 interface AuthenticatedState {
@@ -31,6 +32,14 @@ interface UnauthenticatedState {
 
 type AuthContext = AuthenticatedState | UnauthenticatedState;
 
+const PendingAuthSchema = z.object({
+  codeVerifier: z.string(),
+  state: z.string(),
+  nonce: z.string(),
+});
+
+type PendingAuth = z.infer<typeof PendingAuthSchema>;
+
 const GoogleAuthContext = createContext<AuthContext | null>(null);
 
 export const useAuth = () => {
@@ -50,16 +59,35 @@ const checkCallerIdentity = async (sessionToken: string) => {
   });
 };
 
+const getPendingAuth = (): PendingAuth | null => {
+  const item = sessionStorage.getItem(PENDING_AUTH_KEY);
+  if (item === null) {
+    return null;
+  }
+  try {
+    const result = PendingAuthSchema.safeParse(JSON.parse(item));
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+};
+
+const setPendingAuth = (pendingAuth: PendingAuth) =>
+  sessionStorage.setItem(PENDING_AUTH_KEY, JSON.stringify(pendingAuth));
+
+const clearPendingAuth = () => sessionStorage.removeItem(PENDING_AUTH_KEY);
+
 export default function GoogleAuthProvider({ children }: PropsWithChildren) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [user, setUser] = useAuthStorage();
   const [fetching, setFetching] = useState<boolean>(false);
-  const isGoogleLoginRedirect = user === null && searchParams.has('code') && searchParams.has('scope');
+  const isGoogleLoginRedirect =
+    user === null && searchParams.has('code') && searchParams.has('scope') && searchParams.has('state');
   const [userIsMissingInvite, setUserIsMissingInvite] = useState(false);
 
   const logout = useCallback(async () => {
-    localStorage.removeItem(CODE_VERIFIER_KEY);
+    clearPendingAuth();
     if (user?.sessionToken) {
       try {
         await fetch(new URL(getLogoutUrl(), API_BASE_URL), {
@@ -77,8 +105,8 @@ export default function GoogleAuthProvider({ children }: PropsWithChildren) {
   useCustomEventListener(API_401_EVENT, logout);
 
   const startLogin = useCallback(async () => {
-    const { codeVerifier, loginUrl } = await generatePkceLoginInfo();
-    localStorage.setItem(CODE_VERIFIER_KEY, codeVerifier);
+    const { codeVerifier, state, nonce, loginUrl } = await generatePkceLoginInfo();
+    setPendingAuth({ codeVerifier, state, nonce });
     router.push(loginUrl);
   }, [router]);
 
@@ -86,12 +114,22 @@ export default function GoogleAuthProvider({ children }: PropsWithChildren) {
     if (!isGoogleLoginRedirect) {
       return;
     }
+    const pendingAuth = getPendingAuth();
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    if (!pendingAuth || code === null || state === null) {
+      return;
+    }
     (async () => {
+      if (state !== pendingAuth.state) {
+        console.log('state mismatch');
+        await logout();
+        return;
+      }
       setFetching(true);
       try {
-        const codeVerifier = localStorage.getItem(CODE_VERIFIER_KEY);
-        const tokens = await exchangeCodeForTokens(searchParams.get('code') as string, codeVerifier!);
-        localStorage.removeItem(CODE_VERIFIER_KEY);
+        const tokens = await exchangeCodeForTokens(code, pendingAuth.codeVerifier, pendingAuth.nonce);
+        clearPendingAuth();
         const newToken = tokens.session_token ?? null;
         if (newToken === null) {
           console.log('exchangeCodeForTokens failed to return a usable token');

--- a/src/services/pkce.ts
+++ b/src/services/pkce.ts
@@ -9,11 +9,13 @@ const base64urlEncode = (buffer: ArrayBuffer | Uint8Array) =>
     .replace(/\//g, '_')
     .replace(/=+$/, '');
 
-const createCodeVerifier = () => {
-  const array = new Uint8Array(56);
+const createBase64UrlToken = (bytes: number): string => {
+  const array = new Uint8Array(bytes);
   crypto.getRandomValues(array);
   return base64urlEncode(array);
 };
+
+const createCodeVerifier = () => createBase64UrlToken(56);
 
 const createCodeChallenge = async (codeVerifier: string) => {
   const encoder = new TextEncoder();
@@ -22,6 +24,9 @@ const createCodeChallenge = async (codeVerifier: string) => {
   return base64urlEncode(digest);
 };
 
+const createState = () => createBase64UrlToken(32);
+
+const createNonce = () => createBase64UrlToken(32);
 /**
  * Generates a login URL given a PKCE code challenge.
  *
@@ -29,7 +34,8 @@ const createCodeChallenge = async (codeVerifier: string) => {
  * https://developers.google.com/identity/openid-connect/openid-connect#sendauthrequest
  * https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters
  */
-const createGoogleLoginUrl = (code_challenge: string) => {
+
+const createGoogleLoginUrl = (code_challenge: string, state: string, nonce: string) => {
   if (!OIDC_CLIENT_ID) {
     throw new Error('NEXT_PUBLIC_XNGIN_GOOGLE_CLIENT_ID is not set.');
   }
@@ -40,9 +46,11 @@ const createGoogleLoginUrl = (code_challenge: string) => {
     client_id: OIDC_CLIENT_ID,
     code_challenge: code_challenge,
     code_challenge_method: 'S256',
+    nonce: nonce,
     redirect_uri: OIDC_REDIRECT_URI,
     response_type: 'code',
     scope: 'openid email',
+    state: state,
   };
   const url = new URL(GOOGLE_AUTHORIZATION_ENDPOINT);
   url.search = new URLSearchParams(params).toString();
@@ -52,14 +60,16 @@ const createGoogleLoginUrl = (code_challenge: string) => {
 export async function generatePkceLoginInfo() {
   const codeVerifier = createCodeVerifier();
   const codeChallenge = await createCodeChallenge(codeVerifier);
-  return { codeVerifier, loginUrl: createGoogleLoginUrl(codeChallenge) };
+  const state = createState();
+  const nonce = createNonce();
+  return { codeVerifier, state, nonce, loginUrl: createGoogleLoginUrl(codeChallenge, state, nonce) };
 }
 
-export async function exchangeCodeForTokens(authCode: string, codeVerifier: string) {
+export async function exchangeCodeForTokens(authCode: string, codeVerifier: string, nonce: string) {
   const response = await fetch(`${OIDC_BASE_URL}/callback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code: authCode, code_verifier: codeVerifier }),
+    body: JSON.stringify({ code: authCode, code_verifier: codeVerifier, nonce }),
   });
   return await response.json();
 }


### PR DESCRIPTION
Nonces: Nonces protect against ID token replay attacks. We send this to Google
during authentication, then to the backend during token exchange, allowing the
backend to confirm that the ID token is the one that the client expects. This
is technically not required and the PKCE behavior is almost as strong but this
is defense-in-depth.

State: The state parameter avoids login CSRF. Without this, a 3rd party could
redirect a user to the application and force them to attempt a login using
attacker-specified code and scope. Chained with an XSS or other attack, a
client could be coerced into performing additional actions.