### PR TITLE
Hide redundant "Available (non-null)" metric when equal to total available

### DIFF
--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -232,21 +232,23 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                           )}
                         </DataList.Value>
                       </DataList.Item>
-                      <DataList.Item>
-                        <DataList.Label>Available (non-null)</DataList.Label>
-                        <DataList.Value>
-                          {primaryPower.metric_spec.available_nonnull_n == null ? (
-                            '?'
-                          ) : primaryPower.metric_spec.available_nonnull_n === 0 ||
-                            primaryPower.metric_spec.available_nonnull_n < (primaryPower.target_n ?? 0) ||
-                            primaryPower.metric_spec.available_nonnull_n <
-                              (primaryPower.metric_spec.available_n ?? 0) ? (
-                            <Text color="orange">{primaryPower.metric_spec.available_nonnull_n}</Text>
-                          ) : (
-                            primaryPower.metric_spec.available_nonnull_n
-                          )}
-                        </DataList.Value>
-                      </DataList.Item>
+                      {primaryPower.metric_spec.available_nonnull_n !== primaryPower.metric_spec.available_n && (
+                        <DataList.Item>
+                          <DataList.Label>Available (non-null)</DataList.Label>
+                          <DataList.Value>
+                            {primaryPower.metric_spec.available_nonnull_n == null ? (
+                              '?'
+                            ) : primaryPower.metric_spec.available_nonnull_n === 0 ||
+                              primaryPower.metric_spec.available_nonnull_n < (primaryPower.target_n ?? 0) ||
+                              primaryPower.metric_spec.available_nonnull_n <
+                                (primaryPower.metric_spec.available_n ?? 0) ? (
+                              <Text color="orange">{primaryPower.metric_spec.available_nonnull_n}</Text>
+                            ) : (
+                              primaryPower.metric_spec.available_nonnull_n
+                            )}
+                          </DataList.Value>
+                        </DataList.Item>
+                      )}
                       {primaryPower.pct_change_possible !== null && primaryPower.pct_change_possible !== undefined && (
                         <DataList.Item>
                           <DataList.Label>MME</DataList.Label>
@@ -341,9 +343,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                   </RadioCards.Item>
                   <RadioCards.Item
                     value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-                    disabled={nonNullSamples === undefined || nonNullSamples === 0}
+                    disabled={allSamples === undefined || allSamples === 0}
                   >
-                    Use all available non-null samples: {nonNullSamples}
+                    Use all available samples: {allSamples ?? 'N/A'}
                   </RadioCards.Item>
                   <RadioCards.Item
                     value={PowerCheckOption.ENTER_OWN}


### PR DESCRIPTION
## Ticket

Fixes: https://github.com/agency-fund/evidential-be/issues/229

## Description
Conditionally hide the "Available (non-null)" row when it equals the total available count.
### Goal
Eliminate redundant UI in the power check results when all available samples are non-null. Currently, both "Available" and "Available (non-null)" rows display with identical values, which is distracting and adds no value.
### Changes

Modified `src/app/experiments/create/experiment-form/power-check-section.tsx`
- Added conditional rendering to "Available (non-null)" DataList.Item
- Row now only displays when `available_nonnull_n !== available_n`
- Pure rendering change no backend 

## How has this been tested?
###  when both are equal :
<img width="1044" height="452" alt="Screenshot 2026-05-03 at 7 24 00 PM" src="https://github.com/user-attachments/assets/a0671129-602e-42ef-84eb-4ca8e0bd3049" />

###  when both are not equal :
<img width="1027" height="663" alt="Screenshot 2026-05-03 at 7 26 20 PM" src="https://github.com/user-attachments/assets/0521edd8-3212-4668-8362-72094c781b8f" />

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts