### PR TITLE
Strata UI simplification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+tmp
 
 # env files (can opt-in for committing if needed)
 .env*
@@ -56,3 +57,8 @@ openapi.json
 # Sentry Config File
 .env.sentry-build-plugin
 /.playwright-mcp/
+
+# ides, package managers
+.cursor
+.vscode
+.tool-versions

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -33,6 +33,7 @@ import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experim
 import {
   getReasonableEndDate,
   getReasonableStartDate,
+  filterFormStrata,
 } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import {
   createDefaultBanditParams,
@@ -45,7 +46,7 @@ import {
   BanditParams,
   isBanditExperimentType,
   MetricWithMDE,
-  Stratum,
+  FormStratum,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
 
 export type ExperimentType = Exclude<DesignSpecInput['experiment_type'], BayesABExperimentSpecInputExperimentType>;
@@ -73,7 +74,7 @@ export type ExperimentFormData = {
   filters?: FilterInput[];
   // Cache of available filter fields (and their data types) for lookup/display/search
   availableFilterFields?: GetFiltersResponseElement[];
-  strata?: Stratum[];
+  strata?: FormStratum[];
   // These next 2 Experiment Parameters are strings to allow for empty values,
   // which should be converted to numbers when making power or experiment creation requests.
   confidence?: string;
@@ -262,7 +263,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: shouldClearDependents ? undefined : data.primaryMetric,
             secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
             filters: shouldClearDependents ? undefined : data.filters,
-            strata: shouldClearDependents ? undefined : data.strata,
+            strata: shouldClearDependents ? undefined : filterFormStrata(data.strata, msg.primaryKey),
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
@@ -495,7 +496,13 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
 
         // Strata builder
         if (msg.type === 'set-strata') {
-          return { ...data, strata: msg.strata.map((fieldName) => ({ fieldName })) };
+          return {
+            ...data,
+            strata: filterFormStrata(
+              msg.strata.map((fieldName) => ({ fieldName })),
+              data.primaryKey,
+            ),
+          };
         }
 
         // Power check - changing confidence/power invalidates power check response

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -14,6 +14,7 @@ import {
   FilterInput,
   GetFiltersResponseElement,
   PowerResponseOutput,
+  Stratum,
 } from '@/api/methods.schemas';
 import { abandonExperiment } from '@/api/admin';
 import { ExperimentSelectDatasourceScreen } from '@/app/experiments/create/experiment-form/experiment-select-datasource-screen';
@@ -46,7 +47,6 @@ import {
   BanditParams,
   isBanditExperimentType,
   MetricWithMDE,
-  FormStratum,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
 
 export type ExperimentType = Exclude<DesignSpecInput['experiment_type'], BayesABExperimentSpecInputExperimentType>;
@@ -74,7 +74,7 @@ export type ExperimentFormData = {
   filters?: FilterInput[];
   // Cache of available filter fields (and their data types) for lookup/display/search
   availableFilterFields?: GetFiltersResponseElement[];
-  strata?: FormStratum[];
+  strata?: Stratum[];
   // These next 2 Experiment Parameters are strings to allow for empty values,
   // which should be converted to numbers when making power or experiment creation requests.
   confidence?: string;
@@ -499,7 +499,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             strata: filterFormStrata(
-              msg.strata.map((field) => ({ fieldName: field.field_name })),
+              msg.strata.map((field) => ({ field_name: field.field_name })),
               data.primaryKey,
             ),
           };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -494,7 +494,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return { ...data, filters: msg.filters, powerCheckResponse: undefined, desiredN: undefined };
         }
 
-        // Strata builder
+        // Strata builder -
+        // Does NOT invalidate power check for now as we don't currently incorporate strata in
+        // analysis.  When we do, we should also look to incorporate them as covariates in the power
+        // analysis, and if so invalidate here as well.
         if (msg.type === 'set-strata') {
           return {
             ...data,

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -499,7 +499,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             strata: filterFormStrata(
-              msg.strata.map((fieldName) => ({ fieldName })),
+              msg.strata.map((field) => ({ fieldName: field.field_name })),
               data.primaryKey,
             ),
           };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -11,10 +11,10 @@ import {
   ContextType,
   CreateExperimentResponse,
   DesignSpecInput,
+  FieldMetadata,
   FilterInput,
   GetFiltersResponseElement,
   PowerResponseOutput,
-  Stratum,
 } from '@/api/methods.schemas';
 import { abandonExperiment } from '@/api/admin';
 import { ExperimentSelectDatasourceScreen } from '@/app/experiments/create/experiment-form/experiment-select-datasource-screen';
@@ -34,7 +34,7 @@ import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experim
 import {
   getReasonableEndDate,
   getReasonableStartDate,
-  filterFormStrata,
+  removeFieldByName,
 } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import {
   createDefaultBanditParams,
@@ -74,7 +74,7 @@ export type ExperimentFormData = {
   filters?: FilterInput[];
   // Cache of available filter fields (and their data types) for lookup/display/search
   availableFilterFields?: GetFiltersResponseElement[];
-  strata?: Stratum[];
+  strata?: FieldMetadata[];
   // These next 2 Experiment Parameters are strings to allow for empty values,
   // which should be converted to numbers when making power or experiment creation requests.
   confidence?: string;
@@ -263,7 +263,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: shouldClearDependents ? undefined : data.primaryMetric,
             secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
             filters: shouldClearDependents ? undefined : data.filters,
-            strata: shouldClearDependents ? undefined : filterFormStrata(data.strata, msg.primaryKey),
+            strata: shouldClearDependents ? undefined : removeFieldByName(data.strata, msg.primaryKey),
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
@@ -498,10 +498,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
         if (msg.type === 'set-strata') {
           return {
             ...data,
-            strata: filterFormStrata(
-              msg.strata.map((field) => ({ field_name: field.field_name })),
-              data.primaryKey,
-            ),
+            strata: removeFieldByName(msg.strata, data.primaryKey),
           };
         }
 

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -15,12 +15,16 @@ import { ExperimentFormData } from './experiment-form-def';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
 
-/** Drops entries whose `field_name` matches `fieldNameToRemove` (e.g. exclude the primary key from stratum lists). */
+/**
+ * Drops entries whose `field_name` matches `fieldNameToRemove` (e.g. exclude the primary key from
+ * stratum lists). Always returns an array; `undefined` input is treated as empty.
+ */
 export function removeFieldByName<T extends { field_name: string }>(
   fields: T[] | undefined,
   fieldNameToRemove: string | undefined,
-): T[] | undefined {
-  if (!fieldNameToRemove || !fields?.length) return fields;
+): T[] {
+  if (!fields?.length) return [];
+  if (!fieldNameToRemove) return fields;
   return fields.filter((f) => f.field_name !== fieldNameToRemove);
 }
 
@@ -77,7 +81,7 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     });
   });
 
-  const strata: Stratum[] = (removeFieldByName(data.strata, data.primaryKey) ?? []).map((f) => ({
+  const strata: Stratum[] = removeFieldByName(data.strata, data.primaryKey).map((f) => ({
     field_name: f.field_name,
   }));
 

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -13,16 +13,15 @@ import {
 import { createExperimentBody } from '@/api/admin.zod';
 import { ExperimentFormData } from './experiment-form-def';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
-import { isFreqExperimentType, isFrequentistSpec, FormStratum } from './experiment-form-types';
+import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
 
 /** Drops strata whose field matches the field to remove. Use e.g. to filter out the experiment's primary key. */
 export function filterFormStrata(
-  strata: FormStratum[] | undefined,
-  keyToRemove: string | undefined,
-): FormStratum[] | undefined {
-  if (!keyToRemove) return strata;
-  if (!strata?.length) return strata;
-  return strata.filter((s) => s.fieldName !== keyToRemove);
+  strata: Stratum[] | undefined,
+  fieldToRemove: string | undefined,
+): Stratum[] | undefined {
+  if (!fieldToRemove || !strata?.length) return strata;
+  return strata.filter((s) => s.field_name !== fieldToRemove);
 }
 
 export const getReasonableStartDate = (): string => {
@@ -78,9 +77,7 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     });
   });
 
-  const strata: Stratum[] = (filterFormStrata(data.strata, data.primaryKey) ?? []).map((s) => ({
-    field_name: s.fieldName,
-  }));
+  const strata: Stratum[] = filterFormStrata(data.strata, data.primaryKey) ?? [];
 
   const commonFields = {
     experiment_name: data.name,

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -15,13 +15,13 @@ import { ExperimentFormData } from './experiment-form-def';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
 
-/** Drops strata whose field matches the field to remove. Use e.g. to filter out the experiment's primary key. */
-export function filterFormStrata(
-  strata: Stratum[] | undefined,
-  fieldToRemove: string | undefined,
-): Stratum[] | undefined {
-  if (!fieldToRemove || !strata?.length) return strata;
-  return strata.filter((s) => s.field_name !== fieldToRemove);
+/** Drops entries whose `field_name` matches `fieldNameToRemove` (e.g. exclude the primary key from stratum lists). */
+export function removeFieldByName<T extends { field_name: string }>(
+  fields: T[] | undefined,
+  fieldNameToRemove: string | undefined,
+): T[] | undefined {
+  if (!fieldNameToRemove || !fields?.length) return fields;
+  return fields.filter((f) => f.field_name !== fieldNameToRemove);
 }
 
 export const getReasonableStartDate = (): string => {
@@ -77,7 +77,9 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     });
   });
 
-  const strata: Stratum[] = filterFormStrata(data.strata, data.primaryKey) ?? [];
+  const strata: Stratum[] = (removeFieldByName(data.strata, data.primaryKey) ?? []).map((f) => ({
+    field_name: f.field_name,
+  }));
 
   const commonFields = {
     experiment_name: data.name,

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -13,7 +13,17 @@ import {
 import { createExperimentBody } from '@/api/admin.zod';
 import { ExperimentFormData } from './experiment-form-def';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
-import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
+import { isFreqExperimentType, isFrequentistSpec, FormStratum } from './experiment-form-types';
+
+/** Drops strata whose field matches the field to remove. Use e.g. to filter out the experiment's primary key. */
+export function filterFormStrata(
+  strata: FormStratum[] | undefined,
+  keyToRemove: string | undefined,
+): FormStratum[] | undefined {
+  if (!keyToRemove) return strata;
+  if (!strata?.length) return strata;
+  return strata.filter((s) => s.fieldName !== keyToRemove);
+}
 
 export const getReasonableStartDate = (): string => {
   const date = new Date();
@@ -68,7 +78,9 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     });
   });
 
-  const strata: Stratum[] = (data.strata ?? []).map((s) => ({ field_name: s.fieldName }));
+  const strata: Stratum[] = (filterFormStrata(data.strata, data.primaryKey) ?? []).map((s) => ({
+    field_name: s.fieldName,
+  }));
 
   const commonFields = {
     experiment_name: data.name,

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -64,10 +64,6 @@ export type BanditParams =
       contexts: Context[];
     };
 
-export type FormStratum = {
-  fieldName: string;
-};
-
 export type MetricWithMDE = {
   metric: GetMetricsResponseElement;
   mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -64,7 +64,7 @@ export type BanditParams =
       contexts: Context[];
     };
 
-export type Stratum = {
+export type FormStratum = {
   fieldName: string;
 };
 

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -87,10 +87,10 @@ export const ExperimentFreqStackScreen = ({
     ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
   );
   // Exclude primary key from stratum options.
-  const availableStrata = (removeFieldByName(allTableFields, data.primaryKey) ?? []).toSorted((a, b) =>
+  const availableStrata = removeFieldByName(allTableFields, data.primaryKey).toSorted((a, b) =>
     a.field_name.localeCompare(b.field_name),
   );
-  // Reconfirm that the selected strata are still valid options and filter out any undefines if not.
+  // Reconfirm that the selected strata are still valid options and filter out any undefined if not.
   const selectedStrata = (data.strata ?? [])
     .map((s) => availableStrata.find((f) => f.field_name === s.field_name))
     .filter((f): f is FieldMetadata => Boolean(f));

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -8,7 +8,10 @@ import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
 import { CreateExperimentResponse, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
 import { PowerCheckSection } from './power-check-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
-import { convertToFrequentistDesignSpec } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import {
+  convertToFrequentistDesignSpec,
+  filterFormStrata,
+} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import { createExperimentBody } from '@/api/admin.zod';
 import { ErrorType } from '@/services/orval-fetch';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
@@ -83,6 +86,9 @@ export const ExperimentFreqStackScreen = ({
   const metricFields = fields.filter((f) =>
     ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
   );
+  // Primary key is not a valid stratum so filter it out in both options and selection (just in case)
+  const availableStrata = fields.filter((field) => field.field_name !== data.primaryKey);
+  const selectedStrata = (filterFormStrata(data.strata, data.primaryKey) ?? []).map((s) => s.fieldName);
 
   const nextEnabled = isNextEnabled(data);
 
@@ -128,8 +134,8 @@ export const ExperimentFreqStackScreen = ({
         </Heading>
         <Card>
           <StrataBuilder
-            availableStrata={fields}
-            selectedStrata={data.strata?.map((s) => s.fieldName) ?? []}
+            availableStrata={availableStrata}
+            selectedStrata={selectedStrata}
             onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
           />
         </Card>

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -88,7 +88,7 @@ export const ExperimentFreqStackScreen = ({
     .filter((field) => field.field_name !== data.primaryKey)
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
   const selectedStrata = (data.strata ?? [])
-    .map((s) => availableStrata.find((f) => f.field_name === s.fieldName))
+    .map((s) => availableStrata.find((f) => f.field_name === s.field_name))
     .filter((f): f is FieldMetadata => Boolean(f));
 
   const nextEnabled = isNextEnabled(data);

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -8,7 +8,10 @@ import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
 import { CreateExperimentResponse, FieldMetadata, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
 import { PowerCheckSection } from './power-check-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
-import { convertToFrequentistDesignSpec } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import {
+  convertToFrequentistDesignSpec,
+  removeFieldByName,
+} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import { createExperimentBody } from '@/api/admin.zod';
 import { ErrorType } from '@/services/orval-fetch';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
@@ -83,10 +86,11 @@ export const ExperimentFreqStackScreen = ({
   const metricFields = allTableFields.filter((f) =>
     ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
   );
-  // Primary key is not a valid stratum so filter it out in both options and selection (just in case)
-  const availableStrata = allTableFields
-    .filter((field) => field.field_name !== data.primaryKey)
-    .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
+  // Exclude primary key from stratum options.
+  const availableStrata = (removeFieldByName(allTableFields, data.primaryKey) ?? []).toSorted((a, b) =>
+    a.field_name.localeCompare(b.field_name),
+  );
+  // Reconfirm that the selected strata are still valid options and filter out any undefines if not.
   const selectedStrata = (data.strata ?? [])
     .map((s) => availableStrata.find((f) => f.field_name === s.field_name))
     .filter((f): f is FieldMetadata => Boolean(f));

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -5,13 +5,10 @@ import { MetricBuilder, MetricBuilderAction } from '@/components/features/experi
 import { FilterBuilder } from '@/components/features/experiments/querybuilder/filter-builder';
 import { StrataBuilder } from '@/components/features/experiments/strata-builder';
 import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
-import { CreateExperimentResponse, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
+import { CreateExperimentResponse, FieldMetadata, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
 import { PowerCheckSection } from './power-check-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
-import {
-  convertToFrequentistDesignSpec,
-  filterFormStrata,
-} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import { convertToFrequentistDesignSpec } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import { createExperimentBody } from '@/api/admin.zod';
 import { ErrorType } from '@/services/orval-fetch';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
@@ -19,7 +16,7 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 export type ExperimentFreqStackScreenMessage =
   | MetricBuilderAction
   | { type: 'set-filters'; filters: FilterInput[] }
-  | { type: 'set-strata'; strata: string[] }
+  | { type: 'set-strata'; strata: FieldMetadata[] }
   | { type: 'set-confidence'; value: string }
   | { type: 'set-power'; value: string }
   | { type: 'set-power-check-response'; response: PowerResponseOutput; desiredN?: number }
@@ -80,15 +77,19 @@ export const ExperimentFreqStackScreen = ({
     },
   );
 
-  const fields = tableData?.fields ?? [];
+  const allTableFields = tableData?.fields ?? [];
 
   // Filter numeric and boolean fields for metrics
-  const metricFields = fields.filter((f) =>
+  const metricFields = allTableFields.filter((f) =>
     ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
   );
   // Primary key is not a valid stratum so filter it out in both options and selection (just in case)
-  const availableStrata = fields.filter((field) => field.field_name !== data.primaryKey);
-  const selectedStrata = (filterFormStrata(data.strata, data.primaryKey) ?? []).map((s) => s.fieldName);
+  const availableStrata = allTableFields
+    .filter((field) => field.field_name !== data.primaryKey)
+    .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
+  const selectedStrata = (data.strata ?? [])
+    .map((s) => availableStrata.find((f) => f.field_name === s.fieldName))
+    .filter((f): f is FieldMetadata => Boolean(f));
 
   const nextEnabled = isNextEnabled(data);
 
@@ -123,7 +124,7 @@ export const ExperimentFreqStackScreen = ({
         </Heading>
         <Card>
           <FilterBuilder
-            availableFields={fields}
+            availableFields={allTableFields}
             initialFilters={data.filters ?? []}
             onChange={(filters) => dispatch({ type: 'set-filters', filters })}
           />

--- a/src/components/features/experiments/strata-builder.tsx
+++ b/src/components/features/experiments/strata-builder.tsx
@@ -1,77 +1,133 @@
 'use client';
 
-import { useMemo } from 'react';
-import { Button, Flex, Text } from '@radix-ui/themes';
-import { GetStrataResponseElement } from '@/api/methods.schemas';
-import { ClickableBadge } from './clickable-badge';
-import { PlusIcon, TrashIcon } from '@radix-ui/react-icons';
+import { useState } from 'react';
+import { Box, Flex, IconButton, Table, Text } from '@radix-ui/themes';
+import { FieldMetadata } from '@/api/methods.schemas';
+import { Combobox } from '@/components/ui/combobox';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import FieldDataCard from '@/components/ui/cards/field-data-card';
+import { TrashIcon } from '@radix-ui/react-icons';
+
+const MAX_STRATA_COUNT = 10;
 
 interface StrataBuilderProps {
-  availableStrata: GetStrataResponseElement[];
-  selectedStrata: string[];
-  onStrataChange: (selectedStrata: string[]) => void;
+  /** All strata candidates, excluding invalid fields (e.g. primary key). Caller should sort. */
+  availableStrata: FieldMetadata[];
+  selectedStrata: FieldMetadata[];
+  onStrataChange: (selectedStrata: FieldMetadata[]) => void;
 }
 
+const getSearchTextFromOption = (option: FieldMetadata) => option.field_name;
+
+interface StrataComboboxRowProps {
+  stratum: FieldMetadata;
+}
+
+const StrataComboboxRow = ({ stratum }: StrataComboboxRowProps) => {
+  return (
+    <Flex gap="2" align="center" justify="between" wrap="nowrap">
+      <Text size="2">{stratum.field_name}</Text>
+      <DataTypeBadge type={stratum.data_type} />
+    </Flex>
+  );
+};
+
 export function StrataBuilder({ availableStrata, selectedStrata, onStrataChange }: StrataBuilderProps) {
-  const selectedSet = useMemo(() => new Set(selectedStrata), [selectedStrata]);
-  const sortedStrata = useMemo(
-    () => [...availableStrata].sort((a, b) => a.field_name.localeCompare(b.field_name)),
-    [availableStrata],
+  const [searchText, setSearchText] = useState('');
+  const hasReachedStrataLimit = selectedStrata.length >= MAX_STRATA_COUNT;
+  const comboboxOptions = availableStrata.filter(
+    (stratum) => !selectedStrata.some((s) => s.field_name === stratum.field_name),
   );
 
-  const handleStrataToggle = (fieldName: string, checked: boolean) => {
-    const newSelected = checked ? [...selectedStrata, fieldName] : selectedStrata.filter((s) => s !== fieldName);
-    onStrataChange(newSelected);
+  const handleStrataAdd = (value: string, fieldName?: string) => {
+    setSearchText(value);
+    // Prevent adding beyond the limit, duplicate adds, and adding unavailable fields.
+    if (!fieldName || hasReachedStrataLimit) return;
+    if (selectedStrata.some((s) => s.field_name === fieldName)) return;
+    const added = comboboxOptions.find((f) => f.field_name === fieldName);
+    if (!added) return;
+
+    onStrataChange([...selectedStrata, added]);
+    setSearchText('');
   };
 
-  const handleAddAll = () => {
-    const allFieldNames = availableStrata.map((field) => field.field_name);
-    onStrataChange(allFieldNames);
+  const handleStrataRemove = (fieldName: string) => {
+    onStrataChange(selectedStrata.filter((stratum) => stratum.field_name !== fieldName));
   };
 
-  const handleClearAll = () => {
-    onStrataChange([]);
-  };
-
-  return (
+  return availableStrata.length === 0 ? (
+    <Text color="gray" size="2">
+      No strata available for this participant type.
+    </Text>
+  ) : (
     <Flex direction="column" gap="3" overflowX="auto">
       <Text size="2" color="gray">
         Select strata fields for balanced randomization of participants across experiment arms.
       </Text>
-      <Flex gap="2" wrap="wrap">
-        <Button
-          type="button"
-          variant="soft"
-          size="2"
-          onClick={handleAddAll}
-          disabled={selectedStrata.length === availableStrata.length}
-          color={selectedStrata.length === availableStrata.length ? 'gray' : 'green'}
-        >
-          <PlusIcon /> Add All
-        </Button>
-        <Button
-          type="button"
-          variant="soft"
-          size="2"
-          disabled={selectedStrata.length === 0}
-          color={selectedStrata.length === 0 ? 'gray' : 'red'}
-          onClick={handleClearAll}
-        >
-          <TrashIcon /> Clear All
-        </Button>
+      <Flex direction="column" gap="2">
+        <Flex gap="2" align="center">
+          <Text as="label" size="2" weight="bold">
+            Add strata:
+          </Text>
+          <Combobox<FieldMetadata>
+            value={searchText}
+            onChange={handleStrataAdd}
+            options={comboboxOptions}
+            getDisplayTextForOption={getSearchTextFromOption}
+            getKeyForOption={getSearchTextFromOption}
+            placeholder="Search strata..."
+            noMatchText="No available strata"
+            dropdownRow={({ option }) => <StrataComboboxRow stratum={option} />}
+            disabled={comboboxOptions.length === 0 || hasReachedStrataLimit}
+          />
+          {hasReachedStrataLimit && (
+            <Text color="red" size="2">
+              You may specify no more than {MAX_STRATA_COUNT} strata in the experiment.
+            </Text>
+          )}
+        </Flex>
       </Flex>
 
-      <Flex direction="row" gap="2" wrap="wrap">
-        {sortedStrata.map((stratum) => (
-          <ClickableBadge
-            key={stratum.field_name}
-            input={stratum}
-            color={selectedSet.has(stratum.field_name) ? undefined : 'gray'}
-            onClick={(s) => handleStrataToggle(s.field_name, !selectedSet.has(s.field_name))}
-            showPlus={false}
-          />
-        ))}
-      </Flex>
+      {selectedStrata.length > 0 && (
+        <Box width="50%">
+          <Table.Root layout="fixed">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeaderCell>Stratum</Table.ColumnHeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {selectedStrata.map((stratum) => (
+                <Table.Row key={stratum.field_name}>
+                  <Table.Cell>
+                    <Flex gap="2" align="center">
+                      <IconButton
+                        variant="soft"
+                        color="red"
+                        onClick={(event) => {
+                          event.preventDefault();
+                          handleStrataRemove(stratum.field_name);
+                        }}
+                      >
+                        <TrashIcon />
+                      </IconButton>
+                      <FieldDataCard
+                        field={stratum}
+                        trigger={
+                          <Flex gap="2" align="center">
+                            <Text>{stratum.field_name}</Text>
+                            <DataTypeBadge type={stratum.data_type} />
+                          </Flex>
+                        }
+                      />
+                    </Flex>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        </Box>
+      )}
     </Flex>
   );
 }

--- a/src/components/features/experiments/strata-builder.tsx
+++ b/src/components/features/experiments/strata-builder.tsx
@@ -41,13 +41,12 @@ export function StrataBuilder({ availableStrata, selectedStrata, onStrataChange 
 
   const handleStrataAdd = (value: string, fieldName?: string) => {
     setSearchText(value);
-    // Prevent adding beyond the limit, duplicate adds, and adding unavailable fields.
+    // Prevent adding beyond the limit and adding unavailable fields.
     if (!fieldName || hasReachedStrataLimit) return;
-    if (selectedStrata.some((s) => s.field_name === fieldName)) return;
-    const added = comboboxOptions.find((f) => f.field_name === fieldName);
-    if (!added) return;
+    const toAdd = comboboxOptions.find((f) => f.field_name === fieldName);
+    if (!toAdd) return;
 
-    onStrataChange([...selectedStrata, added]);
+    onStrataChange([...selectedStrata, toAdd]);
     setSearchText('');
   };
 

--- a/src/components/features/experiments/strata-builder.tsx
+++ b/src/components/features/experiments/strata-builder.tsx
@@ -56,39 +56,37 @@ export function StrataBuilder({ availableStrata, selectedStrata, onStrataChange 
 
   return availableStrata.length === 0 ? (
     <Text color="gray" size="2">
-      No strata available for this participant type.
+      No fields available to use as strata for this table.
     </Text>
   ) : (
     <Flex direction="column" gap="3" overflowX="auto">
       <Text size="2" color="gray">
         Select strata fields for balanced randomization of participants across experiment arms.
       </Text>
-      <Flex direction="column" gap="2">
-        <Flex gap="2" align="center">
-          <Text as="label" size="2" weight="bold">
-            Add strata:
+      <Flex gap="2" align="center">
+        <Text as="label" size="2" weight="bold">
+          Add strata:
+        </Text>
+        <Combobox<FieldMetadata>
+          value={searchText}
+          onChange={handleStrataAdd}
+          options={comboboxOptions}
+          getDisplayTextForOption={getSearchTextFromOption}
+          getKeyForOption={getSearchTextFromOption}
+          placeholder="Search fields..."
+          noMatchText="No available strata"
+          dropdownRow={({ option }) => <StrataComboboxRow stratum={option} />}
+          disabled={comboboxOptions.length === 0 || hasReachedStrataLimit}
+        />
+        {hasReachedStrataLimit && (
+          <Text color="red" size="2">
+            You may specify no more than {MAX_STRATA_COUNT} strata in the experiment.
           </Text>
-          <Combobox<FieldMetadata>
-            value={searchText}
-            onChange={handleStrataAdd}
-            options={comboboxOptions}
-            getDisplayTextForOption={getSearchTextFromOption}
-            getKeyForOption={getSearchTextFromOption}
-            placeholder="Search fields..."
-            noMatchText="No available strata"
-            dropdownRow={({ option }) => <StrataComboboxRow stratum={option} />}
-            disabled={comboboxOptions.length === 0 || hasReachedStrataLimit}
-          />
-          {hasReachedStrataLimit && (
-            <Text color="red" size="2">
-              You may specify no more than {MAX_STRATA_COUNT} strata in the experiment.
-            </Text>
-          )}
-        </Flex>
+        )}
       </Flex>
 
       {selectedStrata.length > 0 && (
-        <Box width="50%">
+        <Box maxWidth="50%">
           <Table.Root layout="fixed">
             <Table.Header>
               <Table.Row>
@@ -113,7 +111,7 @@ export function StrataBuilder({ availableStrata, selectedStrata, onStrataChange 
                       <FieldDataCard
                         field={stratum}
                         trigger={
-                          <Flex gap="2" align="center">
+                          <Flex gap="2" align="center" wrap="wrap">
                             <Text>{stratum.field_name}</Text>
                             <DataTypeBadge type={stratum.data_type} />
                           </Flex>

--- a/src/components/features/experiments/strata-builder.tsx
+++ b/src/components/features/experiments/strata-builder.tsx
@@ -75,7 +75,7 @@ export function StrataBuilder({ availableStrata, selectedStrata, onStrataChange 
             options={comboboxOptions}
             getDisplayTextForOption={getSearchTextFromOption}
             getKeyForOption={getSearchTextFromOption}
-            placeholder="Search strata..."
+            placeholder="Search fields..."
             noMatchText="No available strata"
             dropdownRow={({ option }) => <StrataComboboxRow stratum={option} />}
             disabled={comboboxOptions.length === 0 || hasReachedStrataLimit}

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -4,15 +4,29 @@ import { useEffect, useRef, useState } from 'react';
 import { Box, Flex, Popover, ScrollArea, Text, TextField } from '@radix-ui/themes';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
 
-// Helper for computing filtered options with a different search text (used in handlers)
+/**
+ * Returns a predicate to filter based on a case-insensitive substring match with the search text.
+ *
+ * `offset` can be used to let a findIndex() scan past some known match to detect non-uniqueness.
+ */
+const makeOptionFilter = <TOption = string,>(
+  searchText: string,
+  getDisplayTextForOption: (option: TOption) => string,
+  offset = 0,
+) => {
+  const lowerSearch = searchText.toLowerCase();
+  return (option: TOption, index: number) =>
+    index >= offset && getDisplayTextForOption(option).toLowerCase().includes(lowerSearch);
+};
+
+/** Filter options down to those whose display contains `text` (both normalized). */
 const filterOptions = <TOption = string,>(
   text: string,
   options: TOption[],
   getDisplayTextForOption: (option: TOption) => string,
 ) => {
   if (!text) return options;
-  const lowerSearch = text.toLowerCase();
-  return options.filter((opt) => getDisplayTextForOption(opt).toLowerCase().includes(lowerSearch));
+  return options.filter(makeOptionFilter(text, getDisplayTextForOption));
 };
 
 export interface DropdownRowProps<TOption> {
@@ -38,14 +52,27 @@ const DefaultComboboxRow = ({ optionText }: DefaultComboboxRowProps) => {
 export interface ComboboxProps<TOption = string, TKey extends React.Key = string> {
   /** The current input value. */
   value: string;
+
   /**
-   * Called on every input change (typing or selection). `value` is the text entered by the user. When the input value
-   * matches a known item's key, `key` will refer to the selected entry. If the entered value does not match an item,
-   * `key` will be undefined.
+   * Called on every input change (typing or selection).
+   *
+   * For selection, `value` is the text of the selected item, `key` the corresponding item's key.
+   *
+   * For typing, `value` is the text typed by the user, while `key` is only set when:
+   *   - exactly one option's display value contains `value` (case-insensitive), AND
+   *   - that option's display value equals `value` (case-sensitive).
+   * Otherwise, `key` is undefined.
+   *
+   * This is designed to prevent inadvertent auto-selection if there were more than one option still
+   * visible given the current search value.  (Note that this is stricter than the filtered
+   * autosuggest behavior, which is a case-insensitive substring match.)
    */
   onChange: (value: string, key?: TKey) => void;
 
-  /** Whether the user's input value should apply as a filter to the selected options. Defaults to true. */
+  /**
+   * Whether the user's input value should apply as a case-insensitive filter to the selected
+   * options. Defaults to true.
+   * */
   shouldFilter?: boolean;
 
   /** The array of items to present */
@@ -102,7 +129,7 @@ export function Combobox<TOption = string, TKey extends React.Key = string>({
   const [popoverHighlightedIndex, setPopoverHighlightedIndex] = useState(-1);
   const popoverItemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-  // Filter options based on input value (case-insensitive)
+  // Filter options based on case-insensitive substring match with the input value
   const filteredOptions = filterOptions(shouldFilter ? value : '', options, getDisplayTextForOption);
 
   // If filteredOptions changes, existing refs and highlight indexes will be potentially stale,
@@ -134,7 +161,14 @@ export function Combobox<TOption = string, TKey extends React.Key = string>({
     if (disabled) return;
     setIsPopoverOpen(true);
     const newValue = e.target.value;
-    const exactMatch = options.find((opt) => getDisplayTextForOption(opt) === newValue);
+    const firstIndex = options.findIndex(makeOptionFilter(newValue, getDisplayTextForOption, 0));
+    const secondIndex =
+      firstIndex === -1 ? -1 : options.findIndex(makeOptionFilter(newValue, getDisplayTextForOption, firstIndex + 1));
+    // Exact match is on the raw texts, not normalized!
+    const exactMatch =
+      firstIndex >= 0 && secondIndex < 0 && getDisplayTextForOption(options[firstIndex]) === newValue
+        ? options[firstIndex]
+        : undefined;
     onChange(newValue, exactMatch ? getKeyForOption(exactMatch) : undefined);
   };
 

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -201,49 +201,51 @@ export function Combobox<TOption = string, TKey extends React.Key = string>({
         </Box>
       </Popover.Trigger>
 
-      <Popover.Content
-        side="bottom"
-        align="start"
-        sideOffset={4}
-        style={{ minWidth: 'var(--radix-popover-trigger-width)', padding: 0 }}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-      >
-        <ScrollArea scrollbars="vertical" style={{ maxHeight }}>
-          {filteredOptions.length === 0 ? (
-            <Flex p="3" justify="center">
-              <Text size="2" color="gray">
-                {noMatchText}
-              </Text>
-            </Flex>
-          ) : (
-            <Flex direction="column">
-              {filteredOptions.map((option, index) => {
-                const isHighlighted = index === popoverHighlightedIndex;
-                return (
-                  <Box
-                    key={getKeyForOption(option)}
-                    ref={(el) => {
-                      popoverItemRefs.current[index] = el;
-                    }}
-                    onClick={() => handleSelect(option)}
-                    onMouseEnter={() => setPopoverHighlightedIndex(index)}
-                    onPointerDown={(e) => e.preventDefault()}
-                    py="2"
-                    px="3"
-                    style={{
-                      cursor: 'pointer',
-                      backgroundColor: isHighlighted ? 'var(--gray-3)' : undefined,
-                    }}
-                  >
-                    {renderDropdownRow({ option, isHighlighted, index })}
-                  </Box>
-                );
-              })}
-            </Flex>
-          )}
-        </ScrollArea>
-      </Popover.Content>
+      {isPopoverOpen && !disabled && (
+        <Popover.Content
+          side="bottom"
+          align="start"
+          sideOffset={4}
+          style={{ minWidth: 'var(--radix-popover-trigger-width)', padding: 0 }}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <ScrollArea scrollbars="vertical" style={{ maxHeight }}>
+            {filteredOptions.length === 0 ? (
+              <Flex p="3" justify="center">
+                <Text size="2" color="gray">
+                  {noMatchText}
+                </Text>
+              </Flex>
+            ) : (
+              <Flex direction="column">
+                {filteredOptions.map((option, index) => {
+                  const isHighlighted = index === popoverHighlightedIndex;
+                  return (
+                    <Box
+                      key={getKeyForOption(option)}
+                      ref={(el) => {
+                        popoverItemRefs.current[index] = el;
+                      }}
+                      onClick={() => handleSelect(option)}
+                      onMouseEnter={() => setPopoverHighlightedIndex(index)}
+                      onPointerDown={(e) => e.preventDefault()}
+                      py="2"
+                      px="3"
+                      style={{
+                        cursor: 'pointer',
+                        backgroundColor: isHighlighted ? 'var(--gray-3)' : undefined,
+                      }}
+                    >
+                      {renderDropdownRow({ option, isHighlighted, index })}
+                    </Box>
+                  );
+                })}
+              </Flex>
+            )}
+          </ScrollArea>
+        </Popover.Content>
+      )}
     </Popover.Root>
   );
 }


### PR DESCRIPTION
## Description

Simplifies the strata interface, particularly when there are very many fields available. Builds off of/supercedes #241.

### Changes

* Switches the UI to use a combobox to search with autosuggest dropdown, more closely resembling the FilterBuilder component.
* Incorporates a cap of 10 strata.
* Simplifies internal representation to use FieldMetadata (until conversion to design spec) for more consistent passing and filtering out any primary key field.
* Cleans up a slight UI quirk in the combobox by conditionally rendering Popover.Content (i.e. the dropdown)

## How has this been tested?

No strata added yet: 

<img width="614" height="139" alt="image" src="https://github.com/user-attachments/assets/ed569ade-d512-4a39-a9ca-c12e09b9c98f" />

Searching:
<img width="632" height="385" alt="image" src="https://github.com/user-attachments/assets/c155a33d-0c82-43a2-b63e-1984254f4650" />

Hitting the limit:
<img width="700" height="749" alt="image" src="https://github.com/user-attachments/assets/f3b818dc-e5e3-4c7c-bac0-837dfbb32a25" />

No match:
<img width="608" height="220" alt="image" src="https://github.com/user-attachments/assets/762168b9-f3ca-42eb-8568-d0402b2f7e7a" />