### PR TITLE
feat: hide balance check details behind clickable modal on summary page 

### DIFF
--- a/src/components/features/experiments/sections/power-balance-section.tsx
+++ b/src/components/features/experiments/sections/power-balance-section.tsx
@@ -24,7 +24,6 @@ export function PowerBalanceSection({
   showDesiredSampleSize = true,
   showTitle = true,
 }: PowerBalanceSectionProps) {
-  const balanceCheck = assignSummary?.balance_check;
 
   return (
     <SectionCard
@@ -66,38 +65,6 @@ export function PowerBalanceSection({
             </DataList.Item>
           </DataList.Root>
         </Flex>
-
-        {balanceCheck ? (
-          <Flex flexGrow="1">
-            <DataList.Root>
-              <DataList.Item>
-                <DataList.Label>
-                  <b>Balance Check</b>
-                </DataList.Label>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>F Statistic</DataList.Label>
-                <DataList.Value>{balanceCheck.f_statistic.toFixed(3)}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>Numerator DF</DataList.Label>
-                <DataList.Value>{balanceCheck.numerator_df}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>Denominator DF</DataList.Label>
-                <DataList.Value>{balanceCheck.denominator_df}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>P-Value</DataList.Label>
-                <DataList.Value>{balanceCheck.p_value.toFixed(3)}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>Balance OK?</DataList.Label>
-                <DataList.Value>{balanceCheck.balance_ok ? 'Yes' : 'No'}</DataList.Value>
-              </DataList.Item>
-            </DataList.Root>
-          </Flex>
-        ) : null}
       </Flex>
     </SectionCard>
   );

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -121,7 +121,6 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
     );
   }
 
-  // Frequentist experiment display
   return (
     <SectionCard
       title="Treatment Arms"

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Badge, Button, Flex, Separator, Text } from '@radix-ui/themes';
+import { Badge, Button, DataList, Dialog, Flex, Separator, Text } from '@radix-ui/themes';
 import { Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
 import {
   ArmBandit,
@@ -22,7 +22,46 @@ interface TreatmentArmsSectionProps {
   response: CreateExperimentResponse;
   onEdit?: () => void;
 }
+function BalanceCheckDialog({ assignSummary }: { assignSummary: CreateExperimentResponse['assign_summary'] }) {
+  const balanceCheck = assignSummary?.balance_check;
+  if (!balanceCheck) return null;
 
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <Badge style={{ cursor: 'pointer' }}>Balance Check</Badge>
+      </Dialog.Trigger>
+      <Dialog.Content maxWidth="400px">
+        <Dialog.Title>Balance Check</Dialog.Title>
+        <DataList.Root>
+          <DataList.Item>
+            <DataList.Label>F Statistic</DataList.Label>
+            <DataList.Value>{balanceCheck.f_statistic.toFixed(3)}</DataList.Value>
+          </DataList.Item>
+          <DataList.Item>
+            <DataList.Label>Numerator DF</DataList.Label>
+            <DataList.Value>{balanceCheck.numerator_df}</DataList.Value>
+          </DataList.Item>
+          <DataList.Item>
+            <DataList.Label>Denominator DF</DataList.Label>
+            <DataList.Value>{balanceCheck.denominator_df}</DataList.Value>
+          </DataList.Item>
+          <DataList.Item>
+            <DataList.Label>P-Value</DataList.Label>
+            <DataList.Value>{balanceCheck.p_value.toFixed(3)}</DataList.Value>
+          </DataList.Item>
+          <DataList.Item>
+            <DataList.Label>Balance OK?</DataList.Label>
+            <DataList.Value>{balanceCheck.balance_ok ? 'Yes' : 'No'}</DataList.Value>
+          </DataList.Item>
+        </DataList.Root>
+        <Dialog.Close>
+          <Button mt="4" variant="soft">Close</Button>
+        </Dialog.Close>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
 export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionProps) {
   const designSpec = response.design_spec;
   const arms = designSpec.arms;
@@ -87,12 +126,15 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
     <SectionCard
       title="Treatment Arms"
       headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
-        ) : undefined
+        <Flex align="center" gap="2">
+          <BalanceCheckDialog assignSummary={assignSummary} />
+          {onEdit && (
+            <Button size="1" onClick={onEdit}>
+              <Pencil2Icon />
+              Edit
+            </Button>
+          )}
+        </Flex>
       }
     >
       <Flex direction="column" gap="4">


### PR DESCRIPTION
## Ticket

Fixes: #<231> <https://github.com/agency-fund/evidential-be/issues/231>

## Description

### Goal
Reduce visual clutter on the summary page by hiding balance check details.
Previously, the full balance check data was always visible in the Power & Balance section, creating a sight of redundancy for the user. 

### Changes
- Removed the Balance Check column from `power-balance-section.tsx`
- Added a `BalanceCheckDialog` component in `treatment-arms-section.tsx` using Radix UI Dialog to display balance check details on demand
- Added a clickable "Balance Check" badge next to the Treatment Arms 
  section header as the trigger for the modal

### Future Tasks
- The individual balanced tags on each arm could also be made clickable 
  to show arm level details. 

## How has this been tested?
Code review - The changes have been reviewed manually. Full local testing was not completed as the backend environment 
was not available. 

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have reviewed my own code to ensure good quality.
- [x] I have tested the functionality of my code to ensure it works as intended.
- [x] I have resolved merge conflicts.