### PR TITLE
Update FE to use desired_n from the designspec; drop query param in old API (FE change to BE #201)

### DIFF
--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -2816,15 +2816,9 @@ export const createExperimentParams = zod.object({
 	datasource_id: zod.string(),
 });
 
-export const createExperimentQueryDesiredNMinOne = 0;
-
 export const createExperimentQueryStratifyOnMetricsDefault = true;
 
 export const createExperimentQueryParams = zod.object({
-	desired_n: zod
-		.union([zod.number().min(createExperimentQueryDesiredNMinOne), zod.null()])
-		.optional()
-		.describe("Number of participants to assign."),
 	stratify_on_metrics: zod
 		.boolean()
 		.default(createExperimentQueryStratifyOnMetricsDefault)
@@ -2860,6 +2854,8 @@ export const createExperimentBodyDesignSpecMetricsMax = 150;
 export const createExperimentBodyDesignSpecFiltersItemFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentBodyDesignSpecFiltersMax = 20;
+
+export const createExperimentBodyDesignSpecDesiredNMinOne = 0;
 
 export const createExperimentBodyDesignSpecPowerDefault = 0.8;
 export const createExperimentBodyDesignSpecPowerMin = 0;
@@ -2903,6 +2899,8 @@ export const createExperimentBodyDesignSpecFiltersItemFieldNameRegExpOne =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentBodyDesignSpecFiltersMaxOne = 20;
 
+export const createExperimentBodyDesignSpecDesiredNMinFour = 0;
+
 export const createExperimentBodyDesignSpecPowerDefaultOne = 0.8;
 export const createExperimentBodyDesignSpecPowerMinOne = 0;
 export const createExperimentBodyDesignSpecPowerMaxOne = 1;
@@ -2934,6 +2932,8 @@ export const createExperimentBodyDesignSpecContextsItemContextDescriptionMaxOne 
 
 export const createExperimentBodyDesignSpecContextsMaxOne = 150;
 
+export const createExperimentBodyDesignSpecDesiredNMinSeven = 0;
+
 export const createExperimentBodyDesignSpecExperimentNameMaxThree = 100;
 
 export const createExperimentBodyDesignSpecDescriptionMaxThree = 2000;
@@ -2953,6 +2953,8 @@ export const createExperimentBodyDesignSpecContextsItemContextDescriptionMaxFour
 
 export const createExperimentBodyDesignSpecContextsMaxFour = 150;
 
+export const createExperimentBodyDesignSpecDesiredNMinOnezero = 0;
+
 export const createExperimentBodyDesignSpecExperimentNameMaxFour = 100;
 
 export const createExperimentBodyDesignSpecDescriptionMaxFour = 2000;
@@ -2971,6 +2973,8 @@ export const createExperimentBodyDesignSpecContextsItemContextNameMaxTwo = 100;
 export const createExperimentBodyDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
 
 export const createExperimentBodyDesignSpecContextsMaxSeven = 150;
+
+export const createExperimentBodyDesignSpecDesiredNMinOnethree = 0;
 
 export const createExperimentBodyPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
@@ -3126,10 +3130,15 @@ export const createExperimentBody = zod.object({
 									"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 								),
 							desired_n: zod
-								.union([zod.number(), zod.null()])
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinOne),
+									zod.null(),
+								])
 								.optional()
 								.describe(
-									"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+									"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 								),
 							power: zod
 								.number()
@@ -3304,10 +3313,15 @@ export const createExperimentBody = zod.object({
 									"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 								),
 							desired_n: zod
-								.union([zod.number(), zod.null()])
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinFour),
+									zod.null(),
+								])
 								.optional()
 								.describe(
-									"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+									"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 								),
 							power: zod
 								.number()
@@ -3480,6 +3494,17 @@ export const createExperimentBody = zod.object({
 								.describe(
 									"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 								),
+							desired_n: zod
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinSeven),
+									zod.null(),
+								])
+								.optional()
+								.describe(
+									"Optional desired trial count used to initialize stored bandit n_trials.",
+								),
 							prior_type: zod
 								.enum(["beta", "normal"])
 								.optional()
@@ -3632,6 +3657,17 @@ export const createExperimentBody = zod.object({
 								.optional()
 								.describe(
 									"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
+								),
+							desired_n: zod
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinOnezero),
+									zod.null(),
+								])
+								.optional()
+								.describe(
+									"Optional desired trial count used to initialize stored bandit n_trials.",
 								),
 							prior_type: zod
 								.enum(["beta", "normal"])
@@ -3786,6 +3822,17 @@ export const createExperimentBody = zod.object({
 								.describe(
 									"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 								),
+							desired_n: zod
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinOnethree),
+									zod.null(),
+								])
+								.optional()
+								.describe(
+									"Optional desired trial count used to initialize stored bandit n_trials.",
+								),
 							prior_type: zod
 								.enum(["beta", "normal"])
 								.optional()
@@ -3904,6 +3951,12 @@ export const createExperimentBody = zod.object({
 									.optional()
 									.describe(
 										"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+									),
+								pct_change_with_desired_n: zod
+									.union([zod.number(), zod.null()])
+									.optional()
+									.describe(
+										"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 									),
 								msg: zod
 									.union([
@@ -4024,6 +4077,8 @@ export const createExperimentResponseDesignSpecFiltersItemFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentResponseDesignSpecFiltersMax = 20;
 
+export const createExperimentResponseDesignSpecDesiredNMinOne = 0;
+
 export const createExperimentResponseDesignSpecPowerDefault = 0.8;
 export const createExperimentResponseDesignSpecPowerMin = 0;
 export const createExperimentResponseDesignSpecPowerMax = 1;
@@ -4066,6 +4121,8 @@ export const createExperimentResponseDesignSpecFiltersItemFieldNameRegExpOne =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentResponseDesignSpecFiltersMaxOne = 20;
 
+export const createExperimentResponseDesignSpecDesiredNMinFour = 0;
+
 export const createExperimentResponseDesignSpecPowerDefaultOne = 0.8;
 export const createExperimentResponseDesignSpecPowerMinOne = 0;
 export const createExperimentResponseDesignSpecPowerMaxOne = 1;
@@ -4097,6 +4154,8 @@ export const createExperimentResponseDesignSpecContextsItemContextDescriptionMax
 
 export const createExperimentResponseDesignSpecContextsMaxOne = 150;
 
+export const createExperimentResponseDesignSpecDesiredNMinSeven = 0;
+
 export const createExperimentResponseDesignSpecExperimentNameMaxThree = 100;
 
 export const createExperimentResponseDesignSpecDescriptionMaxThree = 2000;
@@ -4116,6 +4175,8 @@ export const createExperimentResponseDesignSpecContextsItemContextDescriptionMax
 
 export const createExperimentResponseDesignSpecContextsMaxFour = 150;
 
+export const createExperimentResponseDesignSpecDesiredNMinOnezero = 0;
+
 export const createExperimentResponseDesignSpecExperimentNameMaxFour = 100;
 
 export const createExperimentResponseDesignSpecDescriptionMaxFour = 2000;
@@ -4134,6 +4195,8 @@ export const createExperimentResponseDesignSpecContextsItemContextNameMaxTwo = 1
 export const createExperimentResponseDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
 
 export const createExperimentResponseDesignSpecContextsMaxSeven = 150;
+
+export const createExperimentResponseDesignSpecDesiredNMinOnethree = 0;
 
 export const createExperimentResponsePowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
@@ -4336,10 +4399,15 @@ export const createExperimentResponse = zod
 										"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 									),
 								desired_n: zod
-									.union([zod.number(), zod.null()])
+									.union([
+										zod
+											.number()
+											.min(createExperimentResponseDesignSpecDesiredNMinOne),
+										zod.null(),
+									])
 									.optional()
 									.describe(
-										"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+										"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 									),
 								power: zod
 									.number()
@@ -4520,10 +4588,15 @@ export const createExperimentResponse = zod
 										"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 									),
 								desired_n: zod
-									.union([zod.number(), zod.null()])
+									.union([
+										zod
+											.number()
+											.min(createExperimentResponseDesignSpecDesiredNMinFour),
+										zod.null(),
+									])
 									.optional()
 									.describe(
-										"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+										"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 									),
 								power: zod
 									.number()
@@ -4703,6 +4776,17 @@ export const createExperimentResponse = zod
 									.describe(
 										"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 									),
+								desired_n: zod
+									.union([
+										zod
+											.number()
+											.min(createExperimentResponseDesignSpecDesiredNMinSeven),
+										zod.null(),
+									])
+									.optional()
+									.describe(
+										"Optional desired trial count used to initialize stored bandit n_trials.",
+									),
 								prior_type: zod
 									.enum(["beta", "normal"])
 									.optional()
@@ -4865,6 +4949,19 @@ export const createExperimentResponse = zod
 									.describe(
 										"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 									),
+								desired_n: zod
+									.union([
+										zod
+											.number()
+											.min(
+												createExperimentResponseDesignSpecDesiredNMinOnezero,
+											),
+										zod.null(),
+									])
+									.optional()
+									.describe(
+										"Optional desired trial count used to initialize stored bandit n_trials.",
+									),
 								prior_type: zod
 									.enum(["beta", "normal"])
 									.optional()
@@ -5025,6 +5122,19 @@ export const createExperimentResponse = zod
 									.describe(
 										"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 									),
+								desired_n: zod
+									.union([
+										zod
+											.number()
+											.min(
+												createExperimentResponseDesignSpecDesiredNMinOnethree,
+											),
+										zod.null(),
+									])
+									.optional()
+									.describe(
+										"Optional desired trial count used to initialize stored bandit n_trials.",
+									),
 								prior_type: zod
 									.enum(["beta", "normal"])
 									.optional()
@@ -5142,6 +5252,12 @@ export const createExperimentResponse = zod
 									.optional()
 									.describe(
 										"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+									),
+								pct_change_with_desired_n: zod
+									.union([zod.number(), zod.null()])
+									.optional()
+									.describe(
+										"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 									),
 								msg: zod
 									.union([
@@ -6037,6 +6153,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFi
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMax = 20;
 
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOne = 0;
+
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefault = 0.8;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMin = 0;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMax = 1;
@@ -6078,6 +6196,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFi
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMaxOne = 20;
 
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinFour = 0;
+
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefaultOne = 0.8;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMinOne = 0;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMaxOne = 1;
@@ -6109,6 +6229,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemC
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxOne = 150;
 
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinSeven = 0;
+
 export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxThree = 100;
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxThree = 2000;
@@ -6128,6 +6250,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemC
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxFour = 150;
 
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOnezero = 0;
+
 export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxFour = 100;
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxFour = 2000;
@@ -6146,6 +6270,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemC
 export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxSeven = 150;
+
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOnethree = 0;
 
 export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
@@ -6372,10 +6498,17 @@ export const listOrganizationExperimentsResponse = zod.object({
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOne,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -6594,10 +6727,17 @@ export const listOrganizationExperimentsResponse = zod.object({
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinFour,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -6815,6 +6955,19 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.describe(
 												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 											),
+										desired_n: zod
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinSeven,
+													),
+												zod.null(),
+											])
+											.optional()
+											.describe(
+												"Optional desired trial count used to initialize stored bandit n_trials.",
+											),
 										prior_type: zod
 											.enum(["beta", "normal"])
 											.optional()
@@ -6994,6 +7147,19 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.optional()
 											.describe(
 												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
+											),
+										desired_n: zod
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOnezero,
+													),
+												zod.null(),
+											])
+											.optional()
+											.describe(
+												"Optional desired trial count used to initialize stored bandit n_trials.",
 											),
 										prior_type: zod
 											.enum(["beta", "normal"])
@@ -7175,6 +7341,19 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.describe(
 												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 											),
+										desired_n: zod
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOnethree,
+													),
+												zod.null(),
+											])
+											.optional()
+											.describe(
+												"Optional desired trial count used to initialize stored bandit n_trials.",
+											),
 										prior_type: zod
 											.enum(["beta", "normal"])
 											.optional()
@@ -7296,6 +7475,12 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.optional()
 											.describe(
 												"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+											),
+										pct_change_with_desired_n: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 											),
 										msg: zod
 											.union([
@@ -7544,6 +7729,8 @@ export const getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegEx
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const getExperimentForUiResponseConfigDesignSpecFiltersMax = 20;
 
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinOne = 0;
+
 export const getExperimentForUiResponseConfigDesignSpecPowerDefault = 0.8;
 export const getExperimentForUiResponseConfigDesignSpecPowerMin = 0;
 export const getExperimentForUiResponseConfigDesignSpecPowerMax = 1;
@@ -7585,6 +7772,8 @@ export const getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegEx
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const getExperimentForUiResponseConfigDesignSpecFiltersMaxOne = 20;
 
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinFour = 0;
+
 export const getExperimentForUiResponseConfigDesignSpecPowerDefaultOne = 0.8;
 export const getExperimentForUiResponseConfigDesignSpecPowerMinOne = 0;
 export const getExperimentForUiResponseConfigDesignSpecPowerMaxOne = 1;
@@ -7616,6 +7805,8 @@ export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescri
 
 export const getExperimentForUiResponseConfigDesignSpecContextsMaxOne = 150;
 
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinSeven = 0;
+
 export const getExperimentForUiResponseConfigDesignSpecExperimentNameMaxThree = 100;
 
 export const getExperimentForUiResponseConfigDesignSpecDescriptionMaxThree = 2000;
@@ -7635,6 +7826,8 @@ export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescri
 
 export const getExperimentForUiResponseConfigDesignSpecContextsMaxFour = 150;
 
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinOnezero = 0;
+
 export const getExperimentForUiResponseConfigDesignSpecExperimentNameMaxFour = 100;
 
 export const getExperimentForUiResponseConfigDesignSpecDescriptionMaxFour = 2000;
@@ -7653,6 +7846,8 @@ export const getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMa
 export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
 
 export const getExperimentForUiResponseConfigDesignSpecContextsMaxSeven = 150;
+
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinOnethree = 0;
 
 export const getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
@@ -7874,10 +8069,17 @@ export const getExperimentForUiResponse = zod
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinOne,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -8086,10 +8288,17 @@ export const getExperimentForUiResponse = zod
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinFour,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -8305,6 +8514,19 @@ export const getExperimentForUiResponse = zod
 											.describe(
 												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 											),
+										desired_n: zod
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinSeven,
+													),
+												zod.null(),
+											])
+											.optional()
+											.describe(
+												"Optional desired trial count used to initialize stored bandit n_trials.",
+											),
 										prior_type: zod
 											.enum(["beta", "normal"])
 											.optional()
@@ -8484,6 +8706,19 @@ export const getExperimentForUiResponse = zod
 											.optional()
 											.describe(
 												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
+											),
+										desired_n: zod
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinOnezero,
+													),
+												zod.null(),
+											])
+											.optional()
+											.describe(
+												"Optional desired trial count used to initialize stored bandit n_trials.",
 											),
 										prior_type: zod
 											.enum(["beta", "normal"])
@@ -8665,6 +8900,19 @@ export const getExperimentForUiResponse = zod
 											.describe(
 												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
 											),
+										desired_n: zod
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinOnethree,
+													),
+												zod.null(),
+											])
+											.optional()
+											.describe(
+												"Optional desired trial count used to initialize stored bandit n_trials.",
+											),
 										prior_type: zod
 											.enum(["beta", "normal"])
 											.optional()
@@ -8786,6 +9034,12 @@ export const getExperimentForUiResponse = zod
 											.optional()
 											.describe(
 												"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+											),
+										pct_change_with_desired_n: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 											),
 										msg: zod
 											.union([
@@ -9237,6 +9491,8 @@ export const powerCheckBodyDesignSpecFiltersItemFieldNameRegExp = new RegExp(
 );
 export const powerCheckBodyDesignSpecFiltersMax = 20;
 
+export const powerCheckBodyDesignSpecDesiredNMinOne = 0;
+
 export const powerCheckBodyDesignSpecPowerDefault = 0.8;
 export const powerCheckBodyDesignSpecPowerMin = 0;
 export const powerCheckBodyDesignSpecPowerMax = 1;
@@ -9281,6 +9537,8 @@ export const powerCheckBodyDesignSpecFiltersItemFieldNameRegExpOne = new RegExp(
 	"^[a-zA-Z_][a-zA-Z0-9_]*$",
 );
 export const powerCheckBodyDesignSpecFiltersMaxOne = 20;
+
+export const powerCheckBodyDesignSpecDesiredNMinFour = 0;
 
 export const powerCheckBodyDesignSpecPowerDefaultOne = 0.8;
 export const powerCheckBodyDesignSpecPowerMinOne = 0;
@@ -9430,10 +9688,13 @@ export const powerCheckBody = zod.object({
 							"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 						),
 					desired_n: zod
-						.union([zod.number(), zod.null()])
+						.union([
+							zod.number().min(powerCheckBodyDesignSpecDesiredNMinOne),
+							zod.null(),
+						])
 						.optional()
 						.describe(
-							"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+							"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 						),
 					power: zod
 						.number()
@@ -9604,10 +9865,13 @@ export const powerCheckBody = zod.object({
 							"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 						),
 					desired_n: zod
-						.union([zod.number(), zod.null()])
+						.union([
+							zod.number().min(powerCheckBodyDesignSpecDesiredNMinFour),
+							zod.null(),
+						])
 						.optional()
 						.describe(
-							"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+							"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 						),
 					power: zod
 						.number()
@@ -9739,6 +10003,12 @@ export const powerCheckResponse = zod.object({
 						.optional()
 						.describe(
 							"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+						),
+					pct_change_with_desired_n: zod
+						.union([zod.number(), zod.null()])
+						.optional()
+						.describe(
+							"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 						),
 					msg: zod
 						.union([

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -592,6 +592,11 @@ export type BayesABExperimentSpecInputDesignUrl = string | null;
 export type BayesABExperimentSpecInputContexts = Context[] | null;
 
 /**
+ * Optional desired trial count used to initialize stored bandit n_trials.
+ */
+export type BayesABExperimentSpecInputDesiredN = number | null;
+
+/**
  * Use this type to randomly assign participants into arms during live experiment execution with
 Bayesian A/B experiments.
 
@@ -614,6 +619,8 @@ export interface BayesABExperimentSpecInput {
 	arms: ArmBandit[];
 	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: BayesABExperimentSpecInputContexts;
+	/** Optional desired trial count used to initialize stored bandit n_trials. */
+	desired_n?: BayesABExperimentSpecInputDesiredN;
 	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
 	/** The type of reward we observe from the experiment. */
@@ -639,6 +646,11 @@ export type BayesABExperimentSpecOutputDesignUrl = string | null;
 export type BayesABExperimentSpecOutputContexts = Context[] | null;
 
 /**
+ * Optional desired trial count used to initialize stored bandit n_trials.
+ */
+export type BayesABExperimentSpecOutputDesiredN = number | null;
+
+/**
  * Use this type to randomly assign participants into arms during live experiment execution with
 Bayesian A/B experiments.
 
@@ -661,6 +673,8 @@ export interface BayesABExperimentSpecOutput {
 	arms: ArmBandit[];
 	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: BayesABExperimentSpecOutputContexts;
+	/** Optional desired trial count used to initialize stored bandit n_trials. */
+	desired_n?: BayesABExperimentSpecOutputDesiredN;
 	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
 	/** The type of reward we observe from the experiment. */
@@ -795,6 +809,11 @@ export type CMABExperimentSpecInputDesignUrl = string | null;
 export type CMABExperimentSpecInputContexts = Context[] | null;
 
 /**
+ * Optional desired trial count used to initialize stored bandit n_trials.
+ */
+export type CMABExperimentSpecInputDesiredN = number | null;
+
+/**
  * Use this type to randomly assign participants into arms during live experiment execution with
 contextual MAB experiments.
 
@@ -817,6 +836,8 @@ export interface CMABExperimentSpecInput {
 	arms: ArmBandit[];
 	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: CMABExperimentSpecInputContexts;
+	/** Optional desired trial count used to initialize stored bandit n_trials. */
+	desired_n?: CMABExperimentSpecInputDesiredN;
 	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
 	/** The type of reward we observe from the experiment. */
@@ -842,6 +863,11 @@ export type CMABExperimentSpecOutputDesignUrl = string | null;
 export type CMABExperimentSpecOutputContexts = Context[] | null;
 
 /**
+ * Optional desired trial count used to initialize stored bandit n_trials.
+ */
+export type CMABExperimentSpecOutputDesiredN = number | null;
+
+/**
  * Use this type to randomly assign participants into arms during live experiment execution with
 contextual MAB experiments.
 
@@ -864,6 +890,8 @@ export interface CMABExperimentSpecOutput {
 	arms: ArmBandit[];
 	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: CMABExperimentSpecOutputContexts;
+	/** Optional desired trial count used to initialize stored bandit n_trials. */
+	desired_n?: CMABExperimentSpecOutputDesiredN;
 	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
 	/** The type of reward we observe from the experiment. */
@@ -1929,6 +1957,11 @@ export type MABExperimentSpecInputDesignUrl = string | null;
 export type MABExperimentSpecInputContexts = Context[] | null;
 
 /**
+ * Optional desired trial count used to initialize stored bandit n_trials.
+ */
+export type MABExperimentSpecInputDesiredN = number | null;
+
+/**
  * Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
@@ -1950,6 +1983,8 @@ export interface MABExperimentSpecInput {
 	arms: ArmBandit[];
 	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: MABExperimentSpecInputContexts;
+	/** Optional desired trial count used to initialize stored bandit n_trials. */
+	desired_n?: MABExperimentSpecInputDesiredN;
 	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
 	/** The type of reward we observe from the experiment. */
@@ -1975,6 +2010,11 @@ export type MABExperimentSpecOutputDesignUrl = string | null;
 export type MABExperimentSpecOutputContexts = Context[] | null;
 
 /**
+ * Optional desired trial count used to initialize stored bandit n_trials.
+ */
+export type MABExperimentSpecOutputDesiredN = number | null;
+
+/**
  * Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.
 
 For example, you may wish to experiment on new users. Assignments are issued via API request.
@@ -1996,6 +2036,8 @@ export interface MABExperimentSpecOutput {
 	arms: ArmBandit[];
 	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: MABExperimentSpecOutputContexts;
+	/** Optional desired trial count used to initialize stored bandit n_trials. */
+	desired_n?: MABExperimentSpecOutputDesiredN;
 	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
 	/** The type of reward we observe from the experiment. */
@@ -2035,6 +2077,11 @@ export type MetricPowerAnalysisInputTargetPossible = number | null;
  * If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.
  */
 export type MetricPowerAnalysisInputPctChangePossible = number | null;
+
+/**
+ * The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).
+ */
+export type MetricPowerAnalysisInputPctChangeWithDesiredN = number | null;
 
 /**
  * Human friendly message about the above results.
@@ -2079,6 +2126,8 @@ export interface MetricPowerAnalysisInput {
 	target_possible?: MetricPowerAnalysisInputTargetPossible;
 	/** If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	pct_change_possible?: MetricPowerAnalysisInputPctChangePossible;
+	/** The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs). */
+	pct_change_with_desired_n?: MetricPowerAnalysisInputPctChangeWithDesiredN;
 	/** Human friendly message about the above results. */
 	msg?: MetricPowerAnalysisInputMsg;
 	/** Total number of clusters needed across all arms */
@@ -2112,6 +2161,11 @@ export type MetricPowerAnalysisOutputTargetPossible = number | null;
  * If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.
  */
 export type MetricPowerAnalysisOutputPctChangePossible = number | null;
+
+/**
+ * The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).
+ */
+export type MetricPowerAnalysisOutputPctChangeWithDesiredN = number | null;
 
 /**
  * Human friendly message about the above results.
@@ -2156,6 +2210,8 @@ export interface MetricPowerAnalysisOutput {
 	target_possible?: MetricPowerAnalysisOutputTargetPossible;
 	/** If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	pct_change_possible?: MetricPowerAnalysisOutputPctChangePossible;
+	/** The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs). */
+	pct_change_with_desired_n?: MetricPowerAnalysisOutputPctChangeWithDesiredN;
 	/** Human friendly message about the above results. */
 	msg?: MetricPowerAnalysisOutputMsg;
 	/** Total number of clusters needed across all arms */
@@ -2248,7 +2304,7 @@ export const OnlineFrequentistExperimentSpecInputExperimentType = {
 export type OnlineFrequentistExperimentSpecInputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type OnlineFrequentistExperimentSpecInputDesiredN = number | null;
 
@@ -2299,7 +2355,7 @@ export interface OnlineFrequentistExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	filters: FilterInput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: OnlineFrequentistExperimentSpecInputDesiredN;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
@@ -2335,7 +2391,7 @@ export const OnlineFrequentistExperimentSpecOutputExperimentType = {
 export type OnlineFrequentistExperimentSpecOutputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type OnlineFrequentistExperimentSpecOutputDesiredN = number | null;
 
@@ -2386,7 +2442,7 @@ export interface OnlineFrequentistExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	filters: FilterOutput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: OnlineFrequentistExperimentSpecOutputDesiredN;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
@@ -2535,7 +2591,7 @@ export const PreassignedFrequentistExperimentSpecInputExperimentType = {
 export type PreassignedFrequentistExperimentSpecInputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type PreassignedFrequentistExperimentSpecInputDesiredN = number | null;
 
@@ -2584,7 +2640,7 @@ export interface PreassignedFrequentistExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	filters: FilterInput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: PreassignedFrequentistExperimentSpecInputDesiredN;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
@@ -2620,7 +2676,7 @@ export const PreassignedFrequentistExperimentSpecOutputExperimentType = {
 export type PreassignedFrequentistExperimentSpecOutputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type PreassignedFrequentistExperimentSpecOutputDesiredN = number | null;
 
@@ -2669,7 +2725,7 @@ export interface PreassignedFrequentistExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	filters: FilterOutput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: PreassignedFrequentistExperimentSpecOutputDesiredN;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
@@ -3168,10 +3224,6 @@ export type DeleteApiKeyParams = {
 };
 
 export type CreateExperimentParams = {
-	/**
-	 * Number of participants to assign.
-	 */
-	desired_n?: number | null;
 	/**
 	 * Whether to also stratify on metrics during assignment.
 	 */

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -212,22 +212,18 @@ export const ExperimentDescribeBanditArmsScreen = ({
   }
   const datasourceId = datasource?.id ?? '';
 
-  const { trigger: triggerCreate, isMutating: createLoading } = useCreateExperiment(
-    datasourceId,
-    undefined,
-    {
-      swr: {
-        onSuccess: async (response) => {
-          dispatch({ type: 'set-datasource-id', datasourceId: datasourceId });
-          dispatch({ type: 'set-create-response', response });
-          navigateNext();
-        },
-        onError: async (response: ErrorType<unknown>) => {
-          dispatch({ type: 'set-create-error', response });
-        },
+  const { trigger: triggerCreate, isMutating: createLoading } = useCreateExperiment(datasourceId, undefined, {
+    swr: {
+      onSuccess: async (response) => {
+        dispatch({ type: 'set-datasource-id', datasourceId: datasourceId });
+        dispatch({ type: 'set-create-response', response });
+        navigateNext();
+      },
+      onError: async (response: ErrorType<unknown>) => {
+        dispatch({ type: 'set-create-error', response });
       },
     },
-  );
+  });
 
   const [showPriors, setShowPriors] = useState(false);
 

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -214,7 +214,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
 
   const { trigger: triggerCreate, isMutating: createLoading } = useCreateExperiment(
     datasourceId,
-    { desired_n: 0 },
+    undefined,
     {
       swr: {
         onSuccess: async (response) => {

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -90,6 +90,9 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     design_spec: {
       ...commonFields,
       experiment_type: data.experimentType,
+      ...(data.experimentType === 'freq_preassigned' && data.desiredN !== undefined
+        ? { desired_n: data.desiredN }
+        : {}),
     },
   }).design_spec;
 
@@ -142,6 +145,7 @@ export function convertToBanditCreateRequest(data: ExperimentFormData): CreateEx
       prior_type: priorType,
       reward_type: canonicalRewardType,
       contexts: standardContexts,
+      desired_n: 0,
     },
     webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
   });

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -59,21 +59,17 @@ export const ExperimentFreqStackScreen = ({
   const { data: tableData } = useInspectTableInDatasource(data.datasourceId ?? '', data.tableName ?? '', {
     refresh: false,
   });
-  const { trigger: triggerCreate, isMutating: triggerLoading } = useCreateExperiment(
-    data.datasourceId!,
-    undefined,
-    {
-      swr: {
-        onSuccess: async (response) => {
-          dispatch({ type: 'set-create-response', response: response });
-          navigateNext();
-        },
-        onError: async (response) => {
-          dispatch({ type: 'set-create-error', response: response });
-        },
+  const { trigger: triggerCreate, isMutating: triggerLoading } = useCreateExperiment(data.datasourceId!, undefined, {
+    swr: {
+      onSuccess: async (response) => {
+        dispatch({ type: 'set-create-response', response: response });
+        navigateNext();
+      },
+      onError: async (response) => {
+        dispatch({ type: 'set-create-error', response: response });
       },
     },
-  );
+  });
 
   const fields = tableData?.fields ?? [];
 

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -61,9 +61,7 @@ export const ExperimentFreqStackScreen = ({
   });
   const { trigger: triggerCreate, isMutating: triggerLoading } = useCreateExperiment(
     data.datasourceId!,
-    {
-      desired_n: data.desiredN,
-    },
+    undefined,
     {
       swr: {
         onSuccess: async (response) => {

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -39,7 +39,7 @@ const isNextEnabled = (data: ExperimentFormData) => {
     // Must have run power check for pre-assigned frequentist experiment
     if (!data.powerCheckResponse) return false;
     // Must have selected a sample size for pre-assigned frequentist experiment
-    if (data.desiredN === undefined) return false;
+    if (data.desiredN === undefined || data.desiredN === 0) return false;
   }
   return true;
 };


### PR DESCRIPTION
## Description

### Goal

This is a paired FE change to support a BE change that removes the `desired_n` query param from `create_experiment()`, instead drawing from the design spec's desired_n field.

## Related PRs

Backend: https://github.com/agency-fund/evidential-be/pull/201

## How has this been tested?

Manual creation of preassigned and bandit experiments. Also verified Power/Balance popup now shows the desiredN instead of N/A.
