### PR TITLE
Remove primary key from available & selected strata lists during experiment creation

### DIFF
--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -33,6 +33,7 @@ import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experim
 import {
   getReasonableEndDate,
   getReasonableStartDate,
+  filterFormStrata,
 } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import {
   createDefaultBanditParams,
@@ -45,7 +46,7 @@ import {
   BanditParams,
   isBanditExperimentType,
   MetricWithMDE,
-  Stratum,
+  FormStratum,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
 
 export type ExperimentType = Exclude<DesignSpecInput['experiment_type'], BayesABExperimentSpecInputExperimentType>;
@@ -73,7 +74,7 @@ export type ExperimentFormData = {
   filters?: FilterInput[];
   // Cache of available filter fields (and their data types) for lookup/display/search
   availableFilterFields?: GetFiltersResponseElement[];
-  strata?: Stratum[];
+  strata?: FormStratum[];
   // These next 2 Experiment Parameters are strings to allow for empty values,
   // which should be converted to numbers when making power or experiment creation requests.
   confidence?: string;
@@ -262,7 +263,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: shouldClearDependents ? undefined : data.primaryMetric,
             secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
             filters: shouldClearDependents ? undefined : data.filters,
-            strata: shouldClearDependents ? undefined : data.strata,
+            strata: shouldClearDependents ? undefined : filterFormStrata(data.strata, msg.primaryKey),
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
@@ -495,7 +496,13 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
 
         // Strata builder
         if (msg.type === 'set-strata') {
-          return { ...data, strata: msg.strata.map((fieldName) => ({ fieldName })) };
+          return {
+            ...data,
+            strata: filterFormStrata(
+              msg.strata.map((fieldName) => ({ fieldName })),
+              data.primaryKey,
+            ),
+          };
         }
 
         // Power check - changing confidence/power invalidates power check response

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -13,7 +13,17 @@ import {
 import { createExperimentBody } from '@/api/admin.zod';
 import { ExperimentFormData } from './experiment-form-def';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
-import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
+import { isFreqExperimentType, isFrequentistSpec, FormStratum } from './experiment-form-types';
+
+/** Drops strata whose field matches the field to remove. Use e.g. to filter out the experiment's primary key. */
+export function filterFormStrata(
+  strata: FormStratum[] | undefined,
+  keyToRemove: string | undefined,
+): FormStratum[] | undefined {
+  if (!keyToRemove) return strata;
+  if (!strata?.length) return strata;
+  return strata.filter((s) => s.fieldName !== keyToRemove);
+}
 
 export const getReasonableStartDate = (): string => {
   const date = new Date();
@@ -68,7 +78,9 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     });
   });
 
-  const strata: Stratum[] = (data.strata ?? []).map((s) => ({ field_name: s.fieldName }));
+  const strata: Stratum[] = (filterFormStrata(data.strata, data.primaryKey) ?? []).map((s) => ({
+    field_name: s.fieldName,
+  }));
 
   const commonFields = {
     experiment_name: data.name,

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -64,7 +64,7 @@ export type BanditParams =
       contexts: Context[];
     };
 
-export type Stratum = {
+export type FormStratum = {
   fieldName: string;
 };
 

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -8,7 +8,10 @@ import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
 import { CreateExperimentResponse, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
 import { PowerCheckSection } from './power-check-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
-import { convertToFrequentistDesignSpec } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import {
+  convertToFrequentistDesignSpec,
+  filterFormStrata,
+} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import { createExperimentBody } from '@/api/admin.zod';
 import { ErrorType } from '@/services/orval-fetch';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
@@ -83,6 +86,9 @@ export const ExperimentFreqStackScreen = ({
   const metricFields = fields.filter((f) =>
     ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
   );
+  // Primary key is not a valid stratum so filter it out in both options and selection (just in case)
+  const availableStrata = fields.filter((field) => field.field_name !== data.primaryKey);
+  const selectedStrata = (filterFormStrata(data.strata, data.primaryKey) ?? []).map((s) => s.fieldName);
 
   const nextEnabled = isNextEnabled(data);
 
@@ -128,8 +134,8 @@ export const ExperimentFreqStackScreen = ({
         </Heading>
         <Card>
           <StrataBuilder
-            availableStrata={fields}
-            selectedStrata={data.strata?.map((s) => s.fieldName) ?? []}
+            availableStrata={availableStrata}
+            selectedStrata={selectedStrata}
             onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
           />
         </Card>


### PR DESCRIPTION
## Description
Remove primary key from available & selected strata lists, and double check removal during request construction. A FE followup to https://github.com/agency-fund/evidential-be/pull/241.

## How has this been tested?

Verifying during experiment creation that the chosen pk "id" is not a selection option.

<img width="1142" height="509" alt="image" src="https://github.com/user-attachments/assets/cf697e58-9faf-4a18-a6c1-388128820ec1" />


