### PR TITLE
Frontend support for cluster-randomized experiments (issue #217)

### DIFF
--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -99,6 +99,24 @@ export const getSnapshotResponse = zod
 																.describe(
 																	"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
 																),
+															icc: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Intracluster correlation coefficient for cluster-randomized designs.",
+																),
+															avg_cluster_size: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Average number of individuals per cluster.",
+																),
+															cv: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Coefficient of variation in cluster sizes (0 = equal sizes).",
+																),
 														})
 														.describe(
 															"Defines a request to look up baseline stats for a metric to measure in an experiment.",
@@ -515,6 +533,24 @@ export const listSnapshotsResponse = zod.object({
 																.optional()
 																.describe(
 																	"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+																),
+															icc: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Intracluster correlation coefficient for cluster-randomized designs.",
+																),
+															avg_cluster_size: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Average number of individuals per cluster.",
+																),
+															cv: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Coefficient of variation in cluster sizes (0 = equal sizes).",
 																),
 														})
 														.describe(
@@ -2816,15 +2852,9 @@ export const createExperimentParams = zod.object({
 	datasource_id: zod.string(),
 });
 
-export const createExperimentQueryDesiredNMinOne = 0;
-
 export const createExperimentQueryStratifyOnMetricsDefault = true;
 
 export const createExperimentQueryParams = zod.object({
-	desired_n: zod
-		.union([zod.number().min(createExperimentQueryDesiredNMinOne), zod.null()])
-		.optional()
-		.describe("Number of participants to assign."),
 	stratify_on_metrics: zod
 		.boolean()
 		.default(createExperimentQueryStratifyOnMetricsDefault)
@@ -2860,6 +2890,8 @@ export const createExperimentBodyDesignSpecMetricsMax = 150;
 export const createExperimentBodyDesignSpecFiltersItemFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentBodyDesignSpecFiltersMax = 20;
+
+export const createExperimentBodyDesignSpecDesiredNMinOne = 0;
 
 export const createExperimentBodyDesignSpecPowerDefault = 0.8;
 export const createExperimentBodyDesignSpecPowerMin = 0;
@@ -2902,6 +2934,8 @@ export const createExperimentBodyDesignSpecMetricsMaxOne = 150;
 export const createExperimentBodyDesignSpecFiltersItemFieldNameRegExpOne =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentBodyDesignSpecFiltersMaxOne = 20;
+
+export const createExperimentBodyDesignSpecDesiredNMinFour = 0;
 
 export const createExperimentBodyDesignSpecPowerDefaultOne = 0.8;
 export const createExperimentBodyDesignSpecPowerMinOne = 0;
@@ -2953,27 +2987,9 @@ export const createExperimentBodyDesignSpecContextsItemContextDescriptionMaxFour
 
 export const createExperimentBodyDesignSpecContextsMaxFour = 150;
 
-export const createExperimentBodyDesignSpecExperimentNameMaxFour = 100;
-
-export const createExperimentBodyDesignSpecDescriptionMaxFour = 2000;
-
-export const createExperimentBodyDesignSpecDesignUrlMaxOnethree = 500;
-
-export const createExperimentBodyDesignSpecArmsItemArmNameMaxFour = 100;
-
-export const createExperimentBodyDesignSpecArmsItemArmDescriptionMaxOnethree = 2000;
-
-export const createExperimentBodyDesignSpecArmsMinFour = 2;
-export const createExperimentBodyDesignSpecArmsMaxFour = 20;
-
-export const createExperimentBodyDesignSpecContextsItemContextNameMaxTwo = 100;
-
-export const createExperimentBodyDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
-
-export const createExperimentBodyDesignSpecContextsMaxSeven = 150;
-
 export const createExperimentBodyPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const createExperimentBodyPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const createExperimentBodyPowerAnalysesAnalysesMax = 150;
 
 export const createExperimentBodyWebhooksDefault = [];
@@ -3053,6 +3069,12 @@ export const createExperimentBody = zod.object({
 								.describe(
 									"Column name in table_name that uniquely identifies each participant.",
 								),
+							cluster_key: zod
+								.union([zod.string(), zod.null()])
+								.optional()
+								.describe(
+									"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+								),
 							strata: zod
 								.array(
 									zod
@@ -3087,6 +3109,22 @@ export const createExperimentBody = zod.object({
 												.optional()
 												.describe(
 													"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+												),
+											icc: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Intracluster correlation coefficient for cluster-randomized designs.",
+												),
+											avg_cluster_size: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe("Average number of individuals per cluster."),
+											cv: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Coefficient of variation in cluster sizes (0 = equal sizes).",
 												),
 										})
 										.describe(
@@ -3126,10 +3164,15 @@ export const createExperimentBody = zod.object({
 									"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 								),
 							desired_n: zod
-								.union([zod.number(), zod.null()])
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinOne),
+									zod.null(),
+								])
 								.optional()
 								.describe(
-									"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+									"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 								),
 							power: zod
 								.number()
@@ -3231,6 +3274,12 @@ export const createExperimentBody = zod.object({
 								.describe(
 									"Column name in table_name that uniquely identifies each participant.",
 								),
+							cluster_key: zod
+								.union([zod.string(), zod.null()])
+								.optional()
+								.describe(
+									"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+								),
 							strata: zod
 								.array(
 									zod
@@ -3265,6 +3314,22 @@ export const createExperimentBody = zod.object({
 												.optional()
 												.describe(
 													"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+												),
+											icc: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Intracluster correlation coefficient for cluster-randomized designs.",
+												),
+											avg_cluster_size: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe("Average number of individuals per cluster."),
+											cv: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Coefficient of variation in cluster sizes (0 = equal sizes).",
 												),
 										})
 										.describe(
@@ -3304,10 +3369,15 @@ export const createExperimentBody = zod.object({
 									"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 								),
 							desired_n: zod
-								.union([zod.number(), zod.null()])
+								.union([
+									zod
+										.number()
+										.min(createExperimentBodyDesignSpecDesiredNMinFour),
+									zod.null(),
+								])
 								.optional()
 								.describe(
-									"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+									"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 								),
 							power: zod
 								.number()
@@ -3647,159 +3717,6 @@ export const createExperimentBody = zod.object({
 						.describe(
 							"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 						),
-					zod
-						.object({
-							experiment_type: zod.enum(["bayes_ab_online"]),
-							experiment_name: zod
-								.string()
-								.max(createExperimentBodyDesignSpecExperimentNameMaxFour),
-							description: zod
-								.string()
-								.max(createExperimentBodyDesignSpecDescriptionMaxFour),
-							design_url: zod
-								.union([
-									zod
-										.string()
-										.url()
-										.min(1)
-										.max(createExperimentBodyDesignSpecDesignUrlMaxOnethree),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Optional URL to a more detailed experiment design doc.",
-								),
-							start_date: zod.string().datetime({}),
-							end_date: zod.string().datetime({}),
-							arms: zod
-								.array(
-									zod
-										.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
-												.string()
-												.max(
-													createExperimentBodyDesignSpecArmsItemArmNameMaxFour,
-												),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecArmsItemArmDescriptionMaxOnethree,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-											alpha_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial alpha parameter for Beta prior"),
-											beta_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial beta parameter for Beta prior"),
-											mu_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial mean parameter for Normal prior"),
-											sigma_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Initial standard deviation parameter for Normal prior",
-												),
-											alpha: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Updated alpha parameter for Beta prior"),
-											beta: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Updated beta parameter for Beta prior"),
-											mu: zod
-												.union([zod.array(zod.number()), zod.null()])
-												.optional()
-												.describe("Updated mean vector for Normal prior"),
-											covariance: zod
-												.union([zod.array(zod.array(zod.number())), zod.null()])
-												.optional()
-												.describe("Updated covariance matrix for Normal prior"),
-										})
-										.describe(
-											"Describes an experiment arm for bandit experiments.",
-										),
-								)
-								.min(createExperimentBodyDesignSpecArmsMinFour)
-								.max(createExperimentBodyDesignSpecArmsMaxFour),
-							contexts: zod
-								.union([
-									zod
-										.array(
-											zod
-												.object({
-													context_id: zod
-														.union([zod.string(), zod.null()])
-														.optional()
-														.describe(
-															"Unique identifier for the context, you should NOT set this when creating a new context.",
-														),
-													context_name: zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecContextsItemContextNameMaxTwo,
-														),
-													context_description: zod
-														.union([
-															zod
-																.string()
-																.max(
-																	createExperimentBodyDesignSpecContextsItemContextDescriptionMaxSeven,
-																),
-															zod.null(),
-														])
-														.optional(),
-													value_type: zod
-														.enum(["binary", "real-valued"])
-														.optional()
-														.describe("Enum for the type of context."),
-												})
-												.describe(
-													"Pydantic model for context of the experiment.",
-												),
-										)
-										.max(createExperimentBodyDesignSpecContextsMaxSeven),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-								),
-							prior_type: zod
-								.enum(["beta", "normal"])
-								.optional()
-								.describe("Enum for the prior distribution of the arm."),
-							reward_type: zod
-								.enum(["binary", "real-valued"])
-								.optional()
-								.describe(
-									"Enum for the likelihood distribution of the reward.",
-								),
-						})
-						.describe(
-							"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-						),
 				])
 				.describe("The specific type of bandit experiment design."),
 		])
@@ -3829,6 +3746,22 @@ export const createExperimentBody = zod.object({
 											.optional()
 											.describe(
 												"Absolute target value = metric_baseline*(1 + metric_pct_change)",
+											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 										metric_type: zod
 											.union([
@@ -3861,22 +3794,6 @@ export const createExperimentBody = zod.object({
 											.describe(
 												"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
 											),
-										icc: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Intracluster correlation coefficient for cluster-randomized designs.",
-											),
-										avg_cluster_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Average number of individuals per cluster."),
-										cv: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Coefficient of variation in cluster sizes (0 = equal sizes).",
-											),
 									})
 									.describe(
 										"Defines a metric to measure in an experiment with its baseline stats.",
@@ -3904,6 +3821,12 @@ export const createExperimentBody = zod.object({
 									.optional()
 									.describe(
 										"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+									),
+								pct_change_with_desired_n: zod
+									.union([zod.number(), zod.null()])
+									.optional()
+									.describe(
+										"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 									),
 								msg: zod
 									.union([
@@ -3940,6 +3863,7 @@ export const createExperimentBody = zod.object({
 														zod.null(),
 													])
 													.optional(),
+												high_cluster_variation: zod.boolean().optional(),
 											})
 											.describe(
 												"Describes interpretation of power analysis results.",
@@ -4024,6 +3948,8 @@ export const createExperimentResponseDesignSpecFiltersItemFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentResponseDesignSpecFiltersMax = 20;
 
+export const createExperimentResponseDesignSpecDesiredNMinOne = 0;
+
 export const createExperimentResponseDesignSpecPowerDefault = 0.8;
 export const createExperimentResponseDesignSpecPowerMin = 0;
 export const createExperimentResponseDesignSpecPowerMax = 1;
@@ -4065,6 +3991,8 @@ export const createExperimentResponseDesignSpecMetricsMaxOne = 150;
 export const createExperimentResponseDesignSpecFiltersItemFieldNameRegExpOne =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const createExperimentResponseDesignSpecFiltersMaxOne = 20;
+
+export const createExperimentResponseDesignSpecDesiredNMinFour = 0;
 
 export const createExperimentResponseDesignSpecPowerDefaultOne = 0.8;
 export const createExperimentResponseDesignSpecPowerMinOne = 0;
@@ -4116,27 +4044,9 @@ export const createExperimentResponseDesignSpecContextsItemContextDescriptionMax
 
 export const createExperimentResponseDesignSpecContextsMaxFour = 150;
 
-export const createExperimentResponseDesignSpecExperimentNameMaxFour = 100;
-
-export const createExperimentResponseDesignSpecDescriptionMaxFour = 2000;
-
-export const createExperimentResponseDesignSpecDesignUrlMaxOnethree = 500;
-
-export const createExperimentResponseDesignSpecArmsItemArmNameMaxFour = 100;
-
-export const createExperimentResponseDesignSpecArmsItemArmDescriptionMaxOnethree = 2000;
-
-export const createExperimentResponseDesignSpecArmsMinFour = 2;
-export const createExperimentResponseDesignSpecArmsMaxFour = 20;
-
-export const createExperimentResponseDesignSpecContextsItemContextNameMaxTwo = 100;
-
-export const createExperimentResponseDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
-
-export const createExperimentResponseDesignSpecContextsMaxSeven = 150;
-
 export const createExperimentResponsePowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const createExperimentResponsePowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const createExperimentResponsePowerAnalysesAnalysesMax = 150;
 
 export const createExperimentResponseAssignSummaryArmSizesItemArmArmNameMax = 100;
@@ -4257,6 +4167,12 @@ export const createExperimentResponse = zod
 									.describe(
 										"Column name in table_name that uniquely identifies each participant.",
 									),
+								cluster_key: zod
+									.union([zod.string(), zod.null()])
+									.optional()
+									.describe(
+										"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+									),
 								strata: zod
 									.array(
 										zod
@@ -4295,6 +4211,24 @@ export const createExperimentResponse = zod
 													.optional()
 													.describe(
 														"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 											})
 											.describe(
@@ -4336,10 +4270,15 @@ export const createExperimentResponse = zod
 										"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 									),
 								desired_n: zod
-									.union([zod.number(), zod.null()])
+									.union([
+										zod
+											.number()
+											.min(createExperimentResponseDesignSpecDesiredNMinOne),
+										zod.null(),
+									])
 									.optional()
 									.describe(
-										"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+										"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 									),
 								power: zod
 									.number()
@@ -4441,6 +4380,12 @@ export const createExperimentResponse = zod
 									.describe(
 										"Column name in table_name that uniquely identifies each participant.",
 									),
+								cluster_key: zod
+									.union([zod.string(), zod.null()])
+									.optional()
+									.describe(
+										"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+									),
 								strata: zod
 									.array(
 										zod
@@ -4479,6 +4424,24 @@ export const createExperimentResponse = zod
 													.optional()
 													.describe(
 														"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 											})
 											.describe(
@@ -4520,10 +4483,15 @@ export const createExperimentResponse = zod
 										"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 									),
 								desired_n: zod
-									.union([zod.number(), zod.null()])
+									.union([
+										zod
+											.number()
+											.min(createExperimentResponseDesignSpecDesiredNMinFour),
+										zod.null(),
+									])
 									.optional()
 									.describe(
-										"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+										"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 									),
 								power: zod
 									.number()
@@ -4879,166 +4847,6 @@ export const createExperimentResponse = zod
 							.describe(
 								"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 							),
-						zod
-							.object({
-								experiment_type: zod.enum(["bayes_ab_online"]),
-								experiment_name: zod
-									.string()
-									.max(createExperimentResponseDesignSpecExperimentNameMaxFour),
-								description: zod
-									.string()
-									.max(createExperimentResponseDesignSpecDescriptionMaxFour),
-								design_url: zod
-									.union([
-										zod
-											.string()
-											.url()
-											.min(1)
-											.max(
-												createExperimentResponseDesignSpecDesignUrlMaxOnethree,
-											),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional URL to a more detailed experiment design doc.",
-									),
-								start_date: zod.string().datetime({}),
-								end_date: zod.string().datetime({}),
-								arms: zod
-									.array(
-										zod
-											.object({
-												arm_id: zod
-													.union([zod.string(), zod.null()])
-													.optional()
-													.describe(
-														"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-													),
-												arm_name: zod
-													.string()
-													.max(
-														createExperimentResponseDesignSpecArmsItemArmNameMaxFour,
-													),
-												arm_description: zod
-													.union([
-														zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecArmsItemArmDescriptionMaxOnethree,
-															),
-														zod.null(),
-													])
-													.optional(),
-												arm_weight: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-													),
-												alpha_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial alpha parameter for Beta prior"),
-												beta_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial beta parameter for Beta prior"),
-												mu_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial mean parameter for Normal prior"),
-												sigma_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Initial standard deviation parameter for Normal prior",
-													),
-												alpha: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Updated alpha parameter for Beta prior"),
-												beta: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Updated beta parameter for Beta prior"),
-												mu: zod
-													.union([zod.array(zod.number()), zod.null()])
-													.optional()
-													.describe("Updated mean vector for Normal prior"),
-												covariance: zod
-													.union([
-														zod.array(zod.array(zod.number())),
-														zod.null(),
-													])
-													.optional()
-													.describe(
-														"Updated covariance matrix for Normal prior",
-													),
-											})
-											.describe(
-												"Describes an experiment arm for bandit experiments.",
-											),
-									)
-									.min(createExperimentResponseDesignSpecArmsMinFour)
-									.max(createExperimentResponseDesignSpecArmsMaxFour),
-								contexts: zod
-									.union([
-										zod
-											.array(
-												zod
-													.object({
-														context_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"Unique identifier for the context, you should NOT set this when creating a new context.",
-															),
-														context_name: zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecContextsItemContextNameMaxTwo,
-															),
-														context_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		createExperimentResponseDesignSpecContextsItemContextDescriptionMaxSeven,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														value_type: zod
-															.enum(["binary", "real-valued"])
-															.optional()
-															.describe("Enum for the type of context."),
-													})
-													.describe(
-														"Pydantic model for context of the experiment.",
-													),
-											)
-											.max(createExperimentResponseDesignSpecContextsMaxSeven),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-									),
-								prior_type: zod
-									.enum(["beta", "normal"])
-									.optional()
-									.describe("Enum for the prior distribution of the arm."),
-								reward_type: zod
-									.enum(["binary", "real-valued"])
-									.optional()
-									.describe(
-										"Enum for the likelihood distribution of the reward.",
-									),
-							})
-							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-							),
 					])
 					.describe("The specific type of bandit experiment design."),
 			])
@@ -5067,6 +4875,22 @@ export const createExperimentResponse = zod
 											.optional()
 											.describe(
 												"Absolute target value = metric_baseline*(1 + metric_pct_change)",
+											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 										metric_type: zod
 											.union([
@@ -5099,22 +4923,6 @@ export const createExperimentResponse = zod
 											.describe(
 												"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
 											),
-										icc: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Intracluster correlation coefficient for cluster-randomized designs.",
-											),
-										avg_cluster_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Average number of individuals per cluster."),
-										cv: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Coefficient of variation in cluster sizes (0 = equal sizes).",
-											),
 									})
 									.describe(
 										"Defines a metric to measure in an experiment with its baseline stats.",
@@ -5142,6 +4950,12 @@ export const createExperimentResponse = zod
 									.optional()
 									.describe(
 										"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+									),
+								pct_change_with_desired_n: zod
+									.union([zod.number(), zod.null()])
+									.optional()
+									.describe(
+										"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 									),
 								msg: zod
 									.union([
@@ -5178,6 +4992,7 @@ export const createExperimentResponse = zod
 														zod.null(),
 													])
 													.optional(),
+												high_cluster_variation: zod.boolean().optional(),
 											})
 											.describe(
 												"Describes interpretation of power analysis results.",
@@ -5399,6 +5214,22 @@ export const analyzeExperimentResponse = zod
 											.optional()
 											.describe(
 												"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 									})
 									.describe(
@@ -5732,6 +5563,22 @@ export const analyzeCmabExperimentResponse = zod
 											.describe(
 												"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
 											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
+											),
 									})
 									.describe(
 										"Defines a request to look up baseline stats for a metric to measure in an experiment.",
@@ -6037,6 +5884,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFi
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMax = 20;
 
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOne = 0;
+
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefault = 0.8;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMin = 0;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMax = 1;
@@ -6077,6 +5926,8 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecMetricsMaxOne
 export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFieldNameRegExpOne =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMaxOne = 20;
+
+export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinFour = 0;
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefaultOne = 0.8;
 export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMinOne = 0;
@@ -6128,27 +5979,9 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemC
 
 export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxFour = 150;
 
-export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxFour = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxFour = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxOnethree = 500;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxFour = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxOnethree = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinFour = 2;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxFour = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextNameMaxTwo = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxSeven = 150;
-
 export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesMax = 150;
 
 export const listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemArmArmNameMax = 100;
@@ -6287,6 +6120,12 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -6327,6 +6166,24 @@ export const listOrganizationExperimentsResponse = zod.object({
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -6372,10 +6229,17 @@ export const listOrganizationExperimentsResponse = zod.object({
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOne,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -6509,6 +6373,12 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -6549,6 +6419,24 @@ export const listOrganizationExperimentsResponse = zod.object({
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -6594,10 +6482,17 @@ export const listOrganizationExperimentsResponse = zod.object({
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinFour,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -7009,186 +6904,6 @@ export const listOrganizationExperimentsResponse = zod.object({
 									.describe(
 										"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 									),
-								zod
-									.object({
-										experiment_type: zod.enum(["bayes_ab_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxFour,
-											),
-										description: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxFour,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxOnethree,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxFour,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxOnethree,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-														alpha_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial alpha parameter for Beta prior",
-															),
-														beta_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial beta parameter for Beta prior",
-															),
-														mu_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial mean parameter for Normal prior",
-															),
-														sigma_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial standard deviation parameter for Normal prior",
-															),
-														alpha: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated alpha parameter for Beta prior",
-															),
-														beta: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated beta parameter for Beta prior",
-															),
-														mu: zod
-															.union([zod.array(zod.number()), zod.null()])
-															.optional()
-															.describe("Updated mean vector for Normal prior"),
-														covariance: zod
-															.union([
-																zod.array(zod.array(zod.number())),
-																zod.null(),
-															])
-															.optional()
-															.describe(
-																"Updated covariance matrix for Normal prior",
-															),
-													})
-													.describe(
-														"Describes an experiment arm for bandit experiments.",
-													),
-											)
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinFour,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxFour,
-											),
-										contexts: zod
-											.union([
-												zod
-													.array(
-														zod
-															.object({
-																context_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Unique identifier for the context, you should NOT set this when creating a new context.",
-																	),
-																context_name: zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextNameMaxTwo,
-																	),
-																context_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxSeven,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																value_type: zod
-																	.enum(["binary", "real-valued"])
-																	.optional()
-																	.describe("Enum for the type of context."),
-															})
-															.describe(
-																"Pydantic model for context of the experiment.",
-															),
-													)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxSeven,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-											),
-										prior_type: zod
-											.enum(["beta", "normal"])
-											.optional()
-											.describe("Enum for the prior distribution of the arm."),
-										reward_type: zod
-											.enum(["binary", "real-valued"])
-											.optional()
-											.describe(
-												"Enum for the likelihood distribution of the reward.",
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
 							])
 							.describe("The specific type of bandit experiment design."),
 					])
@@ -7217,6 +6932,24 @@ export const listOrganizationExperimentsResponse = zod.object({
 													.optional()
 													.describe(
 														"Absolute target value = metric_baseline*(1 + metric_pct_change)",
+													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 												metric_type: zod
 													.union([
@@ -7251,24 +6984,6 @@ export const listOrganizationExperimentsResponse = zod.object({
 													.describe(
 														"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
 													),
-												icc: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Intracluster correlation coefficient for cluster-randomized designs.",
-													),
-												avg_cluster_size: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Average number of individuals per cluster.",
-													),
-												cv: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Coefficient of variation in cluster sizes (0 = equal sizes).",
-													),
 											})
 											.describe(
 												"Defines a metric to measure in an experiment with its baseline stats.",
@@ -7296,6 +7011,12 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.optional()
 											.describe(
 												"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+											),
+										pct_change_with_desired_n: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 											),
 										msg: zod
 											.union([
@@ -7332,6 +7053,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 																zod.null(),
 															])
 															.optional(),
+														high_cluster_variation: zod.boolean().optional(),
 													})
 													.describe(
 														"Describes interpretation of power analysis results.",
@@ -7544,6 +7266,8 @@ export const getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegEx
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const getExperimentForUiResponseConfigDesignSpecFiltersMax = 20;
 
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinOne = 0;
+
 export const getExperimentForUiResponseConfigDesignSpecPowerDefault = 0.8;
 export const getExperimentForUiResponseConfigDesignSpecPowerMin = 0;
 export const getExperimentForUiResponseConfigDesignSpecPowerMax = 1;
@@ -7584,6 +7308,8 @@ export const getExperimentForUiResponseConfigDesignSpecMetricsMaxOne = 150;
 export const getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegExpOne =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
 export const getExperimentForUiResponseConfigDesignSpecFiltersMaxOne = 20;
+
+export const getExperimentForUiResponseConfigDesignSpecDesiredNMinFour = 0;
 
 export const getExperimentForUiResponseConfigDesignSpecPowerDefaultOne = 0.8;
 export const getExperimentForUiResponseConfigDesignSpecPowerMinOne = 0;
@@ -7635,27 +7361,9 @@ export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescri
 
 export const getExperimentForUiResponseConfigDesignSpecContextsMaxFour = 150;
 
-export const getExperimentForUiResponseConfigDesignSpecExperimentNameMaxFour = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecDescriptionMaxFour = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecDesignUrlMaxOnethree = 500;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxFour = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxOnethree = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsMinFour = 2;
-export const getExperimentForUiResponseConfigDesignSpecArmsMaxFour = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMaxTwo = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxSeven = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsMaxSeven = 150;
-
 export const getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const getExperimentForUiResponseConfigPowerAnalysesAnalysesMax = 150;
 
 export const getExperimentForUiResponseConfigAssignSummaryArmSizesItemArmArmNameMax = 100;
@@ -7795,6 +7503,12 @@ export const getExperimentForUiResponse = zod
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -7833,6 +7547,24 @@ export const getExperimentForUiResponse = zod
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -7874,10 +7606,17 @@ export const getExperimentForUiResponse = zod
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinOne,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -8001,6 +7740,12 @@ export const getExperimentForUiResponse = zod
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -8041,6 +7786,24 @@ export const getExperimentForUiResponse = zod
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -8086,10 +7849,17 @@ export const getExperimentForUiResponse = zod
 												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 											),
 										desired_n: zod
-											.union([zod.number(), zod.null()])
+											.union([
+												zod
+													.number()
+													.min(
+														getExperimentForUiResponseConfigDesignSpecDesiredNMinFour,
+													),
+												zod.null(),
+											])
 											.optional()
 											.describe(
-												"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 											),
 										power: zod
 											.number()
@@ -8499,186 +8269,6 @@ export const getExperimentForUiResponse = zod
 									.describe(
 										"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
 									),
-								zod
-									.object({
-										experiment_type: zod.enum(["bayes_ab_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecExperimentNameMaxFour,
-											),
-										description: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecDescriptionMaxFour,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecDesignUrlMaxOnethree,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxFour,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxOnethree,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-														alpha_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial alpha parameter for Beta prior",
-															),
-														beta_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial beta parameter for Beta prior",
-															),
-														mu_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial mean parameter for Normal prior",
-															),
-														sigma_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial standard deviation parameter for Normal prior",
-															),
-														alpha: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated alpha parameter for Beta prior",
-															),
-														beta: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated beta parameter for Beta prior",
-															),
-														mu: zod
-															.union([zod.array(zod.number()), zod.null()])
-															.optional()
-															.describe("Updated mean vector for Normal prior"),
-														covariance: zod
-															.union([
-																zod.array(zod.array(zod.number())),
-																zod.null(),
-															])
-															.optional()
-															.describe(
-																"Updated covariance matrix for Normal prior",
-															),
-													})
-													.describe(
-														"Describes an experiment arm for bandit experiments.",
-													),
-											)
-											.min(
-												getExperimentForUiResponseConfigDesignSpecArmsMinFour,
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecArmsMaxFour,
-											),
-										contexts: zod
-											.union([
-												zod
-													.array(
-														zod
-															.object({
-																context_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Unique identifier for the context, you should NOT set this when creating a new context.",
-																	),
-																context_name: zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMaxTwo,
-																	),
-																context_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxSeven,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																value_type: zod
-																	.enum(["binary", "real-valued"])
-																	.optional()
-																	.describe("Enum for the type of context."),
-															})
-															.describe(
-																"Pydantic model for context of the experiment.",
-															),
-													)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecContextsMaxSeven,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-											),
-										prior_type: zod
-											.enum(["beta", "normal"])
-											.optional()
-											.describe("Enum for the prior distribution of the arm."),
-										reward_type: zod
-											.enum(["binary", "real-valued"])
-											.optional()
-											.describe(
-												"Enum for the likelihood distribution of the reward.",
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with\nBayesian A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
 							])
 							.describe("The specific type of bandit experiment design."),
 					])
@@ -8707,6 +8297,24 @@ export const getExperimentForUiResponse = zod
 													.optional()
 													.describe(
 														"Absolute target value = metric_baseline*(1 + metric_pct_change)",
+													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 												metric_type: zod
 													.union([
@@ -8741,24 +8349,6 @@ export const getExperimentForUiResponse = zod
 													.describe(
 														"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
 													),
-												icc: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Intracluster correlation coefficient for cluster-randomized designs.",
-													),
-												avg_cluster_size: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Average number of individuals per cluster.",
-													),
-												cv: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Coefficient of variation in cluster sizes (0 = equal sizes).",
-													),
 											})
 											.describe(
 												"Defines a metric to measure in an experiment with its baseline stats.",
@@ -8786,6 +8376,12 @@ export const getExperimentForUiResponse = zod
 											.optional()
 											.describe(
 												"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+											),
+										pct_change_with_desired_n: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 											),
 										msg: zod
 											.union([
@@ -8822,6 +8418,7 @@ export const getExperimentForUiResponse = zod
 																zod.null(),
 															])
 															.optional(),
+														high_cluster_variation: zod.boolean().optional(),
 													})
 													.describe(
 														"Describes interpretation of power analysis results.",
@@ -9237,6 +8834,8 @@ export const powerCheckBodyDesignSpecFiltersItemFieldNameRegExp = new RegExp(
 );
 export const powerCheckBodyDesignSpecFiltersMax = 20;
 
+export const powerCheckBodyDesignSpecDesiredNMinOne = 0;
+
 export const powerCheckBodyDesignSpecPowerDefault = 0.8;
 export const powerCheckBodyDesignSpecPowerMin = 0;
 export const powerCheckBodyDesignSpecPowerMax = 1;
@@ -9281,6 +8880,8 @@ export const powerCheckBodyDesignSpecFiltersItemFieldNameRegExpOne = new RegExp(
 	"^[a-zA-Z_][a-zA-Z0-9_]*$",
 );
 export const powerCheckBodyDesignSpecFiltersMaxOne = 20;
+
+export const powerCheckBodyDesignSpecDesiredNMinFour = 0;
 
 export const powerCheckBodyDesignSpecPowerDefaultOne = 0.8;
 export const powerCheckBodyDesignSpecPowerMinOne = 0;
@@ -9363,6 +8964,12 @@ export const powerCheckBody = zod.object({
 						.describe(
 							"Column name in table_name that uniquely identifies each participant.",
 						),
+					cluster_key: zod
+						.union([zod.string(), zod.null()])
+						.optional()
+						.describe(
+							"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+						),
 					strata: zod
 						.array(
 							zod
@@ -9393,6 +9000,22 @@ export const powerCheckBody = zod.object({
 										.optional()
 										.describe(
 											"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+										),
+									icc: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Intracluster correlation coefficient for cluster-randomized designs.",
+										),
+									avg_cluster_size: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe("Average number of individuals per cluster."),
+									cv: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Coefficient of variation in cluster sizes (0 = equal sizes).",
 										),
 								})
 								.describe(
@@ -9430,10 +9053,13 @@ export const powerCheckBody = zod.object({
 							"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 						),
 					desired_n: zod
-						.union([zod.number(), zod.null()])
+						.union([
+							zod.number().min(powerCheckBodyDesignSpecDesiredNMinOne),
+							zod.null(),
+						])
 						.optional()
 						.describe(
-							"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+							"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 						),
 					power: zod
 						.number()
@@ -9531,6 +9157,12 @@ export const powerCheckBody = zod.object({
 						.describe(
 							"Column name in table_name that uniquely identifies each participant.",
 						),
+					cluster_key: zod
+						.union([zod.string(), zod.null()])
+						.optional()
+						.describe(
+							"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+						),
 					strata: zod
 						.array(
 							zod
@@ -9565,6 +9197,22 @@ export const powerCheckBody = zod.object({
 										.optional()
 										.describe(
 											"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+										),
+									icc: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Intracluster correlation coefficient for cluster-randomized designs.",
+										),
+									avg_cluster_size: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe("Average number of individuals per cluster."),
+									cv: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Coefficient of variation in cluster sizes (0 = equal sizes).",
 										),
 								})
 								.describe(
@@ -9604,10 +9252,13 @@ export const powerCheckBody = zod.object({
 							"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
 						),
 					desired_n: zod
-						.union([zod.number(), zod.null()])
+						.union([
+							zod.number().min(powerCheckBodyDesignSpecDesiredNMinFour),
+							zod.null(),
+						])
 						.optional()
 						.describe(
-							"Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.",
+							"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
 						),
 					power: zod
 						.number()
@@ -9643,6 +9294,7 @@ export const powerCheckBody = zod.object({
 
 export const powerCheckResponseAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const powerCheckResponseAnalysesItemMsgHighClusterVariationDefault = false;
 export const powerCheckResponseAnalysesMax = 150;
 
 export const powerCheckResponse = zod.object({
@@ -9666,6 +9318,22 @@ export const powerCheckResponse = zod.object({
 								.optional()
 								.describe(
 									"Absolute target value = metric_baseline*(1 + metric_pct_change)",
+								),
+							icc: zod
+								.union([zod.number(), zod.null()])
+								.optional()
+								.describe(
+									"Intracluster correlation coefficient for cluster-randomized designs.",
+								),
+							avg_cluster_size: zod
+								.union([zod.number(), zod.null()])
+								.optional()
+								.describe("Average number of individuals per cluster."),
+							cv: zod
+								.union([zod.number(), zod.null()])
+								.optional()
+								.describe(
+									"Coefficient of variation in cluster sizes (0 = equal sizes).",
 								),
 							metric_type: zod
 								.union([
@@ -9698,22 +9366,6 @@ export const powerCheckResponse = zod.object({
 								.describe(
 									"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
 								),
-							icc: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Intracluster correlation coefficient for cluster-randomized designs.",
-								),
-							avg_cluster_size: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe("Average number of individuals per cluster."),
-							cv: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Coefficient of variation in cluster sizes (0 = equal sizes).",
-								),
 						})
 						.describe(
 							"Defines a metric to measure in an experiment with its baseline stats.",
@@ -9739,6 +9391,12 @@ export const powerCheckResponse = zod.object({
 						.optional()
 						.describe(
 							"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
+						),
+					pct_change_with_desired_n: zod
+						.union([zod.number(), zod.null()])
+						.optional()
+						.describe(
+							"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
 						),
 					msg: zod
 						.union([
@@ -9773,6 +9431,7 @@ export const powerCheckResponse = zod.object({
 											zod.null(),
 										])
 										.optional(),
+									high_cluster_variation: zod.boolean().optional(),
 								})
 								.describe(
 									"Describes interpretation of power analysis results.",

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -48,7 +48,6 @@ export type AnyBanditDesignSpecInputExperimentType =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AnyBanditDesignSpecInputExperimentType = {
-	bayes_ab_online: "bayes_ab_online",
 	cmab_online: "cmab_online",
 	mab_online: "mab_online",
 } as const;
@@ -62,9 +61,6 @@ export type AnyBanditDesignSpecInput =
 	  })
 	| (CMABExperimentSpecInput & {
 			experiment_type: AnyBanditDesignSpecInputExperimentType;
-	  })
-	| (BayesABExperimentSpecInput & {
-			experiment_type: AnyBanditDesignSpecInputExperimentType;
 	  });
 
 export type AnyBanditDesignSpecOutputExperimentType =
@@ -72,7 +68,6 @@ export type AnyBanditDesignSpecOutputExperimentType =
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AnyBanditDesignSpecOutputExperimentType = {
-	bayes_ab_online: "bayes_ab_online",
 	cmab_online: "cmab_online",
 	mab_online: "mab_online",
 } as const;
@@ -85,9 +80,6 @@ export type AnyBanditDesignSpecOutput =
 			experiment_type: AnyBanditDesignSpecOutputExperimentType;
 	  })
 	| (CMABExperimentSpecOutput & {
-			experiment_type: AnyBanditDesignSpecOutputExperimentType;
-	  })
-	| (BayesABExperimentSpecOutput & {
 			experiment_type: AnyBanditDesignSpecOutputExperimentType;
 	  });
 
@@ -573,100 +565,6 @@ export interface BanditExperimentAnalysisResponse {
 	contexts?: BanditExperimentAnalysisResponseContexts;
 }
 
-export type BayesABExperimentSpecInputExperimentType =
-	(typeof BayesABExperimentSpecInputExperimentType)[keyof typeof BayesABExperimentSpecInputExperimentType];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BayesABExperimentSpecInputExperimentType = {
-	bayes_ab_online: "bayes_ab_online",
-} as const;
-
-/**
- * Optional URL to a more detailed experiment design doc.
- */
-export type BayesABExperimentSpecInputDesignUrl = string | null;
-
-/**
- * Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.
- */
-export type BayesABExperimentSpecInputContexts = Context[] | null;
-
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with
-Bayesian A/B experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
-export interface BayesABExperimentSpecInput {
-	experiment_type: BayesABExperimentSpecInputExperimentType;
-	/** @maxLength 100 */
-	experiment_name: string;
-	/** @maxLength 2000 */
-	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
-	design_url?: BayesABExperimentSpecInputDesignUrl;
-	start_date: string;
-	end_date: string;
-	/**
-	 * @minItems 2
-	 * @maxItems 20
-	 */
-	arms: ArmBandit[];
-	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
-	contexts?: BayesABExperimentSpecInputContexts;
-	/** The type of prior distribution for the arms. */
-	prior_type?: PriorTypes;
-	/** The type of reward we observe from the experiment. */
-	reward_type?: LikelihoodTypes;
-}
-
-export type BayesABExperimentSpecOutputExperimentType =
-	(typeof BayesABExperimentSpecOutputExperimentType)[keyof typeof BayesABExperimentSpecOutputExperimentType];
-
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export const BayesABExperimentSpecOutputExperimentType = {
-	bayes_ab_online: "bayes_ab_online",
-} as const;
-
-/**
- * Optional URL to a more detailed experiment design doc.
- */
-export type BayesABExperimentSpecOutputDesignUrl = string | null;
-
-/**
- * Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.
- */
-export type BayesABExperimentSpecOutputContexts = Context[] | null;
-
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with
-Bayesian A/B experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
-export interface BayesABExperimentSpecOutput {
-	experiment_type: BayesABExperimentSpecOutputExperimentType;
-	/** @maxLength 100 */
-	experiment_name: string;
-	/** @maxLength 2000 */
-	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
-	design_url?: BayesABExperimentSpecOutputDesignUrl;
-	start_date: string;
-	end_date: string;
-	/**
-	 * @minItems 2
-	 * @maxItems 20
-	 */
-	arms: ArmBandit[];
-	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
-	contexts?: BayesABExperimentSpecOutputContexts;
-	/** The type of prior distribution for the arms. */
-	prior_type?: PriorTypes;
-	/** The type of reward we observe from the experiment. */
-	reward_type?: LikelihoodTypes;
-}
-
 export type BqDsnInputType =
 	(typeof BqDsnInputType)[keyof typeof BqDsnInputType];
 
@@ -1142,6 +1040,21 @@ export type DesignSpecMetricMetricPctChange = number | null;
 export type DesignSpecMetricMetricTarget = number | null;
 
 /**
+ * Intracluster correlation coefficient for cluster-randomized designs.
+ */
+export type DesignSpecMetricIcc = number | null;
+
+/**
+ * Average number of individuals per cluster.
+ */
+export type DesignSpecMetricAvgClusterSize = number | null;
+
+/**
+ * Coefficient of variation in cluster sizes (0 = equal sizes).
+ */
+export type DesignSpecMetricCv = number | null;
+
+/**
  * Inferred from dwh type.
  */
 export type DesignSpecMetricMetricType = MetricType | null;
@@ -1167,21 +1080,6 @@ export type DesignSpecMetricAvailableNonnullN = number | null;
 export type DesignSpecMetricAvailableN = number | null;
 
 /**
- * Intracluster correlation coefficient for cluster-randomized designs.
- */
-export type DesignSpecMetricIcc = number | null;
-
-/**
- * Average number of individuals per cluster.
- */
-export type DesignSpecMetricAvgClusterSize = number | null;
-
-/**
- * Coefficient of variation in cluster sizes (0 = equal sizes).
- */
-export type DesignSpecMetricCv = number | null;
-
-/**
  * Defines a metric to measure in an experiment with its baseline stats.
  */
 export interface DesignSpecMetric {
@@ -1191,6 +1089,12 @@ export interface DesignSpecMetric {
 	metric_pct_change?: DesignSpecMetricMetricPctChange;
 	/** Absolute target value = metric_baseline*(1 + metric_pct_change) */
 	metric_target?: DesignSpecMetricMetricTarget;
+	/** Intracluster correlation coefficient for cluster-randomized designs. */
+	icc?: DesignSpecMetricIcc;
+	/** Average number of individuals per cluster. */
+	avg_cluster_size?: DesignSpecMetricAvgClusterSize;
+	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
+	cv?: DesignSpecMetricCv;
 	/** Inferred from dwh type. */
 	metric_type?: DesignSpecMetricMetricType;
 	/** Mean of the tracked metric. */
@@ -1201,12 +1105,6 @@ export interface DesignSpecMetric {
 	available_nonnull_n?: DesignSpecMetricAvailableNonnullN;
 	/** The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n. */
 	available_n?: DesignSpecMetricAvailableN;
-	/** Intracluster correlation coefficient for cluster-randomized designs. */
-	icc?: DesignSpecMetricIcc;
-	/** Average number of individuals per cluster. */
-	avg_cluster_size?: DesignSpecMetricAvgClusterSize;
-	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
-	cv?: DesignSpecMetricCv;
 }
 
 /**
@@ -1220,17 +1118,17 @@ export type DesignSpecMetricRequestMetricPctChange = number | null;
 export type DesignSpecMetricRequestMetricTarget = number | null;
 
 /**
- * Intracluster correlation coefficient for cluster-randomized designs. (Manually added; not regenerated yet from PR #163 BE.)
+ * Intracluster correlation coefficient for cluster-randomized designs.
  */
 export type DesignSpecMetricRequestIcc = number | null;
 
 /**
- * Average number of individuals per cluster. (Manually added; not regenerated yet from PR #163 BE.)
+ * Average number of individuals per cluster.
  */
 export type DesignSpecMetricRequestAvgClusterSize = number | null;
 
 /**
- * Coefficient of variation in cluster sizes (0 = equal sizes). (Manually added; not regenerated yet from PR #163 BE.)
+ * Coefficient of variation in cluster sizes (0 = equal sizes).
  */
 export type DesignSpecMetricRequestCv = number | null;
 
@@ -2058,6 +1956,11 @@ export type MetricPowerAnalysisInputTargetPossible = number | null;
 export type MetricPowerAnalysisInputPctChangePossible = number | null;
 
 /**
+ * The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).
+ */
+export type MetricPowerAnalysisInputPctChangeWithDesiredN = number | null;
+
+/**
  * Human friendly message about the above results.
  */
 export type MetricPowerAnalysisInputMsg = MetricPowerAnalysisMessage | null;
@@ -2100,6 +2003,8 @@ export interface MetricPowerAnalysisInput {
 	target_possible?: MetricPowerAnalysisInputTargetPossible;
 	/** If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	pct_change_possible?: MetricPowerAnalysisInputPctChangePossible;
+	/** The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs). */
+	pct_change_with_desired_n?: MetricPowerAnalysisInputPctChangeWithDesiredN;
 	/** Human friendly message about the above results. */
 	msg?: MetricPowerAnalysisInputMsg;
 	/** Total number of clusters needed across all arms */
@@ -2133,6 +2038,11 @@ export type MetricPowerAnalysisOutputTargetPossible = number | null;
  * If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.
  */
 export type MetricPowerAnalysisOutputPctChangePossible = number | null;
+
+/**
+ * The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).
+ */
+export type MetricPowerAnalysisOutputPctChangeWithDesiredN = number | null;
 
 /**
  * Human friendly message about the above results.
@@ -2177,6 +2087,8 @@ export interface MetricPowerAnalysisOutput {
 	target_possible?: MetricPowerAnalysisOutputTargetPossible;
 	/** If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	pct_change_possible?: MetricPowerAnalysisOutputPctChangePossible;
+	/** The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs). */
+	pct_change_with_desired_n?: MetricPowerAnalysisOutputPctChangeWithDesiredN;
 	/** Human friendly message about the above results. */
 	msg?: MetricPowerAnalysisOutputMsg;
 	/** Total number of clusters needed across all arms */
@@ -2208,6 +2120,7 @@ export interface MetricPowerAnalysisMessage {
 	/** Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages. */
 	source_msg: string;
 	values?: MetricPowerAnalysisMessageValues;
+	high_cluster_variation?: boolean;
 }
 
 /**
@@ -2269,7 +2182,12 @@ export const OnlineFrequentistExperimentSpecInputExperimentType = {
 export type OnlineFrequentistExperimentSpecInputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type OnlineFrequentistExperimentSpecInputClusterKey = string | null;
+
+/**
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type OnlineFrequentistExperimentSpecInputDesiredN = number | null;
 
@@ -2304,6 +2222,8 @@ export interface OnlineFrequentistExperimentSpecInput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: OnlineFrequentistExperimentSpecInputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2320,10 +2240,8 @@ export interface OnlineFrequentistExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	filters: FilterInput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: OnlineFrequentistExperimentSpecInputDesiredN;
-	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
-	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -2358,7 +2276,12 @@ export const OnlineFrequentistExperimentSpecOutputExperimentType = {
 export type OnlineFrequentistExperimentSpecOutputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type OnlineFrequentistExperimentSpecOutputClusterKey = string | null;
+
+/**
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type OnlineFrequentistExperimentSpecOutputDesiredN = number | null;
 
@@ -2393,6 +2316,8 @@ export interface OnlineFrequentistExperimentSpecOutput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: OnlineFrequentistExperimentSpecOutputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2409,10 +2334,8 @@ export interface OnlineFrequentistExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	filters: FilterOutput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: OnlineFrequentistExperimentSpecOutputDesiredN;
-	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
-	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -2560,7 +2483,12 @@ export const PreassignedFrequentistExperimentSpecInputExperimentType = {
 export type PreassignedFrequentistExperimentSpecInputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type PreassignedFrequentistExperimentSpecInputClusterKey = string | null;
+
+/**
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type PreassignedFrequentistExperimentSpecInputDesiredN = number | null;
 
@@ -2593,6 +2521,8 @@ export interface PreassignedFrequentistExperimentSpecInput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: PreassignedFrequentistExperimentSpecInputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2609,10 +2539,8 @@ export interface PreassignedFrequentistExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	filters: FilterInput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: PreassignedFrequentistExperimentSpecInputDesiredN;
-	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
-	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -2647,7 +2575,14 @@ export const PreassignedFrequentistExperimentSpecOutputExperimentType = {
 export type PreassignedFrequentistExperimentSpecOutputDesignUrl = string | null;
 
 /**
- * Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size.
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type PreassignedFrequentistExperimentSpecOutputClusterKey =
+	| string
+	| null;
+
+/**
+ * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type PreassignedFrequentistExperimentSpecOutputDesiredN = number | null;
 
@@ -2680,6 +2615,8 @@ export interface PreassignedFrequentistExperimentSpecOutput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: PreassignedFrequentistExperimentSpecOutputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2696,10 +2633,8 @@ export interface PreassignedFrequentistExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	filters: FilterOutput[];
-	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
+	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: PreassignedFrequentistExperimentSpecOutputDesiredN;
-	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
-	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -3197,10 +3132,6 @@ export type DeleteApiKeyParams = {
 };
 
 export type CreateExperimentParams = {
-	/**
-	 * Number of participants to assign.
-	 */
-	desired_n?: number | null;
 	/**
 	 * Whether to also stratify on metrics during assignment.
 	 */

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -1220,6 +1220,21 @@ export type DesignSpecMetricRequestMetricPctChange = number | null;
 export type DesignSpecMetricRequestMetricTarget = number | null;
 
 /**
+ * Intracluster correlation coefficient for cluster-randomized designs. (Manually added; not regenerated yet from PR #163 BE.)
+ */
+export type DesignSpecMetricRequestIcc = number | null;
+
+/**
+ * Average number of individuals per cluster. (Manually added; not regenerated yet from PR #163 BE.)
+ */
+export type DesignSpecMetricRequestAvgClusterSize = number | null;
+
+/**
+ * Coefficient of variation in cluster sizes (0 = equal sizes). (Manually added; not regenerated yet from PR #163 BE.)
+ */
+export type DesignSpecMetricRequestCv = number | null;
+
+/**
  * Defines a request to look up baseline stats for a metric to measure in an experiment.
  */
 export interface DesignSpecMetricRequest {
@@ -1229,6 +1244,12 @@ export interface DesignSpecMetricRequest {
 	metric_pct_change?: DesignSpecMetricRequestMetricPctChange;
 	/** Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change. */
 	metric_target?: DesignSpecMetricRequestMetricTarget;
+	/** Intracluster correlation coefficient for cluster-randomized designs. */
+	icc?: DesignSpecMetricRequestIcc;
+	/** Average number of individuals per cluster. */
+	avg_cluster_size?: DesignSpecMetricRequestAvgClusterSize;
+	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
+	cv?: DesignSpecMetricRequestCv;
 }
 
 /**
@@ -2301,6 +2322,8 @@ export interface OnlineFrequentistExperimentSpecInput {
 	filters: FilterInput[];
 	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
 	desired_n?: OnlineFrequentistExperimentSpecInputDesiredN;
+	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
+	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -2388,6 +2411,8 @@ export interface OnlineFrequentistExperimentSpecOutput {
 	filters: FilterOutput[];
 	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
 	desired_n?: OnlineFrequentistExperimentSpecOutputDesiredN;
+	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
+	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -2586,6 +2611,8 @@ export interface PreassignedFrequentistExperimentSpecInput {
 	filters: FilterInput[];
 	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
 	desired_n?: PreassignedFrequentistExperimentSpecInputDesiredN;
+	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
+	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
@@ -2671,6 +2698,8 @@ export interface PreassignedFrequentistExperimentSpecOutput {
 	filters: FilterOutput[];
 	/** Optional desired sample size for MDE calculation. If provided, calculates minimum detectable effect instead of required sample size. */
 	desired_n?: PreassignedFrequentistExperimentSpecOutputDesiredN;
+	/** Column name in table_name that identifies the cluster each participant belongs to. Set this to use cluster randomization. (Manually added; not regenerated yet from PR #163 BE.) */
+	cluster_column?: string | null;
 	/**
 	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -437,6 +437,25 @@ export default function ExperimentViewPage() {
 		mdePct = (selectedMetricAnalysis.metric.metric_pct_change * 100).toFixed(1);
 	}
 
+	// Achievable MDE: pulled from the saved power_analyses for the selected
+	// metric. Populated when the user picked a sample size other than the
+	// recommended minimum (the BE's MDE-mode response carries
+	// pct_change_possible alongside the committed N). For experiments that
+	// committed to the recommended size, this stays null and the badge just
+	// shows Target MDE as before.
+	let achievableMdePct: string | null = null;
+	if (selectedMetricAnalysis?.metric?.field_name) {
+		const savedAnalysis = power_analyses?.analyses?.find(
+			(a) =>
+				a.metric_spec.field_name ===
+				selectedMetricAnalysis.metric.field_name,
+		);
+		const pctPossible = savedAnalysis?.pct_change_possible;
+		if (pctPossible != null && Number.isFinite(pctPossible)) {
+			achievableMdePct = (pctPossible * 100).toFixed(2);
+		}
+	}
+
 	const { timeseriesData, armMetadata, minDate, maxDate } =
 		transformAnalysisForForestTimeseriesPlot(
 			analysisHistory,
@@ -564,6 +583,12 @@ export default function ExperimentViewPage() {
 								power={Math.round(power! * 100)}
 								desiredN={design_spec.desired_n ?? undefined}
 								assignSummary={assign_summary}
+								designEffect={
+									power_analyses?.analyses?.[0]?.design_effect ?? null
+								}
+								numClustersTotal={
+									power_analyses?.analyses?.[0]?.num_clusters_total ?? null
+								}
 							/>
 							<Separator orientation="vertical" />
 						</>
@@ -712,7 +737,7 @@ export default function ExperimentViewPage() {
 											)}
 										</Flex>
 									</Badge>
-									<MdeBadge value={mdePct} />
+									<MdeBadge value={mdePct} achievable={achievableMdePct} />
 									{/* Issue #217: show ICC pill for cluster-randomized experiments. */}
 									<IccBadge
 										value={

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -1,982 +1,805 @@
-"use client";
+'use client';
 import {
-	getGetExperimentForUiKey,
-	useAnalyzeCmabExperiment,
-	useAnalyzeExperiment,
-	useGetExperimentForUi,
-	useListSnapshots,
-	useUpdateExperiment,
-} from "@/api/admin";
+  getGetExperimentForUiKey,
+  useAnalyzeCmabExperiment,
+  useAnalyzeExperiment,
+  useGetExperimentForUi,
+  useListSnapshots,
+  useUpdateExperiment,
+} from '@/api/admin';
 import {
-	CMABContextInputRequest,
-	CMABExperimentSpecOutput,
-	ContextInput,
-	ExperimentAnalysisResponse,
-	MABExperimentSpecOutput,
-	MetricAnalysis,
-	Snapshot,
-} from "@/api/methods.schemas";
+  CMABContextInputRequest,
+  CMABExperimentSpecOutput,
+  ContextInput,
+  ExperimentAnalysisResponse,
+  MABExperimentSpecOutput,
+  MetricAnalysis,
+  Snapshot,
+} from '@/api/methods.schemas';
 import {
-	isBanditSpec,
-	isCmabExperiment,
-	isCmabSpec,
-	isFrequentistSpec,
-} from "@/app/experiments/create/experiment-form/experiment-form-types";
-import { ArmsAndAllocationsTable } from "@/components/features/experiments/arms-and-allocations-table";
-import { ContextConfigBox } from "@/components/features/experiments/context-config-box";
-import { DecisionAndImpactSection } from "@/components/features/experiments/decision-and-impact-section";
-import { DownloadAssignmentsCsvButton } from "@/components/features/experiments/download-assignments-csv-button";
-import { ExperimentCompletionCallout } from "@/components/features/experiments/experiment-completion-callout";
-import { ExperimentDetailsDropdownMenu } from "@/components/features/experiments/experiment-details-dropdown-menu";
-import { ExperimentStatusBadge } from "@/components/features/experiments/experiment-status-badge";
-import { ExperimentTypeBadge } from "@/components/features/experiments/experiment-type-badge";
-import { IntegrationGuideDialog } from "@/components/features/experiments/integration-guide-dialog";
-import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
-import { IccBadge } from "@/components/features/experiments/icc-badge";
-import { MdeBadge } from "@/components/features/experiments/mde-badge";
-import { ForestPlot } from "@/components/features/experiments/plots/forest-plot";
+  isBanditSpec,
+  isCmabExperiment,
+  isCmabSpec,
+  isFrequentistSpec,
+} from '@/app/experiments/create/experiment-form/experiment-form-types';
+import { ArmsAndAllocationsTable } from '@/components/features/experiments/arms-and-allocations-table';
+import { ContextConfigBox } from '@/components/features/experiments/context-config-box';
+import { DecisionAndImpactSection } from '@/components/features/experiments/decision-and-impact-section';
+import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
+import { ExperimentCompletionCallout } from '@/components/features/experiments/experiment-completion-callout';
+import { ExperimentDetailsDropdownMenu } from '@/components/features/experiments/experiment-details-dropdown-menu';
+import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
+import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
+import { IntegrationGuideDialog } from '@/components/features/experiments/integration-guide-dialog';
+import { isClusterDesign } from '@/components/features/experiments/cluster-detection';
+import { IccBadge } from '@/components/features/experiments/icc-badge';
+import { MdeBadge } from '@/components/features/experiments/mde-badge';
+import { ForestPlot } from '@/components/features/experiments/plots/forest-plot';
 import {
-	AnalysisState,
-	computeBoundsForMetric,
-	getAlphaAndPower,
-	isBanditAnalysis,
-	isFrequentistAnalysis,
-	precomputeBanditEffects,
-	precomputeFreqEffectsByMetric,
-	transformAnalysisForForestTimeseriesPlot,
-} from "@/components/features/experiments/plots/forest-plot-utils";
-import ForestTimeseriesPlot from "@/components/features/experiments/plots/forest-timeseries-plot";
-import { PowerAndBalanceDialog } from "@/components/features/experiments/power-and-balance-dialog";
-import { TargetingDialog } from "@/components/features/experiments/targeting-dialog";
-import { ParticipantTypeBadge } from "@/components/features/participants/participant-type-badge";
-import { TableNameBadge } from "@/components/features/participants/table-name-badge";
-import { CodeSnippetCard } from "@/components/ui/cards/code-snippet-card";
-import { SectionCard } from "@/components/ui/cards/section-card";
-import { GenericErrorCallout } from "@/components/ui/generic-error";
-import { EditableDateField } from "@/components/ui/inputs/editable-date-field";
-import { EditableTextArea } from "@/components/ui/inputs/editable-text-area";
-import { EditableTextField } from "@/components/ui/inputs/editable-text-field";
-import { ReadMoreText } from "@/components/ui/read-more-text";
-import { XSpinner } from "@/components/ui/x-spinner";
-import { useCurrentOrganization } from "@/providers/organization-provider";
+  AnalysisState,
+  computeBoundsForMetric,
+  getAlphaAndPower,
+  isBanditAnalysis,
+  isFrequentistAnalysis,
+  precomputeBanditEffects,
+  precomputeFreqEffectsByMetric,
+  transformAnalysisForForestTimeseriesPlot,
+} from '@/components/features/experiments/plots/forest-plot-utils';
+import ForestTimeseriesPlot from '@/components/features/experiments/plots/forest-timeseries-plot';
+import { PowerAndBalanceDialog } from '@/components/features/experiments/power-and-balance-dialog';
+import { TargetingDialog } from '@/components/features/experiments/targeting-dialog';
+import { ParticipantTypeBadge } from '@/components/features/participants/participant-type-badge';
+import { TableNameBadge } from '@/components/features/participants/table-name-badge';
+import { CodeSnippetCard } from '@/components/ui/cards/code-snippet-card';
+import { SectionCard } from '@/components/ui/cards/section-card';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { EditableDateField } from '@/components/ui/inputs/editable-date-field';
+import { EditableTextArea } from '@/components/ui/inputs/editable-text-area';
+import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
+import { ReadMoreText } from '@/components/ui/read-more-text';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { useCurrentOrganization } from '@/providers/organization-provider';
+import { extractUtcHHMMLabel, formatUtcDownToMinuteLabel } from '@/services/date-utils';
+import { getExperimentStatus } from '@/services/experiment-utils';
+import { prettyJSON } from '@/services/json-utils';
 import {
-	extractUtcHHMMLabel,
-	formatUtcDownToMinuteLabel,
-} from "@/services/date-utils";
-import { getExperimentStatus } from "@/services/experiment-utils";
-import { prettyJSON } from "@/services/json-utils";
-import {
-	ActivityLogIcon,
-	CalendarIcon,
-	CodeIcon,
-	ExclamationTriangleIcon,
-	FileTextIcon,
-	InfoCircledIcon,
-	PersonIcon,
-} from "@radix-ui/react-icons";
-import {
-	Badge,
-	Box,
-	Flex,
-	Heading,
-	Select,
-	Separator,
-	Tabs,
-	Text,
-	Tooltip,
-} from "@radix-ui/themes";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { useState } from "react";
-import { mutate } from "swr";
+  ActivityLogIcon,
+  CalendarIcon,
+  CodeIcon,
+  ExclamationTriangleIcon,
+  FileTextIcon,
+  InfoCircledIcon,
+  PersonIcon,
+} from '@radix-ui/react-icons';
+import { Badge, Box, Flex, Heading, Select, Separator, Tabs, Text, Tooltip } from '@radix-ui/themes';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import { mutate } from 'swr';
 
 const SNAPSHOT_ERROR_ALERT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
 export default function ExperimentViewPage() {
-	const params = useParams();
-	const orgCtx = useCurrentOrganization();
-	const organizationId = orgCtx?.current.id || "";
-	const datasourceId = (params.datasourceId as string) || "";
-	const experimentId = (params.experimentId as string) || "";
-	const [lastErrorTimestamp, setLastErrorTimestamp] = useState<null | Date>(
-		null,
-	);
+  const params = useParams();
+  const orgCtx = useCurrentOrganization();
+  const organizationId = orgCtx?.current.id || '';
+  const datasourceId = (params.datasourceId as string) || '';
+  const experimentId = (params.experimentId as string) || '';
+  const [lastErrorTimestamp, setLastErrorTimestamp] = useState<null | Date>(null);
 
-	const [analysisHistory, setAnalysisHistory] = useState<AnalysisState[]>([]);
-	const [liveAnalysis, setLiveAnalysis] = useState<AnalysisState>({
-		key: "live",
-		data: undefined,
-		updated_at: new Date(),
-		label: "No live data yet",
-		effectSizesByMetric: undefined,
-		banditEffects: undefined,
-	});
-	// which analysis we're actually displaying (live or a snapshot)
-	const [selectedAnalysisState, setSelectedAnalysisState] =
-		useState<AnalysisState>(liveAnalysis);
-	const [selectedMetricAnalysis, setSelectedMetricAnalysis] =
-		useState<MetricAnalysis | null>(null);
-	const [selectedMetricName, setSelectedMetricName] =
-		useState<string>("unknown");
-	const [cmabAnalysisRequest, setCmabAnalysisRequest] =
-		useState<CMABContextInputRequest>({
-			type: "cmab_assignment",
-			context_inputs: [],
-		});
-	const cmabContextInputs = cmabAnalysisRequest.context_inputs ?? [];
+  const [analysisHistory, setAnalysisHistory] = useState<AnalysisState[]>([]);
+  const [liveAnalysis, setLiveAnalysis] = useState<AnalysisState>({
+    key: 'live',
+    data: undefined,
+    updated_at: new Date(),
+    label: 'No live data yet',
+    effectSizesByMetric: undefined,
+    banditEffects: undefined,
+  });
+  // which analysis we're actually displaying (live or a snapshot)
+  const [selectedAnalysisState, setSelectedAnalysisState] = useState<AnalysisState>(liveAnalysis);
+  const [selectedMetricAnalysis, setSelectedMetricAnalysis] = useState<MetricAnalysis | null>(null);
+  const [selectedMetricName, setSelectedMetricName] = useState<string>('unknown');
+  const [cmabAnalysisRequest, setCmabAnalysisRequest] = useState<CMABContextInputRequest>({
+    type: 'cmab_assignment',
+    context_inputs: [],
+  });
+  const cmabContextInputs = cmabAnalysisRequest.context_inputs ?? [];
 
-	// Track the min/max CI bounds across a recent window of snapshots for more stable forest plot display.
-	const [ciBounds, setCiBounds] = useState<
-		[number | undefined, number | undefined]
-	>([undefined, undefined]);
+  // Track the min/max CI bounds across a recent window of snapshots for more stable forest plot display.
+  const [ciBounds, setCiBounds] = useState<[number | undefined, number | undefined]>([undefined, undefined]);
 
-	const {
-		data: experiment,
-		isLoading: isLoadingExperiment,
-		error: experimentError,
-	} = useGetExperimentForUi(datasourceId, experimentId, {
-		swr: {
-			enabled: !!datasourceId,
-			onSuccess: (expForUi) => {
-				const expConfig = expForUi.config;
-				// Only initialize context input ids for CMAB experiments if they are not already set.
-				// Should only need to set this once for an experiment, as they are fixed at design time.
-				if (
-					isCmabSpec(expConfig.design_spec) &&
-					expConfig.design_spec.contexts &&
-					cmabContextInputs.length === 0
-				) {
-					const contextInputs = expConfig.design_spec.contexts
-						.filter((ctx) => ctx.context_id !== undefined)
-						.map((ctx) => ({
-							context_id: ctx.context_id!,
-							context_value: 0.0,
-						}));
-					setCmabAnalysisRequest({
-						...cmabAnalysisRequest,
-						context_inputs: contextInputs,
-					});
-				}
-			},
-		},
-	});
+  const {
+    data: experiment,
+    isLoading: isLoadingExperiment,
+    error: experimentError,
+  } = useGetExperimentForUi(datasourceId, experimentId, {
+    swr: {
+      enabled: !!datasourceId,
+      onSuccess: (expForUi) => {
+        const expConfig = expForUi.config;
+        // Only initialize context input ids for CMAB experiments if they are not already set.
+        // Should only need to set this once for an experiment, as they are fixed at design time.
+        if (isCmabSpec(expConfig.design_spec) && expConfig.design_spec.contexts && cmabContextInputs.length === 0) {
+          const contextInputs = expConfig.design_spec.contexts
+            .filter((ctx) => ctx.context_id !== undefined)
+            .map((ctx) => ({
+              context_id: ctx.context_id!,
+              context_value: 0.0,
+            }));
+          setCmabAnalysisRequest({
+            ...cmabAnalysisRequest,
+            context_inputs: contextInputs,
+          });
+        }
+      },
+    },
+  });
 
-	const {
-		mutate: analyzeLive,
-		data: analyzeExperimentData,
-		isLoading: isLoadingLiveAnalysis,
-		error: liveAnalysisError,
-	} = useAnalyzeExperiment(datasourceId, experimentId, undefined, {
-		swr: {
-			enabled:
-				!!datasourceId && !!experiment && !isCmabExperiment(experiment.config),
-			// Disable revalidation to only allow manual triggering of the live analysis
-			revalidateIfStale: false,
-			revalidateOnFocus: false,
-			revalidateOnMount: false,
-			revalidateOnReconnect: false,
-			shouldRetryOnError: false,
-			onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
-		},
-	});
+  const {
+    mutate: analyzeLive,
+    data: analyzeExperimentData,
+    isLoading: isLoadingLiveAnalysis,
+    error: liveAnalysisError,
+  } = useAnalyzeExperiment(datasourceId, experimentId, undefined, {
+    swr: {
+      enabled: !!datasourceId && !!experiment && !isCmabExperiment(experiment.config),
+      // Disable revalidation to only allow manual triggering of the live analysis
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+      revalidateOnReconnect: false,
+      shouldRetryOnError: false,
+      onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
+    },
+  });
 
-	const {
-		trigger: analyzeLiveCmab,
-		data: analyzeCmabExperimentData,
-		isMutating: isLoadingLiveCmabAnalysis,
-		error: liveCmabAnalysisError,
-	} = useAnalyzeCmabExperiment(datasourceId, experimentId, {
-		swr: {
-			onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
-		},
-	});
+  const {
+    trigger: analyzeLiveCmab,
+    data: analyzeCmabExperimentData,
+    isMutating: isLoadingLiveCmabAnalysis,
+    error: liveCmabAnalysisError,
+  } = useAnalyzeCmabExperiment(datasourceId, experimentId, {
+    swr: {
+      onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
+    },
+  });
 
-	const { isLoading: isLoadingHistory, error: analysisHistoryError } =
-		useListSnapshots(
-			organizationId,
-			datasourceId,
-			experimentId,
-			{ status: ["success"] },
-			{
-				swr: {
-					enabled:
-						!!organizationId &&
-						!!datasourceId &&
-						!!experimentId &&
-						!!experiment,
-					shouldRetryOnError: false,
-					focusThrottleInterval: 15 * 60_000, // refresh on focus after 15 minutes
-					onSuccess: async (data) => {
-						// Make human-readable labels for the dropdown, showing UTC down to the minute.
-						// Use the snapshot ID as the key, looking up the analysisState by ID upon selection.
+  const { isLoading: isLoadingHistory, error: analysisHistoryError } = useListSnapshots(
+    organizationId,
+    datasourceId,
+    experimentId,
+    { status: ['success'] },
+    {
+      swr: {
+        enabled: !!organizationId && !!datasourceId && !!experimentId && !!experiment,
+        shouldRetryOnError: false,
+        focusThrottleInterval: 15 * 60_000, // refresh on focus after 15 minutes
+        onSuccess: async (data) => {
+          // Make human-readable labels for the dropdown, showing UTC down to the minute.
+          // Use the snapshot ID as the key, looking up the analysisState by ID upon selection.
 
-						// Do live analysis if there are no snapshots and we don't have live analysis data already. This avoids
-						// duplicating a potentially expensive query when useListSnapshots runs.
-						if (data.items.length === 0) {
-							// No snapshots. First check if we have (cached) live analysis data. If so, use that for display.
-							if (
-								isCmabExperiment(experiment?.config) &&
-								analyzeCmabExperimentData !== undefined
-							) {
-								handleLiveAnalysisSuccess(analyzeCmabExperimentData);
-							} else if (analyzeExperimentData !== undefined) {
-								handleLiveAnalysisSuccess(analyzeExperimentData);
-							} else {
-								await triggerLiveAnalysis();
-							}
-							return;
-						}
+          // Do live analysis if there are no snapshots and we don't have live analysis data already. This avoids
+          // duplicating a potentially expensive query when useListSnapshots runs.
+          if (data.items.length === 0) {
+            // No snapshots. First check if we have (cached) live analysis data. If so, use that for display.
+            if (isCmabExperiment(experiment?.config) && analyzeCmabExperimentData !== undefined) {
+              handleLiveAnalysisSuccess(analyzeCmabExperimentData);
+            } else if (analyzeExperimentData !== undefined) {
+              handleLiveAnalysisSuccess(analyzeExperimentData);
+            } else {
+              await triggerLiveAnalysis();
+            }
+            return;
+          }
 
-						// Group snapshots by date and keep only the most recent one per date
-						const snapshotsByDate = new Map<string, Snapshot>();
+          // Group snapshots by date and keep only the most recent one per date
+          const snapshotsByDate = new Map<string, Snapshot>();
 
-						for (const s of data.items) {
-							const dateKey = s.updated_at.split("T")[0]; // Get YYYY-MM-DD from ISO string
-							const existing = snapshotsByDate.get(dateKey);
-							if (!existing || s.updated_at > existing.updated_at) {
-								snapshotsByDate.set(dateKey, s);
-							}
-						}
+          for (const s of data.items) {
+            const dateKey = s.updated_at.split('T')[0]; // Get YYYY-MM-DD from ISO string
+            const existing = snapshotsByDate.get(dateKey);
+            if (!existing || s.updated_at > existing.updated_at) {
+              snapshotsByDate.set(dateKey, s);
+            }
+          }
 
-						// Convert to array
-						const filteredSnapshots = Array.from(snapshotsByDate.values());
-						const history: AnalysisState[] = filteredSnapshots.map((s) => {
-							// The results are guaranteed to be non-null because of the status filter.
-							const analysisData = s.data as ExperimentAnalysisResponse;
-							const date = new Date(s.updated_at);
-							return {
-								key: s.id,
-								data: analysisData,
-								updated_at: date,
-								label: formatUtcDownToMinuteLabel(date),
-								effectSizesByMetric: precomputeFreqEffectsByMetric(
-									analysisData,
-									alpha,
-								),
-								banditEffects: precomputeBanditEffects(analysisData),
-							};
-						});
+          // Convert to array
+          const filteredSnapshots = Array.from(snapshotsByDate.values());
+          const history: AnalysisState[] = filteredSnapshots.map((s) => {
+            // The results are guaranteed to be non-null because of the status filter.
+            const analysisData = s.data as ExperimentAnalysisResponse;
+            const date = new Date(s.updated_at);
+            return {
+              key: s.id,
+              data: analysisData,
+              updated_at: date,
+              label: formatUtcDownToMinuteLabel(date),
+              effectSizesByMetric: precomputeFreqEffectsByMetric(analysisData, alpha),
+              banditEffects: precomputeBanditEffects(analysisData),
+            };
+          });
 
-						setLastErrorTimestamp(
-							data.latest_failure === null
-								? null
-								: new Date(data.latest_failure),
-						);
-						setAnalysisHistory(history);
-						// If we're not viewing real data, set the selected analysis to the most recent snapshot
-						if (selectedAnalysisState.data === undefined) {
-							handleSelectedAnalysisAndMetrics(
-								history[0],
-								selectedMetricName,
-								history,
-							);
-						}
-					},
-					onError: async () => {
-						// Trigger live analysis if snapshot loading fails
-						await triggerLiveAnalysis();
-					},
-				},
-			},
-		);
+          setLastErrorTimestamp(data.latest_failure === null ? null : new Date(data.latest_failure));
+          setAnalysisHistory(history);
+          // If we're not viewing real data, set the selected analysis to the most recent snapshot
+          if (selectedAnalysisState.data === undefined) {
+            handleSelectedAnalysisAndMetrics(history[0], selectedMetricName, history);
+          }
+        },
+        onError: async () => {
+          // Trigger live analysis if snapshot loading fails
+          await triggerLiveAnalysis();
+        },
+      },
+    },
+  );
 
-	const { trigger: updateExperiment } = useUpdateExperiment(
-		datasourceId,
-		experimentId,
-		{
-			swr: {
-				onSuccess: async () => {
-					await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
-				},
-			},
-		},
-	);
+  const { trigger: updateExperiment } = useUpdateExperiment(datasourceId, experimentId, {
+    swr: {
+      onSuccess: async () => {
+        await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
+      },
+    },
+  });
 
-	const handleSelectedAnalysisAndMetrics = (
-		analysis: AnalysisState,
-		forMetricName: string | undefined = undefined,
-		historyOverride: AnalysisState[] | undefined = undefined,
-	) => {
-		setSelectedAnalysisState(analysis);
-		if (!isFrequentistAnalysis(analysis.data)) {
-			setSelectedMetricAnalysis(null);
-			return;
-		}
+  const handleSelectedAnalysisAndMetrics = (
+    analysis: AnalysisState,
+    forMetricName: string | undefined = undefined,
+    historyOverride: AnalysisState[] | undefined = undefined,
+  ) => {
+    setSelectedAnalysisState(analysis);
+    if (!isFrequentistAnalysis(analysis.data)) {
+      setSelectedMetricAnalysis(null);
+      return;
+    }
 
-		// Try to maintain the same metric as before when switching between snapshots.
-		// The fallback to the first metric should not actually happen in practice.
-		const nameToFind = forMetricName || selectedMetricName;
-		const metricAnalyses = analysis.data.metric_analyses;
-		const newMetric: MetricAnalysis | null =
-			metricAnalyses.find((metric) => metric.metric_name === nameToFind) ||
-			metricAnalyses[0] ||
-			null;
-		const newMetricName = newMetric?.metric_name || "unknown";
-		// Recompute bounds if the metric changed
-		if (selectedMetricName !== newMetricName) {
-			setSelectedMetricName(newMetricName);
+    // Try to maintain the same metric as before when switching between snapshots.
+    // The fallback to the first metric should not actually happen in practice.
+    const nameToFind = forMetricName || selectedMetricName;
+    const metricAnalyses = analysis.data.metric_analyses;
+    const newMetric: MetricAnalysis | null =
+      metricAnalyses.find((metric) => metric.metric_name === nameToFind) || metricAnalyses[0] || null;
+    const newMetricName = newMetric?.metric_name || 'unknown';
+    // Recompute bounds if the metric changed
+    if (selectedMetricName !== newMetricName) {
+      setSelectedMetricName(newMetricName);
 
-			// First make a copy since we may mutate contents by adding live data.
-			const snapshotsToUse = [...(historyOverride || analysisHistory)];
-			// Include the live analysis if it has data.
-			if (analysis.key === "live" && analysis.data) {
-				snapshotsToUse.push(analysis);
-			} else if (liveAnalysis.data) {
-				snapshotsToUse.push(liveAnalysis);
-			}
-			const bounds = computeBoundsForMetric(newMetricName, snapshotsToUse);
-			setCiBounds(bounds);
-		}
-		setSelectedMetricAnalysis(newMetric);
-	};
+      // First make a copy since we may mutate contents by adding live data.
+      const snapshotsToUse = [...(historyOverride || analysisHistory)];
+      // Include the live analysis if it has data.
+      if (analysis.key === 'live' && analysis.data) {
+        snapshotsToUse.push(analysis);
+      } else if (liveAnalysis.data) {
+        snapshotsToUse.push(liveAnalysis);
+      }
+      const bounds = computeBoundsForMetric(newMetricName, snapshotsToUse);
+      setCiBounds(bounds);
+    }
+    setSelectedMetricAnalysis(newMetric);
+  };
 
-	// Wrapper around the live analysis functions for CMAB and non-CMAB experiments.
-	const triggerLiveAnalysis = async (
-		requestOverride?: CMABContextInputRequest,
-	) => {
-		const request = requestOverride ?? cmabAnalysisRequest;
-		return isCmabExperiment(experiment?.config)
-			? await analyzeLiveCmab(request)
-			: await analyzeLive();
-	};
+  // Wrapper around the live analysis functions for CMAB and non-CMAB experiments.
+  const triggerLiveAnalysis = async (requestOverride?: CMABContextInputRequest) => {
+    const request = requestOverride ?? cmabAnalysisRequest;
+    return isCmabExperiment(experiment?.config) ? await analyzeLiveCmab(request) : await analyzeLive();
+  };
 
-	const handleLiveAnalysisSuccess = (
-		analysisData: ExperimentAnalysisResponse,
-	) => {
-		const date = new Date();
-		const analysis: AnalysisState = {
-			key: "live",
-			data: analysisData,
-			updated_at: date,
-			label: `LIVE as of ${extractUtcHHMMLabel(date)}`,
-			effectSizesByMetric: precomputeFreqEffectsByMetric(analysisData, alpha),
-			banditEffects: precomputeBanditEffects(analysisData),
-		};
-		setLiveAnalysis(analysis);
-		// Only update the display if we were previously viewing live data.
-		if (selectedAnalysisState.key === "live") {
-			handleSelectedAnalysisAndMetrics(analysis);
-		}
-	};
+  const handleLiveAnalysisSuccess = (analysisData: ExperimentAnalysisResponse) => {
+    const date = new Date();
+    const analysis: AnalysisState = {
+      key: 'live',
+      data: analysisData,
+      updated_at: date,
+      label: `LIVE as of ${extractUtcHHMMLabel(date)}`,
+      effectSizesByMetric: precomputeFreqEffectsByMetric(analysisData, alpha),
+      banditEffects: precomputeBanditEffects(analysisData),
+    };
+    setLiveAnalysis(analysis);
+    // Only update the display if we were previously viewing live data.
+    if (selectedAnalysisState.key === 'live') {
+      handleSelectedAnalysisAndMetrics(analysis);
+    }
+  };
 
-	const handleSelectAnalysis = async (key: string) => {
-		if (key === "live") {
-			// If we haven't fetched it yet, trigger a live analysis.
-			if (liveAnalysis.data === undefined) {
-				await triggerLiveAnalysis();
-			}
-			handleSelectedAnalysisAndMetrics(liveAnalysis);
-		} else {
-			const analysis =
-				analysisHistory.find((opt) => opt.key === key) || liveAnalysis;
-			handleSelectedAnalysisAndMetrics(analysis);
-		}
-	};
+  const handleSelectAnalysis = async (key: string) => {
+    if (key === 'live') {
+      // If we haven't fetched it yet, trigger a live analysis.
+      if (liveAnalysis.data === undefined) {
+        await triggerLiveAnalysis();
+      }
+      handleSelectedAnalysisAndMetrics(liveAnalysis);
+    } else {
+      const analysis = analysisHistory.find((opt) => opt.key === key) || liveAnalysis;
+      handleSelectedAnalysisAndMetrics(analysis);
+    }
+  };
 
-	const handleUpdateCmabContextValue = async (
-		key: string,
-		context_inputs: ContextInput[],
-	) => {
-		if (key === "live") {
-			const updatedRequest = {
-				...cmabAnalysisRequest,
-				context_inputs: context_inputs,
-			};
-			setCmabAnalysisRequest(updatedRequest);
-			await triggerLiveAnalysis(updatedRequest);
-		} else {
-			console.warn("Cannot update context values for snapshot analyses.");
-		}
-	};
+  const handleUpdateCmabContextValue = async (key: string, context_inputs: ContextInput[]) => {
+    if (key === 'live') {
+      const updatedRequest = {
+        ...cmabAnalysisRequest,
+        context_inputs: context_inputs,
+      };
+      setCmabAnalysisRequest(updatedRequest);
+      await triggerLiveAnalysis(updatedRequest);
+    } else {
+      console.warn('Cannot update context values for snapshot analyses.');
+    }
+  };
 
-	const showLoadingAnalysisSpinner =
-		isLoadingLiveAnalysis || isLoadingLiveCmabAnalysis || isLoadingHistory;
+  const showLoadingAnalysisSpinner = isLoadingLiveAnalysis || isLoadingLiveCmabAnalysis || isLoadingHistory;
 
-	if (isLoadingExperiment) {
-		return <XSpinner message="Loading experiment details..." />;
-	}
+  if (isLoadingExperiment) {
+    return <XSpinner message="Loading experiment details..." />;
+  }
 
-	if (experimentError) {
-		return (
-			<GenericErrorCallout
-				title="Error loading experiment"
-				error={experimentError}
-			/>
-		);
-	}
+  if (experimentError) {
+    return <GenericErrorCallout title="Error loading experiment" error={experimentError} />;
+  }
 
-	if (!experiment) {
-		return <Text>No experiment data found</Text>;
-	}
+  if (!experiment) {
+    return <Text>No experiment data found</Text>;
+  }
 
-	const { design_spec, assign_summary, decision, impact, power_analyses } =
-		experiment.config;
-	const { alpha, power } = getAlphaAndPower(experiment.config); // undefined for non-frequentist experiments
-	const {
-		experiment_name,
-		description,
-		start_date,
-		end_date,
-		arms,
-		design_url,
-	} = design_spec;
-	const isFrequentistExperiment = isFrequentistSpec(design_spec);
-	const contexts = isBanditSpec(design_spec)
-		? (design_spec.contexts ?? [])
-		: [];
+  const { design_spec, assign_summary, decision, impact, power_analyses } = experiment.config;
+  const { alpha, power } = getAlphaAndPower(experiment.config); // undefined for non-frequentist experiments
+  const { experiment_name, description, start_date, end_date, arms, design_url } = design_spec;
+  const isFrequentistExperiment = isFrequentistSpec(design_spec);
+  const contexts = isBanditSpec(design_spec) ? (design_spec.contexts ?? []) : [];
 
-	const selectedMetricAnalyses =
-		selectedAnalysisState.data &&
-		"metric_analyses" in selectedAnalysisState.data
-			? selectedAnalysisState.data.metric_analyses
-			: null;
+  const selectedMetricAnalyses =
+    selectedAnalysisState.data && 'metric_analyses' in selectedAnalysisState.data
+      ? selectedAnalysisState.data.metric_analyses
+      : null;
 
-	// Calculate MDE percentage for the selected metric
-	let mdePct: string | null = null;
-	if (selectedMetricAnalysis?.metric?.metric_pct_change) {
-		mdePct = (selectedMetricAnalysis.metric.metric_pct_change * 100).toFixed(1);
-	}
+  // Calculate MDE percentage for the selected metric
+  let mdePct: string | null = null;
+  if (selectedMetricAnalysis?.metric?.metric_pct_change) {
+    mdePct = (selectedMetricAnalysis.metric.metric_pct_change * 100).toFixed(1);
+  }
 
-	// Achievable MDE: pulled from the saved power_analyses for the selected
-	// metric. Populated when the user picked a sample size other than the
-	// recommended minimum (the BE's MDE-mode response carries
-	// pct_change_possible alongside the committed N). For experiments that
-	// committed to the recommended size, this stays null and the badge just
-	// shows Target MDE as before.
-	let achievableMdePct: string | null = null;
-	if (selectedMetricAnalysis?.metric?.field_name) {
-		const savedAnalysis = power_analyses?.analyses?.find(
-			(a) =>
-				a.metric_spec.field_name ===
-				selectedMetricAnalysis.metric.field_name,
-		);
-		const pctPossible = savedAnalysis?.pct_change_possible;
-		if (pctPossible != null && Number.isFinite(pctPossible)) {
-			achievableMdePct = (pctPossible * 100).toFixed(2);
-		}
-	}
+  // Achievable MDE: pulled from the saved power_analyses for the selected
+  // metric. Populated when the user picked a sample size other than the
+  // recommended minimum (the BE's MDE-mode response carries
+  // pct_change_possible alongside the committed N). For experiments that
+  // committed to the recommended size, this stays null and the badge just
+  // shows Target MDE as before.
+  let achievableMdePct: string | null = null;
+  if (selectedMetricAnalysis?.metric?.field_name) {
+    const savedAnalysis = power_analyses?.analyses?.find(
+      (a) => a.metric_spec.field_name === selectedMetricAnalysis.metric.field_name,
+    );
+    const pctPossible = savedAnalysis?.pct_change_possible;
+    if (pctPossible != null && Number.isFinite(pctPossible)) {
+      achievableMdePct = (pctPossible * 100).toFixed(2);
+    }
+  }
 
-	const { timeseriesData, armMetadata, minDate, maxDate } =
-		transformAnalysisForForestTimeseriesPlot(
-			analysisHistory,
-			selectedMetricName,
-		);
+  const { timeseriesData, armMetadata, minDate, maxDate } = transformAnalysisForForestTimeseriesPlot(
+    analysisHistory,
+    selectedMetricName,
+  );
 
-	const isLastSnapshotErrorRelevant =
-		lastErrorTimestamp !== null &&
-		Date.now() - lastErrorTimestamp.getTime() <=
-			SNAPSHOT_ERROR_ALERT_THRESHOLD_MS;
+  const isLastSnapshotErrorRelevant =
+    lastErrorTimestamp !== null && Date.now() - lastErrorTimestamp.getTime() <= SNAPSHOT_ERROR_ALERT_THRESHOLD_MS;
 
-	return (
-		<Flex direction="column" gap="6">
-			<Flex direction="column" gap="3">
-				<Flex direction="row" justify="between" gap="2" align="center">
-					<EditableTextField
-						value={experiment_name}
-						onSubmit={(value) => updateExperiment({ name: value })}
-						size="2"
-					>
-						<Heading size="8">{experiment_name}</Heading>
-					</EditableTextField>
-					<Flex gap="2" align="center">
-						<IntegrationGuideDialog
-							experimentId={experimentId}
-							datasourceId={datasourceId}
-							organizationId={organizationId}
-							arms={arms}
-							contexts={contexts}
-						/>
-						<ExperimentDetailsDropdownMenu
-							datasourceId={datasourceId}
-							experimentId={experimentId}
-						/>
-					</Flex>
-				</Flex>
+  return (
+    <Flex direction="column" gap="6">
+      <Flex direction="column" gap="3">
+        <Flex direction="row" justify="between" gap="2" align="center">
+          <EditableTextField value={experiment_name} onSubmit={(value) => updateExperiment({ name: value })} size="2">
+            <Heading size="8">{experiment_name}</Heading>
+          </EditableTextField>
+          <Flex gap="2" align="center">
+            <IntegrationGuideDialog
+              experimentId={experimentId}
+              datasourceId={datasourceId}
+              organizationId={organizationId}
+              arms={arms}
+              contexts={contexts}
+            />
+            <ExperimentDetailsDropdownMenu datasourceId={datasourceId} experimentId={experimentId} />
+          </Flex>
+        </Flex>
 
-				<ExperimentCompletionCallout
-					endDate={end_date}
-					hasImpact={!!impact}
-					hasDecision={!!decision}
-				/>
+        <ExperimentCompletionCallout endDate={end_date} hasImpact={!!impact} hasDecision={!!decision} />
 
-				<Flex gap="4" align="center">
-					<Flex align="center" gap="2">
-						<CalendarIcon />
-						<EditableDateField
-							value={start_date}
-							onSubmit={(value) => updateExperiment({ start_date: value })}
-							size="1"
-						/>
-						<Text>→</Text>
-						<EditableDateField
-							value={end_date}
-							onSubmit={(value) => updateExperiment({ end_date: value })}
-							size="1"
-						/>
-					</Flex>
-					<Separator orientation="vertical" />
-					<ExperimentStatusBadge
-						status={getExperimentStatus(start_date, end_date)}
-					/>
-				</Flex>
-				<Flex gap="4" align="center">
-					<ExperimentTypeBadge
-						type={design_spec.experiment_type}
-						isCluster={isClusterDesign(design_spec, power_analyses)}
-					/>
-					{isClusterDesign(design_spec, power_analyses) && (
-						<>
-							<Separator orientation="vertical" />
-							<Tooltip
-								content={`Cluster ID: ${
-									(design_spec as { cluster_column?: string | null })
-										.cluster_column ?? "(persisted in power analysis)"
-								}${
-									power_analyses?.analyses?.[0]?.num_clusters_total != null
-										? ` — ${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters needed across all arms`
-										: ""
-								}`}
-							>
-								<Badge size="2">
-									{power_analyses?.analyses?.[0]?.num_clusters_total != null
-										? `${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters`
-										: "Cluster"}
-								</Badge>
-							</Tooltip>
-						</>
-					)}
-					<Separator orientation="vertical" />
-					{isFrequentistSpec(design_spec) && (
-						<>
-							{design_spec.table_name ? (
-								<>
-									<TableNameBadge tableName={design_spec.table_name} />
-									<Separator orientation="vertical" />
-								</>
-							) : experiment.config.participant_type_deprecated ? (
-								// For backwards compatibility with legacy experiments, show the participant type badge.
-								<>
-									<ParticipantTypeBadge
-										datasourceId={experiment.config.datasource_id}
-										participantType={
-											experiment.config.participant_type_deprecated
-										}
-									/>
-									<Separator orientation="vertical" />
-								</>
-							) : null}
-						</>
-					)}
-					<>
-						<TargetingDialog
-							designSpec={design_spec}
-							participantType={experiment.participant_type}
-							webhookIds={experiment.config.webhooks ?? []}
-							powerAnalyses={power_analyses}
-						/>
-						<Separator orientation="vertical" />
-					</>
-					{isFrequentistSpec(design_spec) && (
-						<>
-							<PowerAndBalanceDialog
-								confidence={Math.round((1 - alpha!) * 100)}
-								power={Math.round(power! * 100)}
-								desiredN={design_spec.desired_n ?? undefined}
-								assignSummary={assign_summary}
-								designEffect={
-									power_analyses?.analyses?.[0]?.design_effect ?? null
-								}
-								numClustersTotal={
-									power_analyses?.analyses?.[0]?.num_clusters_total ?? null
-								}
-							/>
-							<Separator orientation="vertical" />
-						</>
-					)}
-					<Flex align="center" gap="2">
-						<FileTextIcon />
-						<EditableTextField
-							value={design_url ?? ""}
-							onSubmit={(value) => updateExperiment({ design_url: value })}
-							size="1"
-						>
-							{design_url ? (
-								<Link
-									href={design_url}
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									<Text color="blue" style={{ textDecoration: "underline" }}>
-										{design_url.slice(0, 30)}
-										{design_url.length > 30 ? "..." : ""}
-									</Text>
-								</Link>
-							) : (
-								<Text color="gray">No design doc</Text>
-							)}
-						</EditableTextField>
-					</Flex>
-				</Flex>
-			</Flex>
-			<Flex direction="column" gap="4">
-				{/* Hypothesis Section */}
-				<SectionCard title="Hypothesis">
-					<EditableTextArea
-						value={description}
-						onSubmit={(value) => updateExperiment({ description: value })}
-						size="2"
-					>
-						<ReadMoreText text={description} maxWords={30} />
-					</EditableTextArea>
-				</SectionCard>
+        <Flex gap="4" align="center">
+          <Flex align="center" gap="2">
+            <CalendarIcon />
+            <EditableDateField
+              value={start_date}
+              onSubmit={(value) => updateExperiment({ start_date: value })}
+              size="1"
+            />
+            <Text>→</Text>
+            <EditableDateField value={end_date} onSubmit={(value) => updateExperiment({ end_date: value })} size="1" />
+          </Flex>
+          <Separator orientation="vertical" />
+          <ExperimentStatusBadge status={getExperimentStatus(start_date, end_date)} />
+        </Flex>
+        <Flex gap="4" align="center">
+          <ExperimentTypeBadge
+            type={design_spec.experiment_type}
+            isCluster={isClusterDesign(design_spec, power_analyses)}
+          />
+          {isClusterDesign(design_spec, power_analyses) && (
+            <>
+              <Separator orientation="vertical" />
+              <Tooltip
+                content={`Cluster ID: ${
+                  (design_spec as { cluster_column?: string | null }).cluster_column ?? '(persisted in power analysis)'
+                }${
+                  power_analyses?.analyses?.[0]?.num_clusters_total != null
+                    ? ` — ${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters needed across all arms`
+                    : ''
+                }`}
+              >
+                <Badge size="2">
+                  {power_analyses?.analyses?.[0]?.num_clusters_total != null
+                    ? `${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters`
+                    : 'Cluster'}
+                </Badge>
+              </Tooltip>
+            </>
+          )}
+          <Separator orientation="vertical" />
+          {isFrequentistSpec(design_spec) && (
+            <>
+              {design_spec.table_name ? (
+                <>
+                  <TableNameBadge tableName={design_spec.table_name} />
+                  <Separator orientation="vertical" />
+                </>
+              ) : experiment.config.participant_type_deprecated ? (
+                // For backwards compatibility with legacy experiments, show the participant type badge.
+                <>
+                  <ParticipantTypeBadge
+                    datasourceId={experiment.config.datasource_id}
+                    participantType={experiment.config.participant_type_deprecated}
+                  />
+                  <Separator orientation="vertical" />
+                </>
+              ) : null}
+            </>
+          )}
+          <>
+            <TargetingDialog
+              designSpec={design_spec}
+              participantType={experiment.participant_type}
+              webhookIds={experiment.config.webhooks ?? []}
+              powerAnalyses={power_analyses}
+            />
+            <Separator orientation="vertical" />
+          </>
+          {isFrequentistSpec(design_spec) && (
+            <>
+              <PowerAndBalanceDialog
+                confidence={Math.round((1 - alpha!) * 100)}
+                power={Math.round(power! * 100)}
+                desiredN={design_spec.desired_n ?? undefined}
+                assignSummary={assign_summary}
+                designEffect={power_analyses?.analyses?.[0]?.design_effect ?? null}
+                numClustersTotal={power_analyses?.analyses?.[0]?.num_clusters_total ?? null}
+              />
+              <Separator orientation="vertical" />
+            </>
+          )}
+          <Flex align="center" gap="2">
+            <FileTextIcon />
+            <EditableTextField
+              value={design_url ?? ''}
+              onSubmit={(value) => updateExperiment({ design_url: value })}
+              size="1"
+            >
+              {design_url ? (
+                <Link href={design_url} target="_blank" rel="noopener noreferrer">
+                  <Text color="blue" style={{ textDecoration: 'underline' }}>
+                    {design_url.slice(0, 30)}
+                    {design_url.length > 30 ? '...' : ''}
+                  </Text>
+                </Link>
+              ) : (
+                <Text color="gray">No design doc</Text>
+              )}
+            </EditableTextField>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex direction="column" gap="4">
+        {/* Hypothesis Section */}
+        <SectionCard title="Hypothesis">
+          <EditableTextArea value={description} onSubmit={(value) => updateExperiment({ description: value })} size="2">
+            <ReadMoreText text={description} maxWords={30} />
+          </EditableTextArea>
+        </SectionCard>
 
-				{/* Arms & Allocations Section */}
-				{assign_summary &&
-					(() => {
-						// Issue #217: derive cluster totals for the header and per-arm
-						// counts for the table from the stored power_analyses.
-						// We use the primary metric's analysis since cluster counts are
-						// the same across all arms / metrics for a given cluster spec.
-						const isClusterExperiment = isClusterDesign(
-							design_spec,
-							power_analyses,
-						);
-						const primaryAnalysis = power_analyses?.analyses?.[0];
-						const numClustersTotal = primaryAnalysis?.num_clusters_total ?? null;
-						const clustersPerArm = primaryAnalysis?.clusters_per_arm ?? null;
-						// Map per-arm cluster counts onto arm_ids in the design spec's order.
-						const clustersByArmId =
-							isClusterExperiment && clustersPerArm
-								? Object.fromEntries(
-										arms.map((arm, i) => [
-											arm.arm_id ?? `arm-${i}`,
-											clustersPerArm[i] ?? 0,
-										]),
-									)
-								: undefined;
-						return (
-							<SectionCard
-								headerLeft={
-									<Flex gap="3" align="center">
-										<Heading size="3">Arms & Allocations</Heading>
-										<DownloadAssignmentsCsvButton
-											datasourceId={experiment.config.datasource_id}
-											experimentId={experimentId}
-										/>
-									</Flex>
-								}
-								headerRight={
-									<Flex gap="2" align="center">
-										{isClusterExperiment && numClustersTotal !== null && (
-											<Badge color="green">
-												<Text size="2">
-													{numClustersTotal.toLocaleString()} clusters
-												</Text>
-											</Badge>
-										)}
-										<Badge>
-											<PersonIcon />
-											<Text size="2">
-												{assign_summary.sample_size.toLocaleString()}{" "}
-												participants
-											</Text>
-										</Badge>
-									</Flex>
-								}
-							>
-								<ArmsAndAllocationsTable
-									datasourceId={datasourceId}
-									experimentId={experimentId}
-									arms={arms}
-									sampleSize={assign_summary.sample_size}
-									armSizes={assign_summary.arm_sizes}
-									clustersByArmId={clustersByArmId}
-								/>
-							</SectionCard>
-						);
-					})()}
+        {/* Arms & Allocations Section */}
+        {assign_summary &&
+          (() => {
+            // Issue #217: derive cluster totals for the header and per-arm
+            // counts for the table from the stored power_analyses.
+            // We use the primary metric's analysis since cluster counts are
+            // the same across all arms / metrics for a given cluster spec.
+            const isClusterExperiment = isClusterDesign(design_spec, power_analyses);
+            const primaryAnalysis = power_analyses?.analyses?.[0];
+            const numClustersTotal = primaryAnalysis?.num_clusters_total ?? null;
+            const clustersPerArm = primaryAnalysis?.clusters_per_arm ?? null;
+            // Map per-arm cluster counts onto arm_ids in the design spec's order.
+            const clustersByArmId =
+              isClusterExperiment && clustersPerArm
+                ? Object.fromEntries(arms.map((arm, i) => [arm.arm_id ?? `arm-${i}`, clustersPerArm[i] ?? 0]))
+                : undefined;
+            return (
+              <SectionCard
+                headerLeft={
+                  <Flex gap="3" align="center">
+                    <Heading size="3">Arms & Allocations</Heading>
+                    <DownloadAssignmentsCsvButton
+                      datasourceId={experiment.config.datasource_id}
+                      experimentId={experimentId}
+                    />
+                  </Flex>
+                }
+                headerRight={
+                  <Flex gap="2" align="center">
+                    {isClusterExperiment && numClustersTotal !== null && (
+                      <Badge color="green">
+                        <Text size="2">{numClustersTotal.toLocaleString()} clusters</Text>
+                      </Badge>
+                    )}
+                    <Badge>
+                      <PersonIcon />
+                      <Text size="2">{assign_summary.sample_size.toLocaleString()} participants</Text>
+                    </Badge>
+                  </Flex>
+                }
+              >
+                <ArmsAndAllocationsTable
+                  datasourceId={datasourceId}
+                  experimentId={experimentId}
+                  arms={arms}
+                  sampleSize={assign_summary.sample_size}
+                  armSizes={assign_summary.arm_sizes}
+                  clustersByArmId={clustersByArmId}
+                />
+              </SectionCard>
+            );
+          })()}
 
-				{/* Analysis Section */}
-				<SectionCard
-					headerLeft={
-						<Flex gap="3" align="center" wrap="wrap">
-							<Heading size="3">Analysis</Heading>
-							{isFrequentistExperiment ? (
-								<Flex gap="3" wrap="wrap">
-									<Badge size="2">
-										<Flex gap="2" align="center">
-											<Heading size="2">Metric:</Heading>
-											{selectedMetricAnalyses &&
-											selectedMetricAnalyses.length > 1 ? (
-												<Select.Root
-													size="1"
-													value={selectedMetricName}
-													onValueChange={(metricName) => {
-														handleSelectedAnalysisAndMetrics(
-															selectedAnalysisState,
-															metricName,
-														);
-													}}
-												>
-													<Select.Trigger style={{ height: 18 }} />
-													<Select.Content>
-														{selectedMetricAnalyses.map((metric) => {
-															return (
-																<Select.Item
-																	key={metric.metric_name}
-																	value={metric.metric_name}
-																>
-																	{metric.metric_name}
-																</Select.Item>
-															);
-														})}
-													</Select.Content>
-												</Select.Root>
-											) : (
-												<Text>{selectedMetricName}</Text>
-											)}
-										</Flex>
-									</Badge>
-									<MdeBadge value={mdePct} achievable={achievableMdePct} />
-									{/* Issue #217: show ICC pill for cluster-randomized experiments. */}
-									<IccBadge
-										value={
-											(selectedMetricAnalysis?.metric as
-												| { icc?: number | null }
-												| undefined)?.icc ?? null
-										}
-									/>
-								</Flex>
-							) : isBanditAnalysis(selectedAnalysisState.data) &&
-								selectedAnalysisState.banditEffects &&
-								selectedAnalysisState.banditEffects.length > 1 ? (
-								<>
-									<Badge size="2">
-										<Flex gap="2" align="center">
-											<Heading size="2"> Prior Type:</Heading>
-											<Text>
-												{
-													(
-														experiment.config
-															.design_spec as MABExperimentSpecOutput
-													).prior_type
-												}
-											</Text>
-										</Flex>
-									</Badge>
-									<Badge size="2">
-										<Flex gap="2" align="center">
-											<Heading size="2">Reward Type:</Heading>
-											<Text>
-												{
-													(
-														experiment.config
-															.design_spec as MABExperimentSpecOutput
-													).reward_type
-												}
-											</Text>
-										</Flex>
-									</Badge>
-									{cmabContextInputs.length > 0 && (
-										<ContextConfigBox
-											analysisKey={selectedAnalysisState.key}
-											contexts={
-												(
-													experiment.config
-														.design_spec as CMABExperimentSpecOutput
-												).contexts || []
-											}
-											contextValues={cmabContextInputs}
-											onUpdate={handleUpdateCmabContextValue}
-										/>
-									)}
-								</>
-							) : null}
-						</Flex>
-					}
-					headerRight={
-						<Flex gap="3" wrap="wrap">
-							<Flex gap="3" wrap="wrap" align="center" justify="between">
-								<Badge size="2" style={{ height: "26px" }}>
-									<Flex gap="2" align="center">
-										<Heading size="2">Viewing:</Heading>
-										{analysisHistory.length == 0 ? (
-											<Text>{liveAnalysis.label}</Text>
-										) : (
-											<>
-												<Select.Root
-													size="1"
-													value={selectedAnalysisState.key}
-													onValueChange={handleSelectAnalysis}
-												>
-													<Select.Trigger style={{ height: 18 }} />
-													<Select.Content>
-														<Select.Group>
-															<Select.Item key="live" value="live">
-																<Box minWidth="136px">{liveAnalysis.label}</Box>
-															</Select.Item>
-														</Select.Group>
-														<Select.Separator />
-														<Select.Group>
-															{analysisHistory.map((opt) => (
-																<Select.Item key={opt.key} value={opt.key}>
-																	<Box minWidth="136px">{opt.label}</Box>
-																</Select.Item>
-															))}
-														</Select.Group>
-													</Select.Content>
-												</Select.Root>
-												{isLastSnapshotErrorRelevant ? (
-													<Tooltip
-														content={
-															"Last snapshot error: " +
-															lastErrorTimestamp?.toLocaleTimeString()
-														}
-													>
-														<Link
-															href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}
-														>
-															<ExclamationTriangleIcon color={"red"} />
-														</Link>
-													</Tooltip>
-												) : (
-													<Tooltip content={"View snapshot log"}>
-														<Link
-															href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}
-														>
-															<ActivityLogIcon />
-														</Link>
-													</Tooltip>
-												)}
-											</>
-										)}
-									</Flex>
-								</Badge>
-							</Flex>
-							{isFrequentistExperiment ? (
-								<Flex gap="3" wrap="wrap">
-									<Badge size="2">
-										<Flex gap="4" align="center">
-											<Heading size="2">Confidence:</Heading>
-											<Flex gap="2" align="center">
-												<Text>{alpha ? `${(1 - alpha) * 100}%` : "?"}</Text>
-												<Tooltip content="Chance that our test correctly shows no significant difference, if there truly is none. (The probability of avoiding a false positive.)">
-													<InfoCircledIcon />
-												</Tooltip>
-											</Flex>
-										</Flex>
-									</Badge>
-									<Badge size="2">
-										<Flex gap="4" align="center">
-											<Heading size="2">Power:</Heading>
-											<Flex gap="2" align="center">
-												<Text>{power ? `${power * 100}%` : "?"}</Text>
-												<Tooltip content="Chance of detecting a difference at least as large as the pre-specified minimum effect for the metric, if that difference truly exists. (The probability of avoiding a false negative.)">
-													<InfoCircledIcon />
-												</Tooltip>
-											</Flex>
-										</Flex>
-									</Badge>
-								</Flex>
-							) : (
-								<Badge size="2">
-									<Flex gap="4" align="center">
-										<Tooltip
-											content={`The leaderboard and timeseries show the posterior predictive mean—the estimated average outcome for each arm after observing data and accounting for prior beliefs and noise. This is not a treatment effect! The CI is a confidence interval indicating the interval that contains the true average outcome with 95% probability.`}
-										>
-											<InfoCircledIcon />
-										</Tooltip>
-									</Flex>
-								</Badge>
-							)}
-						</Flex>
-					}
-				>
-					<Flex direction="column" gap="3">
-						<Tabs.Root defaultValue="leaderboard">
-							<Tabs.List>
-								<Tabs.Trigger value="leaderboard">Leaderboard</Tabs.Trigger>
-								<Tabs.Trigger value="raw">
-									<Flex gap="2" align="center">
-										Raw Data <CodeIcon />
-									</Flex>
-								</Tabs.Trigger>
-								{showLoadingAnalysisSpinner && (
-									<Tabs.Trigger value="loading" disabled={true}>
-										<Flex gap="2" align="center">
-											<XSpinner message="Loading analyses..." />
-										</Flex>
-									</Tabs.Trigger>
-								)}
-							</Tabs.List>
-							<Box px="4">
-								<Tabs.Content value="leaderboard">
-									<Flex direction="column" gap="3" py="3">
-										{/* Analysis may not be available yet or the experiment hasn't collected enough data. */}
-										{(liveAnalysisError || liveCmabAnalysisError) && (
-											<GenericErrorCallout
-												title="Error loading live analysis"
-												error={liveAnalysisError ?? liveCmabAnalysisError}
-											/>
-										)}
+        {/* Analysis Section */}
+        <SectionCard
+          headerLeft={
+            <Flex gap="3" align="center" wrap="wrap">
+              <Heading size="3">Analysis</Heading>
+              {isFrequentistExperiment ? (
+                <Flex gap="3" wrap="wrap">
+                  <Badge size="2">
+                    <Flex gap="2" align="center">
+                      <Heading size="2">Metric:</Heading>
+                      {selectedMetricAnalyses && selectedMetricAnalyses.length > 1 ? (
+                        <Select.Root
+                          size="1"
+                          value={selectedMetricName}
+                          onValueChange={(metricName) => {
+                            handleSelectedAnalysisAndMetrics(selectedAnalysisState, metricName);
+                          }}
+                        >
+                          <Select.Trigger style={{ height: 18 }} />
+                          <Select.Content>
+                            {selectedMetricAnalyses.map((metric) => {
+                              return (
+                                <Select.Item key={metric.metric_name} value={metric.metric_name}>
+                                  {metric.metric_name}
+                                </Select.Item>
+                              );
+                            })}
+                          </Select.Content>
+                        </Select.Root>
+                      ) : (
+                        <Text>{selectedMetricName}</Text>
+                      )}
+                    </Flex>
+                  </Badge>
+                  <MdeBadge value={mdePct} achievable={achievableMdePct} />
+                  {/* Issue #217: show ICC pill for cluster-randomized experiments. */}
+                  <IccBadge
+                    value={(selectedMetricAnalysis?.metric as { icc?: number | null } | undefined)?.icc ?? null}
+                  />
+                </Flex>
+              ) : isBanditAnalysis(selectedAnalysisState.data) &&
+                selectedAnalysisState.banditEffects &&
+                selectedAnalysisState.banditEffects.length > 1 ? (
+                <>
+                  <Badge size="2">
+                    <Flex gap="2" align="center">
+                      <Heading size="2"> Prior Type:</Heading>
+                      <Text>{(experiment.config.design_spec as MABExperimentSpecOutput).prior_type}</Text>
+                    </Flex>
+                  </Badge>
+                  <Badge size="2">
+                    <Flex gap="2" align="center">
+                      <Heading size="2">Reward Type:</Heading>
+                      <Text>{(experiment.config.design_spec as MABExperimentSpecOutput).reward_type}</Text>
+                    </Flex>
+                  </Badge>
+                  {cmabContextInputs.length > 0 && (
+                    <ContextConfigBox
+                      analysisKey={selectedAnalysisState.key}
+                      contexts={(experiment.config.design_spec as CMABExperimentSpecOutput).contexts || []}
+                      contextValues={cmabContextInputs}
+                      onUpdate={handleUpdateCmabContextValue}
+                    />
+                  )}
+                </>
+              ) : null}
+            </Flex>
+          }
+          headerRight={
+            <Flex gap="3" wrap="wrap">
+              <Flex gap="3" wrap="wrap" align="center" justify="between">
+                <Badge size="2" style={{ height: '26px' }}>
+                  <Flex gap="2" align="center">
+                    <Heading size="2">Viewing:</Heading>
+                    {analysisHistory.length == 0 ? (
+                      <Text>{liveAnalysis.label}</Text>
+                    ) : (
+                      <>
+                        <Select.Root size="1" value={selectedAnalysisState.key} onValueChange={handleSelectAnalysis}>
+                          <Select.Trigger style={{ height: 18 }} />
+                          <Select.Content>
+                            <Select.Group>
+                              <Select.Item key="live" value="live">
+                                <Box minWidth="136px">{liveAnalysis.label}</Box>
+                              </Select.Item>
+                            </Select.Group>
+                            <Select.Separator />
+                            <Select.Group>
+                              {analysisHistory.map((opt) => (
+                                <Select.Item key={opt.key} value={opt.key}>
+                                  <Box minWidth="136px">{opt.label}</Box>
+                                </Select.Item>
+                              ))}
+                            </Select.Group>
+                          </Select.Content>
+                        </Select.Root>
+                        {isLastSnapshotErrorRelevant ? (
+                          <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
+                            <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
+                              <ExclamationTriangleIcon color={'red'} />
+                            </Link>
+                          </Tooltip>
+                        ) : (
+                          <Tooltip content={'View snapshot log'}>
+                            <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
+                              <ActivityLogIcon />
+                            </Link>
+                          </Tooltip>
+                        )}
+                      </>
+                    )}
+                  </Flex>
+                </Badge>
+              </Flex>
+              {isFrequentistExperiment ? (
+                <Flex gap="3" wrap="wrap">
+                  <Badge size="2">
+                    <Flex gap="4" align="center">
+                      <Heading size="2">Confidence:</Heading>
+                      <Flex gap="2" align="center">
+                        <Text>{alpha ? `${(1 - alpha) * 100}%` : '?'}</Text>
+                        <Tooltip content="Chance that our test correctly shows no significant difference, if there truly is none. (The probability of avoiding a false positive.)">
+                          <InfoCircledIcon />
+                        </Tooltip>
+                      </Flex>
+                    </Flex>
+                  </Badge>
+                  <Badge size="2">
+                    <Flex gap="4" align="center">
+                      <Heading size="2">Power:</Heading>
+                      <Flex gap="2" align="center">
+                        <Text>{power ? `${power * 100}%` : '?'}</Text>
+                        <Tooltip content="Chance of detecting a difference at least as large as the pre-specified minimum effect for the metric, if that difference truly exists. (The probability of avoiding a false negative.)">
+                          <InfoCircledIcon />
+                        </Tooltip>
+                      </Flex>
+                    </Flex>
+                  </Badge>
+                </Flex>
+              ) : (
+                <Badge size="2">
+                  <Flex gap="4" align="center">
+                    <Tooltip
+                      content={`The leaderboard and timeseries show the posterior predictive mean—the estimated average outcome for each arm after observing data and accounting for prior beliefs and noise. This is not a treatment effect! The CI is a confidence interval indicating the interval that contains the true average outcome with 95% probability.`}
+                    >
+                      <InfoCircledIcon />
+                    </Tooltip>
+                  </Flex>
+                </Badge>
+              )}
+            </Flex>
+          }
+        >
+          <Flex direction="column" gap="3">
+            <Tabs.Root defaultValue="leaderboard">
+              <Tabs.List>
+                <Tabs.Trigger value="leaderboard">Leaderboard</Tabs.Trigger>
+                <Tabs.Trigger value="raw">
+                  <Flex gap="2" align="center">
+                    Raw Data <CodeIcon />
+                  </Flex>
+                </Tabs.Trigger>
+                {showLoadingAnalysisSpinner && (
+                  <Tabs.Trigger value="loading" disabled={true}>
+                    <Flex gap="2" align="center">
+                      <XSpinner message="Loading analyses..." />
+                    </Flex>
+                  </Tabs.Trigger>
+                )}
+              </Tabs.List>
+              <Box px="4">
+                <Tabs.Content value="leaderboard">
+                  <Flex direction="column" gap="3" py="3">
+                    {/* Analysis may not be available yet or the experiment hasn't collected enough data. */}
+                    {(liveAnalysisError || liveCmabAnalysisError) && (
+                      <GenericErrorCallout
+                        title="Error loading live analysis"
+                        error={liveAnalysisError ?? liveCmabAnalysisError}
+                      />
+                    )}
 
-										{selectedAnalysisState.data && (
-											<ForestPlot
-												effectSizes={selectedAnalysisState.effectSizesByMetric?.get(
-													selectedMetricName,
-												)}
-												banditEffects={selectedAnalysisState.banditEffects}
-												minX={ciBounds[0]}
-												maxX={ciBounds[1]}
-											/>
-										)}
+                    {selectedAnalysisState.data && (
+                      <ForestPlot
+                        effectSizes={selectedAnalysisState.effectSizesByMetric?.get(selectedMetricName)}
+                        banditEffects={selectedAnalysisState.banditEffects}
+                        minX={ciBounds[0]}
+                        maxX={ciBounds[1]}
+                      />
+                    )}
 
-										{analysisHistoryError && (
-											<GenericErrorCallout
-												title="Error loading historical analyses"
-												message="Historical analyses may not be available yet."
-											/>
-										)}
+                    {analysisHistoryError && (
+                      <GenericErrorCallout
+                        title="Error loading historical analyses"
+                        message="Historical analyses may not be available yet."
+                      />
+                    )}
 
-										{!isLoadingHistory && (
-											<ForestTimeseriesPlot
-												data={timeseriesData}
-												armMetadata={armMetadata}
-												minDate={minDate}
-												maxDate={maxDate}
-												onPointClick={handleSelectAnalysis}
-											/>
-										)}
-									</Flex>
-								</Tabs.Content>
+                    {!isLoadingHistory && (
+                      <ForestTimeseriesPlot
+                        data={timeseriesData}
+                        armMetadata={armMetadata}
+                        minDate={minDate}
+                        maxDate={maxDate}
+                        onPointClick={handleSelectAnalysis}
+                      />
+                    )}
+                  </Flex>
+                </Tabs.Content>
 
-								<Tabs.Content value="raw">
-									<Flex direction="column" gap="3" py="3">
-										<CodeSnippetCard
-											title="Raw Data"
-											content={
-												selectedAnalysisState.data
-													? prettyJSON(selectedAnalysisState.data)
-													: "NO DATA"
-											}
-											height="200px"
-											tooltipContent="Copy raw data"
-											variant="ghost"
-										/>
-									</Flex>
-								</Tabs.Content>
-							</Box>
-						</Tabs.Root>
-					</Flex>
-				</SectionCard>
+                <Tabs.Content value="raw">
+                  <Flex direction="column" gap="3" py="3">
+                    <CodeSnippetCard
+                      title="Raw Data"
+                      content={selectedAnalysisState.data ? prettyJSON(selectedAnalysisState.data) : 'NO DATA'}
+                      height="200px"
+                      tooltipContent="Copy raw data"
+                      variant="ghost"
+                    />
+                  </Flex>
+                </Tabs.Content>
+              </Box>
+            </Tabs.Root>
+          </Flex>
+        </SectionCard>
 
-				<div id="decision-and-impact" />
-				<DecisionAndImpactSection
-					impact={impact}
-					decision={decision}
-					onUpdate={(updates) => updateExperiment(updates)}
-				/>
-			</Flex>
-		</Flex>
-	);
+        <div id="decision-and-impact" />
+        <DecisionAndImpactSection
+          impact={impact}
+          decision={decision}
+          onUpdate={(updates) => updateExperiment(updates)}
+        />
+      </Flex>
+    </Flex>
+  );
 }

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -346,7 +346,8 @@ export default function ExperimentViewPage() {
   const { alpha, power } = getAlphaAndPower(experiment.config); // undefined for non-frequentist experiments
   const { experiment_name, description, start_date, end_date, arms, design_url } = design_spec;
   const isFrequentistExperiment = isFrequentistSpec(design_spec);
-  const contexts = isBanditSpec(design_spec) ? (design_spec.contexts ?? []) : [];
+  // contexts only exist on CMAB; plain MAB has no contexts field.
+  const contexts = isCmabSpec(design_spec) ? (design_spec.contexts ?? []) : [];
 
   const selectedMetricAnalyses =
     selectedAnalysisState.data && 'metric_analyses' in selectedAnalysisState.data
@@ -360,19 +361,22 @@ export default function ExperimentViewPage() {
   }
 
   // Achievable MDE: pulled from the saved power_analyses for the selected
-  // metric. Populated when the user picked a sample size other than the
-  // recommended minimum (the BE's MDE-mode response carries
-  // pct_change_possible alongside the committed N). For experiments that
-  // committed to the recommended size, this stays null and the badge just
-  // shows Target MDE as before.
+  // metric. The BE puts the achievable MDE in pct_change_with_desired_n when
+  // desired_n was sufficient, and in pct_change_possible when not. For
+  // experiments that committed to the recommended size, both stay null and
+  // the badge just shows Target MDE.
   let achievableMdePct: string | null = null;
   if (selectedMetricAnalysis?.metric?.field_name) {
     const savedAnalysis = power_analyses?.analyses?.find(
       (a) => a.metric_spec.field_name === selectedMetricAnalysis.metric.field_name,
     );
-    const pctPossible = savedAnalysis?.pct_change_possible;
-    if (pctPossible != null && Number.isFinite(pctPossible)) {
-      achievableMdePct = (pctPossible * 100).toFixed(2);
+    const pct =
+      (savedAnalysis as { pct_change_with_desired_n?: number | null } | undefined)
+        ?.pct_change_with_desired_n ??
+      savedAnalysis?.pct_change_possible ??
+      null;
+    if (pct != null && Number.isFinite(pct)) {
+      achievableMdePct = (pct * 100).toFixed(2);
     }
   }
 
@@ -429,7 +433,7 @@ export default function ExperimentViewPage() {
               <Separator orientation="vertical" />
               <Tooltip
                 content={`Cluster ID: ${
-                  (design_spec as { cluster_column?: string | null }).cluster_column ?? '(persisted in power analysis)'
+                  (design_spec as { cluster_key?: string | null }).cluster_key ?? '(persisted in power analysis)'
                 }${
                   power_analyses?.analyses?.[0]?.num_clusters_total != null
                     ? ` — ${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters needed across all arms`

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -1,723 +1,957 @@
-'use client';
-import { useState } from 'react';
-import { useParams } from 'next/navigation';
-import Link from 'next/link';
-import { mutate } from 'swr';
-import { Badge, Box, Flex, Heading, Select, Separator, Tabs, Text, Tooltip } from '@radix-ui/themes';
+"use client";
 import {
-  ActivityLogIcon,
-  CalendarIcon,
-  CodeIcon,
-  ExclamationTriangleIcon,
-  FileTextIcon,
-  InfoCircledIcon,
-  PersonIcon,
-} from '@radix-ui/react-icons';
+	getGetExperimentForUiKey,
+	useAnalyzeCmabExperiment,
+	useAnalyzeExperiment,
+	useGetExperimentForUi,
+	useListSnapshots,
+	useUpdateExperiment,
+} from "@/api/admin";
 import {
-  getGetExperimentForUiKey,
-  useAnalyzeCmabExperiment,
-  useAnalyzeExperiment,
-  useGetExperimentForUi,
-  useListSnapshots,
-  useUpdateExperiment,
-} from '@/api/admin';
+	CMABContextInputRequest,
+	CMABExperimentSpecOutput,
+	ContextInput,
+	ExperimentAnalysisResponse,
+	MABExperimentSpecOutput,
+	MetricAnalysis,
+	Snapshot,
+} from "@/api/methods.schemas";
 import {
-  CMABContextInputRequest,
-  CMABExperimentSpecOutput,
-  ContextInput,
-  ExperimentAnalysisResponse,
-  MABExperimentSpecOutput,
-  MetricAnalysis,
-  Snapshot,
-} from '@/api/methods.schemas';
-import { ForestPlot } from '@/components/features/experiments/plots/forest-plot';
+	isBanditSpec,
+	isCmabExperiment,
+	isCmabSpec,
+	isFrequentistSpec,
+} from "@/app/experiments/create/experiment-form/experiment-form-types";
+import { ArmsAndAllocationsTable } from "@/components/features/experiments/arms-and-allocations-table";
+import { ContextConfigBox } from "@/components/features/experiments/context-config-box";
+import { DecisionAndImpactSection } from "@/components/features/experiments/decision-and-impact-section";
+import { DownloadAssignmentsCsvButton } from "@/components/features/experiments/download-assignments-csv-button";
+import { ExperimentCompletionCallout } from "@/components/features/experiments/experiment-completion-callout";
+import { ExperimentDetailsDropdownMenu } from "@/components/features/experiments/experiment-details-dropdown-menu";
+import { ExperimentStatusBadge } from "@/components/features/experiments/experiment-status-badge";
+import { ExperimentTypeBadge } from "@/components/features/experiments/experiment-type-badge";
+import { IntegrationGuideDialog } from "@/components/features/experiments/integration-guide-dialog";
+import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
+import { IccBadge } from "@/components/features/experiments/icc-badge";
+import { MdeBadge } from "@/components/features/experiments/mde-badge";
+import { ForestPlot } from "@/components/features/experiments/plots/forest-plot";
 import {
-  AnalysisState,
-  computeBoundsForMetric,
-  getAlphaAndPower,
-  isBanditAnalysis,
-  isFrequentistAnalysis,
-  precomputeBanditEffects,
-  precomputeFreqEffectsByMetric,
-  transformAnalysisForForestTimeseriesPlot,
-} from '@/components/features/experiments/plots/forest-plot-utils';
-import ForestTimeseriesPlot from '@/components/features/experiments/plots/forest-timeseries-plot';
-import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
-import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
-import { MdeBadge } from '@/components/features/experiments/mde-badge';
-import { ArmsAndAllocationsTable } from '@/components/features/experiments/arms-and-allocations-table';
-import { IntegrationGuideDialog } from '@/components/features/experiments/integration-guide-dialog';
-import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
-import { ExperimentDetailsDropdownMenu } from '@/components/features/experiments/experiment-details-dropdown-menu';
-import { DecisionAndImpactSection } from '@/components/features/experiments/decision-and-impact-section';
-import { ExperimentCompletionCallout } from '@/components/features/experiments/experiment-completion-callout';
-import { ParticipantTypeBadge } from '@/components/features/participants/participant-type-badge';
-import { XSpinner } from '@/components/ui/x-spinner';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
-import { CodeSnippetCard } from '@/components/ui/cards/code-snippet-card';
-import { SectionCard } from '@/components/ui/cards/section-card';
-import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
-import { EditableDateField } from '@/components/ui/inputs/editable-date-field';
-import { EditableTextArea } from '@/components/ui/inputs/editable-text-area';
-import { ReadMoreText } from '@/components/ui/read-more-text';
-import { useCurrentOrganization } from '@/providers/organization-provider';
-import { prettyJSON } from '@/services/json-utils';
-import { getExperimentStatus } from '@/services/experiment-utils';
-import { extractUtcHHMMLabel, formatUtcDownToMinuteLabel } from '@/services/date-utils';
-import { ContextConfigBox } from '@/components/features/experiments/context-config-box';
+	AnalysisState,
+	computeBoundsForMetric,
+	getAlphaAndPower,
+	isBanditAnalysis,
+	isFrequentistAnalysis,
+	precomputeBanditEffects,
+	precomputeFreqEffectsByMetric,
+	transformAnalysisForForestTimeseriesPlot,
+} from "@/components/features/experiments/plots/forest-plot-utils";
+import ForestTimeseriesPlot from "@/components/features/experiments/plots/forest-timeseries-plot";
+import { PowerAndBalanceDialog } from "@/components/features/experiments/power-and-balance-dialog";
+import { TargetingDialog } from "@/components/features/experiments/targeting-dialog";
+import { ParticipantTypeBadge } from "@/components/features/participants/participant-type-badge";
+import { TableNameBadge } from "@/components/features/participants/table-name-badge";
+import { CodeSnippetCard } from "@/components/ui/cards/code-snippet-card";
+import { SectionCard } from "@/components/ui/cards/section-card";
+import { GenericErrorCallout } from "@/components/ui/generic-error";
+import { EditableDateField } from "@/components/ui/inputs/editable-date-field";
+import { EditableTextArea } from "@/components/ui/inputs/editable-text-area";
+import { EditableTextField } from "@/components/ui/inputs/editable-text-field";
+import { ReadMoreText } from "@/components/ui/read-more-text";
+import { XSpinner } from "@/components/ui/x-spinner";
+import { useCurrentOrganization } from "@/providers/organization-provider";
 import {
-  isBanditSpec,
-  isCmabExperiment,
-  isCmabSpec,
-  isFrequentistSpec,
-} from '@/app/experiments/create/experiment-form/experiment-form-types';
-import { TableNameBadge } from '@/components/features/participants/table-name-badge';
-import { TargetingDialog } from '@/components/features/experiments/targeting-dialog';
-import { PowerAndBalanceDialog } from '@/components/features/experiments/power-and-balance-dialog';
+	extractUtcHHMMLabel,
+	formatUtcDownToMinuteLabel,
+} from "@/services/date-utils";
+import { getExperimentStatus } from "@/services/experiment-utils";
+import { prettyJSON } from "@/services/json-utils";
+import {
+	ActivityLogIcon,
+	CalendarIcon,
+	CodeIcon,
+	ExclamationTriangleIcon,
+	FileTextIcon,
+	InfoCircledIcon,
+	PersonIcon,
+} from "@radix-ui/react-icons";
+import {
+	Badge,
+	Box,
+	Flex,
+	Heading,
+	Select,
+	Separator,
+	Tabs,
+	Text,
+	Tooltip,
+} from "@radix-ui/themes";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { mutate } from "swr";
 
 const SNAPSHOT_ERROR_ALERT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
 export default function ExperimentViewPage() {
-  const params = useParams();
-  const orgCtx = useCurrentOrganization();
-  const organizationId = orgCtx?.current.id || '';
-  const datasourceId = (params.datasourceId as string) || '';
-  const experimentId = (params.experimentId as string) || '';
-  const [lastErrorTimestamp, setLastErrorTimestamp] = useState<null | Date>(null);
+	const params = useParams();
+	const orgCtx = useCurrentOrganization();
+	const organizationId = orgCtx?.current.id || "";
+	const datasourceId = (params.datasourceId as string) || "";
+	const experimentId = (params.experimentId as string) || "";
+	const [lastErrorTimestamp, setLastErrorTimestamp] = useState<null | Date>(
+		null,
+	);
 
-  const [analysisHistory, setAnalysisHistory] = useState<AnalysisState[]>([]);
-  const [liveAnalysis, setLiveAnalysis] = useState<AnalysisState>({
-    key: 'live',
-    data: undefined,
-    updated_at: new Date(),
-    label: 'No live data yet',
-    effectSizesByMetric: undefined,
-    banditEffects: undefined,
-  });
-  // which analysis we're actually displaying (live or a snapshot)
-  const [selectedAnalysisState, setSelectedAnalysisState] = useState<AnalysisState>(liveAnalysis);
-  const [selectedMetricAnalysis, setSelectedMetricAnalysis] = useState<MetricAnalysis | null>(null);
-  const [selectedMetricName, setSelectedMetricName] = useState<string>('unknown');
-  const [cmabAnalysisRequest, setCmabAnalysisRequest] = useState<CMABContextInputRequest>({
-    type: 'cmab_assignment',
-    context_inputs: [],
-  });
-  const cmabContextInputs = cmabAnalysisRequest.context_inputs ?? [];
+	const [analysisHistory, setAnalysisHistory] = useState<AnalysisState[]>([]);
+	const [liveAnalysis, setLiveAnalysis] = useState<AnalysisState>({
+		key: "live",
+		data: undefined,
+		updated_at: new Date(),
+		label: "No live data yet",
+		effectSizesByMetric: undefined,
+		banditEffects: undefined,
+	});
+	// which analysis we're actually displaying (live or a snapshot)
+	const [selectedAnalysisState, setSelectedAnalysisState] =
+		useState<AnalysisState>(liveAnalysis);
+	const [selectedMetricAnalysis, setSelectedMetricAnalysis] =
+		useState<MetricAnalysis | null>(null);
+	const [selectedMetricName, setSelectedMetricName] =
+		useState<string>("unknown");
+	const [cmabAnalysisRequest, setCmabAnalysisRequest] =
+		useState<CMABContextInputRequest>({
+			type: "cmab_assignment",
+			context_inputs: [],
+		});
+	const cmabContextInputs = cmabAnalysisRequest.context_inputs ?? [];
 
-  // Track the min/max CI bounds across a recent window of snapshots for more stable forest plot display.
-  const [ciBounds, setCiBounds] = useState<[number | undefined, number | undefined]>([undefined, undefined]);
+	// Track the min/max CI bounds across a recent window of snapshots for more stable forest plot display.
+	const [ciBounds, setCiBounds] = useState<
+		[number | undefined, number | undefined]
+	>([undefined, undefined]);
 
-  const {
-    data: experiment,
-    isLoading: isLoadingExperiment,
-    error: experimentError,
-  } = useGetExperimentForUi(datasourceId, experimentId, {
-    swr: {
-      enabled: !!datasourceId,
-      onSuccess: (expForUi) => {
-        const expConfig = expForUi.config;
-        // Only initialize context input ids for CMAB experiments if they are not already set.
-        // Should only need to set this once for an experiment, as they are fixed at design time.
-        if (isCmabSpec(expConfig.design_spec) && expConfig.design_spec.contexts && cmabContextInputs.length === 0) {
-          const contextInputs = expConfig.design_spec.contexts
-            .filter((ctx) => ctx.context_id !== undefined)
-            .map((ctx) => ({ context_id: ctx.context_id!, context_value: 0.0 }));
-          setCmabAnalysisRequest({ ...cmabAnalysisRequest, context_inputs: contextInputs });
-        }
-      },
-    },
-  });
+	const {
+		data: experiment,
+		isLoading: isLoadingExperiment,
+		error: experimentError,
+	} = useGetExperimentForUi(datasourceId, experimentId, {
+		swr: {
+			enabled: !!datasourceId,
+			onSuccess: (expForUi) => {
+				const expConfig = expForUi.config;
+				// Only initialize context input ids for CMAB experiments if they are not already set.
+				// Should only need to set this once for an experiment, as they are fixed at design time.
+				if (
+					isCmabSpec(expConfig.design_spec) &&
+					expConfig.design_spec.contexts &&
+					cmabContextInputs.length === 0
+				) {
+					const contextInputs = expConfig.design_spec.contexts
+						.filter((ctx) => ctx.context_id !== undefined)
+						.map((ctx) => ({
+							context_id: ctx.context_id!,
+							context_value: 0.0,
+						}));
+					setCmabAnalysisRequest({
+						...cmabAnalysisRequest,
+						context_inputs: contextInputs,
+					});
+				}
+			},
+		},
+	});
 
-  const {
-    mutate: analyzeLive,
-    data: analyzeExperimentData,
-    isLoading: isLoadingLiveAnalysis,
-    error: liveAnalysisError,
-  } = useAnalyzeExperiment(datasourceId, experimentId, undefined, {
-    swr: {
-      enabled: !!datasourceId && !!experiment && !isCmabExperiment(experiment.config),
-      // Disable revalidation to only allow manual triggering of the live analysis
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-      revalidateOnMount: false,
-      revalidateOnReconnect: false,
-      shouldRetryOnError: false,
-      onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
-    },
-  });
+	const {
+		mutate: analyzeLive,
+		data: analyzeExperimentData,
+		isLoading: isLoadingLiveAnalysis,
+		error: liveAnalysisError,
+	} = useAnalyzeExperiment(datasourceId, experimentId, undefined, {
+		swr: {
+			enabled:
+				!!datasourceId && !!experiment && !isCmabExperiment(experiment.config),
+			// Disable revalidation to only allow manual triggering of the live analysis
+			revalidateIfStale: false,
+			revalidateOnFocus: false,
+			revalidateOnMount: false,
+			revalidateOnReconnect: false,
+			shouldRetryOnError: false,
+			onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
+		},
+	});
 
-  const {
-    trigger: analyzeLiveCmab,
-    data: analyzeCmabExperimentData,
-    isMutating: isLoadingLiveCmabAnalysis,
-    error: liveCmabAnalysisError,
-  } = useAnalyzeCmabExperiment(datasourceId, experimentId, {
-    swr: {
-      onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
-    },
-  });
+	const {
+		trigger: analyzeLiveCmab,
+		data: analyzeCmabExperimentData,
+		isMutating: isLoadingLiveCmabAnalysis,
+		error: liveCmabAnalysisError,
+	} = useAnalyzeCmabExperiment(datasourceId, experimentId, {
+		swr: {
+			onSuccess: (analysisData) => handleLiveAnalysisSuccess(analysisData),
+		},
+	});
 
-  const { isLoading: isLoadingHistory, error: analysisHistoryError } = useListSnapshots(
-    organizationId,
-    datasourceId,
-    experimentId,
-    { status: ['success'] },
-    {
-      swr: {
-        enabled: !!organizationId && !!datasourceId && !!experimentId && !!experiment,
-        shouldRetryOnError: false,
-        focusThrottleInterval: 15 * 60_000, // refresh on focus after 15 minutes
-        onSuccess: async (data) => {
-          // Make human-readable labels for the dropdown, showing UTC down to the minute.
-          // Use the snapshot ID as the key, looking up the analysisState by ID upon selection.
+	const { isLoading: isLoadingHistory, error: analysisHistoryError } =
+		useListSnapshots(
+			organizationId,
+			datasourceId,
+			experimentId,
+			{ status: ["success"] },
+			{
+				swr: {
+					enabled:
+						!!organizationId &&
+						!!datasourceId &&
+						!!experimentId &&
+						!!experiment,
+					shouldRetryOnError: false,
+					focusThrottleInterval: 15 * 60_000, // refresh on focus after 15 minutes
+					onSuccess: async (data) => {
+						// Make human-readable labels for the dropdown, showing UTC down to the minute.
+						// Use the snapshot ID as the key, looking up the analysisState by ID upon selection.
 
-          // Do live analysis if there are no snapshots and we don't have live analysis data already. This avoids
-          // duplicating a potentially expensive query when useListSnapshots runs.
-          if (data.items.length === 0) {
-            // No snapshots. First check if we have (cached) live analysis data. If so, use that for display.
-            if (isCmabExperiment(experiment?.config) && analyzeCmabExperimentData !== undefined) {
-              handleLiveAnalysisSuccess(analyzeCmabExperimentData);
-            } else if (analyzeExperimentData !== undefined) {
-              handleLiveAnalysisSuccess(analyzeExperimentData);
-            } else {
-              await triggerLiveAnalysis();
-            }
-            return;
-          }
+						// Do live analysis if there are no snapshots and we don't have live analysis data already. This avoids
+						// duplicating a potentially expensive query when useListSnapshots runs.
+						if (data.items.length === 0) {
+							// No snapshots. First check if we have (cached) live analysis data. If so, use that for display.
+							if (
+								isCmabExperiment(experiment?.config) &&
+								analyzeCmabExperimentData !== undefined
+							) {
+								handleLiveAnalysisSuccess(analyzeCmabExperimentData);
+							} else if (analyzeExperimentData !== undefined) {
+								handleLiveAnalysisSuccess(analyzeExperimentData);
+							} else {
+								await triggerLiveAnalysis();
+							}
+							return;
+						}
 
-          // Group snapshots by date and keep only the most recent one per date
-          const snapshotsByDate = new Map<string, Snapshot>();
+						// Group snapshots by date and keep only the most recent one per date
+						const snapshotsByDate = new Map<string, Snapshot>();
 
-          for (const s of data.items) {
-            const dateKey = s.updated_at.split('T')[0]; // Get YYYY-MM-DD from ISO string
-            const existing = snapshotsByDate.get(dateKey);
-            if (!existing || s.updated_at > existing.updated_at) {
-              snapshotsByDate.set(dateKey, s);
-            }
-          }
+						for (const s of data.items) {
+							const dateKey = s.updated_at.split("T")[0]; // Get YYYY-MM-DD from ISO string
+							const existing = snapshotsByDate.get(dateKey);
+							if (!existing || s.updated_at > existing.updated_at) {
+								snapshotsByDate.set(dateKey, s);
+							}
+						}
 
-          // Convert to array
-          const filteredSnapshots = Array.from(snapshotsByDate.values());
-          const history: AnalysisState[] = filteredSnapshots.map((s) => {
-            // The results are guaranteed to be non-null because of the status filter.
-            const analysisData = s.data as ExperimentAnalysisResponse;
-            const date = new Date(s.updated_at);
-            return {
-              key: s.id,
-              data: analysisData,
-              updated_at: date,
-              label: formatUtcDownToMinuteLabel(date),
-              effectSizesByMetric: precomputeFreqEffectsByMetric(analysisData, alpha),
-              banditEffects: precomputeBanditEffects(analysisData),
-            };
-          });
+						// Convert to array
+						const filteredSnapshots = Array.from(snapshotsByDate.values());
+						const history: AnalysisState[] = filteredSnapshots.map((s) => {
+							// The results are guaranteed to be non-null because of the status filter.
+							const analysisData = s.data as ExperimentAnalysisResponse;
+							const date = new Date(s.updated_at);
+							return {
+								key: s.id,
+								data: analysisData,
+								updated_at: date,
+								label: formatUtcDownToMinuteLabel(date),
+								effectSizesByMetric: precomputeFreqEffectsByMetric(
+									analysisData,
+									alpha,
+								),
+								banditEffects: precomputeBanditEffects(analysisData),
+							};
+						});
 
-          setLastErrorTimestamp(data.latest_failure === null ? null : new Date(data.latest_failure));
-          setAnalysisHistory(history);
-          // If we're not viewing real data, set the selected analysis to the most recent snapshot
-          if (selectedAnalysisState.data === undefined) {
-            handleSelectedAnalysisAndMetrics(history[0], selectedMetricName, history);
-          }
-        },
-        onError: async () => {
-          // Trigger live analysis if snapshot loading fails
-          await triggerLiveAnalysis();
-        },
-      },
-    },
-  );
+						setLastErrorTimestamp(
+							data.latest_failure === null
+								? null
+								: new Date(data.latest_failure),
+						);
+						setAnalysisHistory(history);
+						// If we're not viewing real data, set the selected analysis to the most recent snapshot
+						if (selectedAnalysisState.data === undefined) {
+							handleSelectedAnalysisAndMetrics(
+								history[0],
+								selectedMetricName,
+								history,
+							);
+						}
+					},
+					onError: async () => {
+						// Trigger live analysis if snapshot loading fails
+						await triggerLiveAnalysis();
+					},
+				},
+			},
+		);
 
-  const { trigger: updateExperiment } = useUpdateExperiment(datasourceId, experimentId, {
-    swr: {
-      onSuccess: async () => {
-        await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
-      },
-    },
-  });
+	const { trigger: updateExperiment } = useUpdateExperiment(
+		datasourceId,
+		experimentId,
+		{
+			swr: {
+				onSuccess: async () => {
+					await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
+				},
+			},
+		},
+	);
 
-  const handleSelectedAnalysisAndMetrics = (
-    analysis: AnalysisState,
-    forMetricName: string | undefined = undefined,
-    historyOverride: AnalysisState[] | undefined = undefined,
-  ) => {
-    setSelectedAnalysisState(analysis);
-    if (!isFrequentistAnalysis(analysis.data)) {
-      setSelectedMetricAnalysis(null);
-      return;
-    }
+	const handleSelectedAnalysisAndMetrics = (
+		analysis: AnalysisState,
+		forMetricName: string | undefined = undefined,
+		historyOverride: AnalysisState[] | undefined = undefined,
+	) => {
+		setSelectedAnalysisState(analysis);
+		if (!isFrequentistAnalysis(analysis.data)) {
+			setSelectedMetricAnalysis(null);
+			return;
+		}
 
-    // Try to maintain the same metric as before when switching between snapshots.
-    // The fallback to the first metric should not actually happen in practice.
-    const nameToFind = forMetricName || selectedMetricName;
-    const metricAnalyses = analysis.data.metric_analyses;
-    const newMetric: MetricAnalysis | null =
-      metricAnalyses.find((metric) => metric.metric_name === nameToFind) || metricAnalyses[0] || null;
-    const newMetricName = newMetric?.metric_name || 'unknown';
-    // Recompute bounds if the metric changed
-    if (selectedMetricName !== newMetricName) {
-      setSelectedMetricName(newMetricName);
+		// Try to maintain the same metric as before when switching between snapshots.
+		// The fallback to the first metric should not actually happen in practice.
+		const nameToFind = forMetricName || selectedMetricName;
+		const metricAnalyses = analysis.data.metric_analyses;
+		const newMetric: MetricAnalysis | null =
+			metricAnalyses.find((metric) => metric.metric_name === nameToFind) ||
+			metricAnalyses[0] ||
+			null;
+		const newMetricName = newMetric?.metric_name || "unknown";
+		// Recompute bounds if the metric changed
+		if (selectedMetricName !== newMetricName) {
+			setSelectedMetricName(newMetricName);
 
-      // First make a copy since we may mutate contents by adding live data.
-      const snapshotsToUse = [...(historyOverride || analysisHistory)];
-      // Include the live analysis if it has data.
-      if (analysis.key === 'live' && analysis.data) {
-        snapshotsToUse.push(analysis);
-      } else if (liveAnalysis.data) {
-        snapshotsToUse.push(liveAnalysis);
-      }
-      const bounds = computeBoundsForMetric(newMetricName, snapshotsToUse);
-      setCiBounds(bounds);
-    }
-    setSelectedMetricAnalysis(newMetric);
-  };
+			// First make a copy since we may mutate contents by adding live data.
+			const snapshotsToUse = [...(historyOverride || analysisHistory)];
+			// Include the live analysis if it has data.
+			if (analysis.key === "live" && analysis.data) {
+				snapshotsToUse.push(analysis);
+			} else if (liveAnalysis.data) {
+				snapshotsToUse.push(liveAnalysis);
+			}
+			const bounds = computeBoundsForMetric(newMetricName, snapshotsToUse);
+			setCiBounds(bounds);
+		}
+		setSelectedMetricAnalysis(newMetric);
+	};
 
-  // Wrapper around the live analysis functions for CMAB and non-CMAB experiments.
-  const triggerLiveAnalysis = async (requestOverride?: CMABContextInputRequest) => {
-    const request = requestOverride ?? cmabAnalysisRequest;
-    return isCmabExperiment(experiment?.config) ? await analyzeLiveCmab(request) : await analyzeLive();
-  };
+	// Wrapper around the live analysis functions for CMAB and non-CMAB experiments.
+	const triggerLiveAnalysis = async (
+		requestOverride?: CMABContextInputRequest,
+	) => {
+		const request = requestOverride ?? cmabAnalysisRequest;
+		return isCmabExperiment(experiment?.config)
+			? await analyzeLiveCmab(request)
+			: await analyzeLive();
+	};
 
-  const handleLiveAnalysisSuccess = (analysisData: ExperimentAnalysisResponse) => {
-    const date = new Date();
-    const analysis: AnalysisState = {
-      key: 'live',
-      data: analysisData,
-      updated_at: date,
-      label: `LIVE as of ${extractUtcHHMMLabel(date)}`,
-      effectSizesByMetric: precomputeFreqEffectsByMetric(analysisData, alpha),
-      banditEffects: precomputeBanditEffects(analysisData),
-    };
-    setLiveAnalysis(analysis);
-    // Only update the display if we were previously viewing live data.
-    if (selectedAnalysisState.key === 'live') {
-      handleSelectedAnalysisAndMetrics(analysis);
-    }
-  };
+	const handleLiveAnalysisSuccess = (
+		analysisData: ExperimentAnalysisResponse,
+	) => {
+		const date = new Date();
+		const analysis: AnalysisState = {
+			key: "live",
+			data: analysisData,
+			updated_at: date,
+			label: `LIVE as of ${extractUtcHHMMLabel(date)}`,
+			effectSizesByMetric: precomputeFreqEffectsByMetric(analysisData, alpha),
+			banditEffects: precomputeBanditEffects(analysisData),
+		};
+		setLiveAnalysis(analysis);
+		// Only update the display if we were previously viewing live data.
+		if (selectedAnalysisState.key === "live") {
+			handleSelectedAnalysisAndMetrics(analysis);
+		}
+	};
 
-  const handleSelectAnalysis = async (key: string) => {
-    if (key === 'live') {
-      // If we haven't fetched it yet, trigger a live analysis.
-      if (liveAnalysis.data === undefined) {
-        await triggerLiveAnalysis();
-      }
-      handleSelectedAnalysisAndMetrics(liveAnalysis);
-    } else {
-      const analysis = analysisHistory.find((opt) => opt.key === key) || liveAnalysis;
-      handleSelectedAnalysisAndMetrics(analysis);
-    }
-  };
+	const handleSelectAnalysis = async (key: string) => {
+		if (key === "live") {
+			// If we haven't fetched it yet, trigger a live analysis.
+			if (liveAnalysis.data === undefined) {
+				await triggerLiveAnalysis();
+			}
+			handleSelectedAnalysisAndMetrics(liveAnalysis);
+		} else {
+			const analysis =
+				analysisHistory.find((opt) => opt.key === key) || liveAnalysis;
+			handleSelectedAnalysisAndMetrics(analysis);
+		}
+	};
 
-  const handleUpdateCmabContextValue = async (key: string, context_inputs: ContextInput[]) => {
-    if (key === 'live') {
-      const updatedRequest = { ...cmabAnalysisRequest, context_inputs: context_inputs };
-      setCmabAnalysisRequest(updatedRequest);
-      await triggerLiveAnalysis(updatedRequest);
-    } else {
-      console.warn('Cannot update context values for snapshot analyses.');
-    }
-  };
+	const handleUpdateCmabContextValue = async (
+		key: string,
+		context_inputs: ContextInput[],
+	) => {
+		if (key === "live") {
+			const updatedRequest = {
+				...cmabAnalysisRequest,
+				context_inputs: context_inputs,
+			};
+			setCmabAnalysisRequest(updatedRequest);
+			await triggerLiveAnalysis(updatedRequest);
+		} else {
+			console.warn("Cannot update context values for snapshot analyses.");
+		}
+	};
 
-  const showLoadingAnalysisSpinner = isLoadingLiveAnalysis || isLoadingLiveCmabAnalysis || isLoadingHistory;
+	const showLoadingAnalysisSpinner =
+		isLoadingLiveAnalysis || isLoadingLiveCmabAnalysis || isLoadingHistory;
 
-  if (isLoadingExperiment) {
-    return <XSpinner message="Loading experiment details..." />;
-  }
+	if (isLoadingExperiment) {
+		return <XSpinner message="Loading experiment details..." />;
+	}
 
-  if (experimentError) {
-    return <GenericErrorCallout title="Error loading experiment" error={experimentError} />;
-  }
+	if (experimentError) {
+		return (
+			<GenericErrorCallout
+				title="Error loading experiment"
+				error={experimentError}
+			/>
+		);
+	}
 
-  if (!experiment) {
-    return <Text>No experiment data found</Text>;
-  }
+	if (!experiment) {
+		return <Text>No experiment data found</Text>;
+	}
 
-  const { design_spec, assign_summary, decision, impact } = experiment.config;
-  const { alpha, power } = getAlphaAndPower(experiment.config); // undefined for non-frequentist experiments
-  const { experiment_name, description, start_date, end_date, arms, design_url } = design_spec;
-  const isFrequentistExperiment = isFrequentistSpec(design_spec);
-  const contexts = isBanditSpec(design_spec) ? (design_spec.contexts ?? []) : [];
+	const { design_spec, assign_summary, decision, impact, power_analyses } =
+		experiment.config;
+	const { alpha, power } = getAlphaAndPower(experiment.config); // undefined for non-frequentist experiments
+	const {
+		experiment_name,
+		description,
+		start_date,
+		end_date,
+		arms,
+		design_url,
+	} = design_spec;
+	const isFrequentistExperiment = isFrequentistSpec(design_spec);
+	const contexts = isBanditSpec(design_spec)
+		? (design_spec.contexts ?? [])
+		: [];
 
-  const selectedMetricAnalyses =
-    selectedAnalysisState.data && 'metric_analyses' in selectedAnalysisState.data
-      ? selectedAnalysisState.data.metric_analyses
-      : null;
+	const selectedMetricAnalyses =
+		selectedAnalysisState.data &&
+		"metric_analyses" in selectedAnalysisState.data
+			? selectedAnalysisState.data.metric_analyses
+			: null;
 
-  // Calculate MDE percentage for the selected metric
-  let mdePct: string | null = null;
-  if (selectedMetricAnalysis?.metric?.metric_pct_change) {
-    mdePct = (selectedMetricAnalysis.metric.metric_pct_change * 100).toFixed(1);
-  }
+	// Calculate MDE percentage for the selected metric
+	let mdePct: string | null = null;
+	if (selectedMetricAnalysis?.metric?.metric_pct_change) {
+		mdePct = (selectedMetricAnalysis.metric.metric_pct_change * 100).toFixed(1);
+	}
 
-  const { timeseriesData, armMetadata, minDate, maxDate } = transformAnalysisForForestTimeseriesPlot(
-    analysisHistory,
-    selectedMetricName,
-  );
+	const { timeseriesData, armMetadata, minDate, maxDate } =
+		transformAnalysisForForestTimeseriesPlot(
+			analysisHistory,
+			selectedMetricName,
+		);
 
-  const isLastSnapshotErrorRelevant =
-    lastErrorTimestamp !== null && Date.now() - lastErrorTimestamp.getTime() <= SNAPSHOT_ERROR_ALERT_THRESHOLD_MS;
+	const isLastSnapshotErrorRelevant =
+		lastErrorTimestamp !== null &&
+		Date.now() - lastErrorTimestamp.getTime() <=
+			SNAPSHOT_ERROR_ALERT_THRESHOLD_MS;
 
-  return (
-    <Flex direction="column" gap="6">
-      <Flex direction="column" gap="3">
-        <Flex direction="row" justify="between" gap="2" align="center">
-          <EditableTextField value={experiment_name} onSubmit={(value) => updateExperiment({ name: value })} size="2">
-            <Heading size="8">{experiment_name}</Heading>
-          </EditableTextField>
-          <Flex gap="2" align="center">
-            <IntegrationGuideDialog
-              experimentId={experimentId}
-              datasourceId={datasourceId}
-              organizationId={organizationId}
-              arms={arms}
-              contexts={contexts}
-            />
-            <ExperimentDetailsDropdownMenu datasourceId={datasourceId} experimentId={experimentId} />
-          </Flex>
-        </Flex>
+	return (
+		<Flex direction="column" gap="6">
+			<Flex direction="column" gap="3">
+				<Flex direction="row" justify="between" gap="2" align="center">
+					<EditableTextField
+						value={experiment_name}
+						onSubmit={(value) => updateExperiment({ name: value })}
+						size="2"
+					>
+						<Heading size="8">{experiment_name}</Heading>
+					</EditableTextField>
+					<Flex gap="2" align="center">
+						<IntegrationGuideDialog
+							experimentId={experimentId}
+							datasourceId={datasourceId}
+							organizationId={organizationId}
+							arms={arms}
+							contexts={contexts}
+						/>
+						<ExperimentDetailsDropdownMenu
+							datasourceId={datasourceId}
+							experimentId={experimentId}
+						/>
+					</Flex>
+				</Flex>
 
-        <ExperimentCompletionCallout endDate={end_date} hasImpact={!!impact} hasDecision={!!decision} />
+				<ExperimentCompletionCallout
+					endDate={end_date}
+					hasImpact={!!impact}
+					hasDecision={!!decision}
+				/>
 
-        <Flex gap="4" align="center">
-          <Flex align="center" gap="2">
-            <CalendarIcon />
-            <EditableDateField
-              value={start_date}
-              onSubmit={(value) => updateExperiment({ start_date: value })}
-              size="1"
-            />
-            <Text>→</Text>
-            <EditableDateField value={end_date} onSubmit={(value) => updateExperiment({ end_date: value })} size="1" />
-          </Flex>
-          <Separator orientation="vertical" />
-          <ExperimentStatusBadge status={getExperimentStatus(start_date, end_date)} />
-        </Flex>
-        <Flex gap="4" align="center">
-          <ExperimentTypeBadge type={design_spec.experiment_type} />
-          <Separator orientation="vertical" />
-          {isFrequentistSpec(design_spec) && (
-            <>
-              {design_spec.table_name ? (
-                <>
-                  <TableNameBadge tableName={design_spec.table_name} />
-                  <Separator orientation="vertical" />
-                </>
-              ) : experiment.config.participant_type_deprecated ? (
-                // For backwards compatibility with legacy experiments, show the participant type badge.
-                <>
-                  <ParticipantTypeBadge
-                    datasourceId={experiment.config.datasource_id}
-                    participantType={experiment.config.participant_type_deprecated}
-                  />
-                  <Separator orientation="vertical" />
-                </>
-              ) : null}
-            </>
-          )}
-          <>
-            <TargetingDialog
-              designSpec={design_spec}
-              participantType={experiment.participant_type}
-              webhookIds={experiment.config.webhooks ?? []}
-            />
-            <Separator orientation="vertical" />
-          </>
-          {isFrequentistSpec(design_spec) && (
-            <>
-              <PowerAndBalanceDialog
-                confidence={Math.round((1 - alpha!) * 100)}
-                power={Math.round(power! * 100)}
-                desiredN={design_spec.desired_n ?? undefined}
-                assignSummary={assign_summary}
-              />
-              <Separator orientation="vertical" />
-            </>
-          )}
-          <Flex align="center" gap="2">
-            <FileTextIcon />
-            <EditableTextField
-              value={design_url ?? ''}
-              onSubmit={(value) => updateExperiment({ design_url: value })}
-              size="1"
-            >
-              {design_url ? (
-                <Link href={design_url} target="_blank" rel="noopener noreferrer">
-                  <Text color="blue" style={{ textDecoration: 'underline' }}>
-                    {design_url.slice(0, 30)}
-                    {design_url.length > 30 ? '...' : ''}
-                  </Text>
-                </Link>
-              ) : (
-                <Text color="gray">No design doc</Text>
-              )}
-            </EditableTextField>
-          </Flex>
-        </Flex>
-      </Flex>
-      <Flex direction="column" gap="4">
-        {/* Hypothesis Section */}
-        <SectionCard title="Hypothesis">
-          <EditableTextArea value={description} onSubmit={(value) => updateExperiment({ description: value })} size="2">
-            <ReadMoreText text={description} maxWords={30} />
-          </EditableTextArea>
-        </SectionCard>
+				<Flex gap="4" align="center">
+					<Flex align="center" gap="2">
+						<CalendarIcon />
+						<EditableDateField
+							value={start_date}
+							onSubmit={(value) => updateExperiment({ start_date: value })}
+							size="1"
+						/>
+						<Text>→</Text>
+						<EditableDateField
+							value={end_date}
+							onSubmit={(value) => updateExperiment({ end_date: value })}
+							size="1"
+						/>
+					</Flex>
+					<Separator orientation="vertical" />
+					<ExperimentStatusBadge
+						status={getExperimentStatus(start_date, end_date)}
+					/>
+				</Flex>
+				<Flex gap="4" align="center">
+					<ExperimentTypeBadge
+						type={design_spec.experiment_type}
+						isCluster={isClusterDesign(design_spec, power_analyses)}
+					/>
+					{isClusterDesign(design_spec, power_analyses) && (
+						<>
+							<Separator orientation="vertical" />
+							<Tooltip
+								content={`Cluster ID: ${
+									(design_spec as { cluster_column?: string | null })
+										.cluster_column ?? "(persisted in power analysis)"
+								}${
+									power_analyses?.analyses?.[0]?.num_clusters_total != null
+										? ` — ${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters needed across all arms`
+										: ""
+								}`}
+							>
+								<Badge size="2">
+									{power_analyses?.analyses?.[0]?.num_clusters_total != null
+										? `${power_analyses.analyses[0].num_clusters_total.toLocaleString()} clusters`
+										: "Cluster"}
+								</Badge>
+							</Tooltip>
+						</>
+					)}
+					<Separator orientation="vertical" />
+					{isFrequentistSpec(design_spec) && (
+						<>
+							{design_spec.table_name ? (
+								<>
+									<TableNameBadge tableName={design_spec.table_name} />
+									<Separator orientation="vertical" />
+								</>
+							) : experiment.config.participant_type_deprecated ? (
+								// For backwards compatibility with legacy experiments, show the participant type badge.
+								<>
+									<ParticipantTypeBadge
+										datasourceId={experiment.config.datasource_id}
+										participantType={
+											experiment.config.participant_type_deprecated
+										}
+									/>
+									<Separator orientation="vertical" />
+								</>
+							) : null}
+						</>
+					)}
+					<>
+						<TargetingDialog
+							designSpec={design_spec}
+							participantType={experiment.participant_type}
+							webhookIds={experiment.config.webhooks ?? []}
+							powerAnalyses={power_analyses}
+						/>
+						<Separator orientation="vertical" />
+					</>
+					{isFrequentistSpec(design_spec) && (
+						<>
+							<PowerAndBalanceDialog
+								confidence={Math.round((1 - alpha!) * 100)}
+								power={Math.round(power! * 100)}
+								desiredN={design_spec.desired_n ?? undefined}
+								assignSummary={assign_summary}
+							/>
+							<Separator orientation="vertical" />
+						</>
+					)}
+					<Flex align="center" gap="2">
+						<FileTextIcon />
+						<EditableTextField
+							value={design_url ?? ""}
+							onSubmit={(value) => updateExperiment({ design_url: value })}
+							size="1"
+						>
+							{design_url ? (
+								<Link
+									href={design_url}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<Text color="blue" style={{ textDecoration: "underline" }}>
+										{design_url.slice(0, 30)}
+										{design_url.length > 30 ? "..." : ""}
+									</Text>
+								</Link>
+							) : (
+								<Text color="gray">No design doc</Text>
+							)}
+						</EditableTextField>
+					</Flex>
+				</Flex>
+			</Flex>
+			<Flex direction="column" gap="4">
+				{/* Hypothesis Section */}
+				<SectionCard title="Hypothesis">
+					<EditableTextArea
+						value={description}
+						onSubmit={(value) => updateExperiment({ description: value })}
+						size="2"
+					>
+						<ReadMoreText text={description} maxWords={30} />
+					</EditableTextArea>
+				</SectionCard>
 
-        {/* Arms & Allocations Section */}
-        {assign_summary && (
-          <SectionCard
-            headerLeft={
-              <Flex gap="3" align="center">
-                <Heading size="3">Arms & Allocations</Heading>
-                <DownloadAssignmentsCsvButton
-                  datasourceId={experiment.config.datasource_id}
-                  experimentId={experimentId}
-                />
-              </Flex>
-            }
-            headerRight={
-              <Badge>
-                <PersonIcon />
-                <Text size="2">{assign_summary.sample_size.toLocaleString()} participants</Text>
-              </Badge>
-            }
-          >
-            <ArmsAndAllocationsTable
-              datasourceId={datasourceId}
-              experimentId={experimentId}
-              arms={arms}
-              sampleSize={assign_summary.sample_size}
-              armSizes={assign_summary.arm_sizes}
-            />
-          </SectionCard>
-        )}
+				{/* Arms & Allocations Section */}
+				{assign_summary &&
+					(() => {
+						// Issue #217: derive cluster totals for the header and per-arm
+						// counts for the table from the stored power_analyses.
+						// We use the primary metric's analysis since cluster counts are
+						// the same across all arms / metrics for a given cluster spec.
+						const isClusterExperiment = isClusterDesign(
+							design_spec,
+							power_analyses,
+						);
+						const primaryAnalysis = power_analyses?.analyses?.[0];
+						const numClustersTotal = primaryAnalysis?.num_clusters_total ?? null;
+						const clustersPerArm = primaryAnalysis?.clusters_per_arm ?? null;
+						// Map per-arm cluster counts onto arm_ids in the design spec's order.
+						const clustersByArmId =
+							isClusterExperiment && clustersPerArm
+								? Object.fromEntries(
+										arms.map((arm, i) => [
+											arm.arm_id ?? `arm-${i}`,
+											clustersPerArm[i] ?? 0,
+										]),
+									)
+								: undefined;
+						return (
+							<SectionCard
+								headerLeft={
+									<Flex gap="3" align="center">
+										<Heading size="3">Arms & Allocations</Heading>
+										<DownloadAssignmentsCsvButton
+											datasourceId={experiment.config.datasource_id}
+											experimentId={experimentId}
+										/>
+									</Flex>
+								}
+								headerRight={
+									<Flex gap="2" align="center">
+										{isClusterExperiment && numClustersTotal !== null && (
+											<Badge color="green">
+												<Text size="2">
+													{numClustersTotal.toLocaleString()} clusters
+												</Text>
+											</Badge>
+										)}
+										<Badge>
+											<PersonIcon />
+											<Text size="2">
+												{assign_summary.sample_size.toLocaleString()}{" "}
+												participants
+											</Text>
+										</Badge>
+									</Flex>
+								}
+							>
+								<ArmsAndAllocationsTable
+									datasourceId={datasourceId}
+									experimentId={experimentId}
+									arms={arms}
+									sampleSize={assign_summary.sample_size}
+									armSizes={assign_summary.arm_sizes}
+									clustersByArmId={clustersByArmId}
+								/>
+							</SectionCard>
+						);
+					})()}
 
-        {/* Analysis Section */}
-        <SectionCard
-          headerLeft={
-            <Flex gap="3" align="center" wrap="wrap">
-              <Heading size="3">Analysis</Heading>
-              {isFrequentistExperiment ? (
-                <Flex gap="3" wrap="wrap">
-                  <Badge size="2">
-                    <Flex gap="2" align="center">
-                      <Heading size="2">Metric:</Heading>
-                      {selectedMetricAnalyses && selectedMetricAnalyses.length > 1 ? (
-                        <Select.Root
-                          size="1"
-                          value={selectedMetricName}
-                          onValueChange={(metricName) => {
-                            handleSelectedAnalysisAndMetrics(selectedAnalysisState, metricName);
-                          }}
-                        >
-                          <Select.Trigger style={{ height: 18 }} />
-                          <Select.Content>
-                            {selectedMetricAnalyses.map((metric) => {
-                              return (
-                                <Select.Item key={metric.metric_name} value={metric.metric_name}>
-                                  {metric.metric_name}
-                                </Select.Item>
-                              );
-                            })}
-                          </Select.Content>
-                        </Select.Root>
-                      ) : (
-                        <Text>{selectedMetricName}</Text>
-                      )}
-                    </Flex>
-                  </Badge>
-                  <MdeBadge value={mdePct} />
-                </Flex>
-              ) : isBanditAnalysis(selectedAnalysisState.data) &&
-                selectedAnalysisState.banditEffects &&
-                selectedAnalysisState.banditEffects.length > 1 ? (
-                <>
-                  <Badge size="2">
-                    <Flex gap="2" align="center">
-                      <Heading size="2"> Prior Type:</Heading>
-                      <Text>{(experiment.config.design_spec as MABExperimentSpecOutput).prior_type}</Text>
-                    </Flex>
-                  </Badge>
-                  <Badge size="2">
-                    <Flex gap="2" align="center">
-                      <Heading size="2">Reward Type:</Heading>
-                      <Text>{(experiment.config.design_spec as MABExperimentSpecOutput).reward_type}</Text>
-                    </Flex>
-                  </Badge>
-                  {cmabContextInputs.length > 0 && (
-                    <ContextConfigBox
-                      analysisKey={selectedAnalysisState.key}
-                      contexts={(experiment.config.design_spec as CMABExperimentSpecOutput).contexts || []}
-                      contextValues={cmabContextInputs}
-                      onUpdate={handleUpdateCmabContextValue}
-                    />
-                  )}
-                </>
-              ) : null}
-            </Flex>
-          }
-          headerRight={
-            <Flex gap="3" wrap="wrap">
-              <Flex gap="3" wrap="wrap" align="center" justify="between">
-                <Badge size="2" style={{ height: '26px' }}>
-                  <Flex gap="2" align="center">
-                    <Heading size="2">Viewing:</Heading>
-                    {analysisHistory.length == 0 ? (
-                      <Text>{liveAnalysis.label}</Text>
-                    ) : (
-                      <>
-                        <Select.Root size="1" value={selectedAnalysisState.key} onValueChange={handleSelectAnalysis}>
-                          <Select.Trigger style={{ height: 18 }} />
-                          <Select.Content>
-                            <Select.Group>
-                              <Select.Item key="live" value="live">
-                                <Box minWidth="136px">{liveAnalysis.label}</Box>
-                              </Select.Item>
-                            </Select.Group>
-                            <Select.Separator />
-                            <Select.Group>
-                              {analysisHistory.map((opt) => (
-                                <Select.Item key={opt.key} value={opt.key}>
-                                  <Box minWidth="136px">{opt.label}</Box>
-                                </Select.Item>
-                              ))}
-                            </Select.Group>
-                          </Select.Content>
-                        </Select.Root>
-                        {isLastSnapshotErrorRelevant ? (
-                          <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
-                            <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
-                              <ExclamationTriangleIcon color={'red'} />
-                            </Link>
-                          </Tooltip>
-                        ) : (
-                          <Tooltip content={'View snapshot log'}>
-                            <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
-                              <ActivityLogIcon />
-                            </Link>
-                          </Tooltip>
-                        )}
-                      </>
-                    )}
-                  </Flex>
-                </Badge>
-              </Flex>
-              {isFrequentistExperiment ? (
-                <Flex gap="3" wrap="wrap">
-                  <Badge size="2">
-                    <Flex gap="4" align="center">
-                      <Heading size="2">Confidence:</Heading>
-                      <Flex gap="2" align="center">
-                        <Text>{alpha ? `${(1 - alpha) * 100}%` : '?'}</Text>
-                        <Tooltip content="Chance that our test correctly shows no significant difference, if there truly is none. (The probability of avoiding a false positive.)">
-                          <InfoCircledIcon />
-                        </Tooltip>
-                      </Flex>
-                    </Flex>
-                  </Badge>
-                  <Badge size="2">
-                    <Flex gap="4" align="center">
-                      <Heading size="2">Power:</Heading>
-                      <Flex gap="2" align="center">
-                        <Text>{power ? `${power * 100}%` : '?'}</Text>
-                        <Tooltip content="Chance of detecting a difference at least as large as the pre-specified minimum effect for the metric, if that difference truly exists. (The probability of avoiding a false negative.)">
-                          <InfoCircledIcon />
-                        </Tooltip>
-                      </Flex>
-                    </Flex>
-                  </Badge>
-                </Flex>
-              ) : (
-                <Badge size="2">
-                  <Flex gap="4" align="center">
-                    <Tooltip
-                      content={`The leaderboard and timeseries show the posterior predictive mean—the estimated average outcome for each arm after observing data and accounting for prior beliefs and noise. This is not a treatment effect! The CI is a confidence interval indicating the interval that contains the true average outcome with 95% probability.`}
-                    >
-                      <InfoCircledIcon />
-                    </Tooltip>
-                  </Flex>
-                </Badge>
-              )}
-            </Flex>
-          }
-        >
-          <Flex direction="column" gap="3">
-            <Tabs.Root defaultValue="leaderboard">
-              <Tabs.List>
-                <Tabs.Trigger value="leaderboard">Leaderboard</Tabs.Trigger>
-                <Tabs.Trigger value="raw">
-                  <Flex gap="2" align="center">
-                    Raw Data <CodeIcon />
-                  </Flex>
-                </Tabs.Trigger>
-                {showLoadingAnalysisSpinner && (
-                  <Tabs.Trigger value="loading" disabled={true}>
-                    <Flex gap="2" align="center">
-                      <XSpinner message="Loading analyses..." />
-                    </Flex>
-                  </Tabs.Trigger>
-                )}
-              </Tabs.List>
-              <Box px="4">
-                <Tabs.Content value="leaderboard">
-                  <Flex direction="column" gap="3" py="3">
-                    {/* Analysis may not be available yet or the experiment hasn't collected enough data. */}
-                    {(liveAnalysisError || liveCmabAnalysisError) && (
-                      <GenericErrorCallout
-                        title="Error loading live analysis"
-                        error={liveAnalysisError ?? liveCmabAnalysisError}
-                      />
-                    )}
+				{/* Analysis Section */}
+				<SectionCard
+					headerLeft={
+						<Flex gap="3" align="center" wrap="wrap">
+							<Heading size="3">Analysis</Heading>
+							{isFrequentistExperiment ? (
+								<Flex gap="3" wrap="wrap">
+									<Badge size="2">
+										<Flex gap="2" align="center">
+											<Heading size="2">Metric:</Heading>
+											{selectedMetricAnalyses &&
+											selectedMetricAnalyses.length > 1 ? (
+												<Select.Root
+													size="1"
+													value={selectedMetricName}
+													onValueChange={(metricName) => {
+														handleSelectedAnalysisAndMetrics(
+															selectedAnalysisState,
+															metricName,
+														);
+													}}
+												>
+													<Select.Trigger style={{ height: 18 }} />
+													<Select.Content>
+														{selectedMetricAnalyses.map((metric) => {
+															return (
+																<Select.Item
+																	key={metric.metric_name}
+																	value={metric.metric_name}
+																>
+																	{metric.metric_name}
+																</Select.Item>
+															);
+														})}
+													</Select.Content>
+												</Select.Root>
+											) : (
+												<Text>{selectedMetricName}</Text>
+											)}
+										</Flex>
+									</Badge>
+									<MdeBadge value={mdePct} />
+									{/* Issue #217: show ICC pill for cluster-randomized experiments. */}
+									<IccBadge
+										value={
+											(selectedMetricAnalysis?.metric as
+												| { icc?: number | null }
+												| undefined)?.icc ?? null
+										}
+									/>
+								</Flex>
+							) : isBanditAnalysis(selectedAnalysisState.data) &&
+								selectedAnalysisState.banditEffects &&
+								selectedAnalysisState.banditEffects.length > 1 ? (
+								<>
+									<Badge size="2">
+										<Flex gap="2" align="center">
+											<Heading size="2"> Prior Type:</Heading>
+											<Text>
+												{
+													(
+														experiment.config
+															.design_spec as MABExperimentSpecOutput
+													).prior_type
+												}
+											</Text>
+										</Flex>
+									</Badge>
+									<Badge size="2">
+										<Flex gap="2" align="center">
+											<Heading size="2">Reward Type:</Heading>
+											<Text>
+												{
+													(
+														experiment.config
+															.design_spec as MABExperimentSpecOutput
+													).reward_type
+												}
+											</Text>
+										</Flex>
+									</Badge>
+									{cmabContextInputs.length > 0 && (
+										<ContextConfigBox
+											analysisKey={selectedAnalysisState.key}
+											contexts={
+												(
+													experiment.config
+														.design_spec as CMABExperimentSpecOutput
+												).contexts || []
+											}
+											contextValues={cmabContextInputs}
+											onUpdate={handleUpdateCmabContextValue}
+										/>
+									)}
+								</>
+							) : null}
+						</Flex>
+					}
+					headerRight={
+						<Flex gap="3" wrap="wrap">
+							<Flex gap="3" wrap="wrap" align="center" justify="between">
+								<Badge size="2" style={{ height: "26px" }}>
+									<Flex gap="2" align="center">
+										<Heading size="2">Viewing:</Heading>
+										{analysisHistory.length == 0 ? (
+											<Text>{liveAnalysis.label}</Text>
+										) : (
+											<>
+												<Select.Root
+													size="1"
+													value={selectedAnalysisState.key}
+													onValueChange={handleSelectAnalysis}
+												>
+													<Select.Trigger style={{ height: 18 }} />
+													<Select.Content>
+														<Select.Group>
+															<Select.Item key="live" value="live">
+																<Box minWidth="136px">{liveAnalysis.label}</Box>
+															</Select.Item>
+														</Select.Group>
+														<Select.Separator />
+														<Select.Group>
+															{analysisHistory.map((opt) => (
+																<Select.Item key={opt.key} value={opt.key}>
+																	<Box minWidth="136px">{opt.label}</Box>
+																</Select.Item>
+															))}
+														</Select.Group>
+													</Select.Content>
+												</Select.Root>
+												{isLastSnapshotErrorRelevant ? (
+													<Tooltip
+														content={
+															"Last snapshot error: " +
+															lastErrorTimestamp?.toLocaleTimeString()
+														}
+													>
+														<Link
+															href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}
+														>
+															<ExclamationTriangleIcon color={"red"} />
+														</Link>
+													</Tooltip>
+												) : (
+													<Tooltip content={"View snapshot log"}>
+														<Link
+															href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}
+														>
+															<ActivityLogIcon />
+														</Link>
+													</Tooltip>
+												)}
+											</>
+										)}
+									</Flex>
+								</Badge>
+							</Flex>
+							{isFrequentistExperiment ? (
+								<Flex gap="3" wrap="wrap">
+									<Badge size="2">
+										<Flex gap="4" align="center">
+											<Heading size="2">Confidence:</Heading>
+											<Flex gap="2" align="center">
+												<Text>{alpha ? `${(1 - alpha) * 100}%` : "?"}</Text>
+												<Tooltip content="Chance that our test correctly shows no significant difference, if there truly is none. (The probability of avoiding a false positive.)">
+													<InfoCircledIcon />
+												</Tooltip>
+											</Flex>
+										</Flex>
+									</Badge>
+									<Badge size="2">
+										<Flex gap="4" align="center">
+											<Heading size="2">Power:</Heading>
+											<Flex gap="2" align="center">
+												<Text>{power ? `${power * 100}%` : "?"}</Text>
+												<Tooltip content="Chance of detecting a difference at least as large as the pre-specified minimum effect for the metric, if that difference truly exists. (The probability of avoiding a false negative.)">
+													<InfoCircledIcon />
+												</Tooltip>
+											</Flex>
+										</Flex>
+									</Badge>
+								</Flex>
+							) : (
+								<Badge size="2">
+									<Flex gap="4" align="center">
+										<Tooltip
+											content={`The leaderboard and timeseries show the posterior predictive mean—the estimated average outcome for each arm after observing data and accounting for prior beliefs and noise. This is not a treatment effect! The CI is a confidence interval indicating the interval that contains the true average outcome with 95% probability.`}
+										>
+											<InfoCircledIcon />
+										</Tooltip>
+									</Flex>
+								</Badge>
+							)}
+						</Flex>
+					}
+				>
+					<Flex direction="column" gap="3">
+						<Tabs.Root defaultValue="leaderboard">
+							<Tabs.List>
+								<Tabs.Trigger value="leaderboard">Leaderboard</Tabs.Trigger>
+								<Tabs.Trigger value="raw">
+									<Flex gap="2" align="center">
+										Raw Data <CodeIcon />
+									</Flex>
+								</Tabs.Trigger>
+								{showLoadingAnalysisSpinner && (
+									<Tabs.Trigger value="loading" disabled={true}>
+										<Flex gap="2" align="center">
+											<XSpinner message="Loading analyses..." />
+										</Flex>
+									</Tabs.Trigger>
+								)}
+							</Tabs.List>
+							<Box px="4">
+								<Tabs.Content value="leaderboard">
+									<Flex direction="column" gap="3" py="3">
+										{/* Analysis may not be available yet or the experiment hasn't collected enough data. */}
+										{(liveAnalysisError || liveCmabAnalysisError) && (
+											<GenericErrorCallout
+												title="Error loading live analysis"
+												error={liveAnalysisError ?? liveCmabAnalysisError}
+											/>
+										)}
 
-                    {selectedAnalysisState.data && (
-                      <ForestPlot
-                        effectSizes={selectedAnalysisState.effectSizesByMetric?.get(selectedMetricName)}
-                        banditEffects={selectedAnalysisState.banditEffects}
-                        minX={ciBounds[0]}
-                        maxX={ciBounds[1]}
-                      />
-                    )}
+										{selectedAnalysisState.data && (
+											<ForestPlot
+												effectSizes={selectedAnalysisState.effectSizesByMetric?.get(
+													selectedMetricName,
+												)}
+												banditEffects={selectedAnalysisState.banditEffects}
+												minX={ciBounds[0]}
+												maxX={ciBounds[1]}
+											/>
+										)}
 
-                    {analysisHistoryError && (
-                      <GenericErrorCallout
-                        title="Error loading historical analyses"
-                        message="Historical analyses may not be available yet."
-                      />
-                    )}
+										{analysisHistoryError && (
+											<GenericErrorCallout
+												title="Error loading historical analyses"
+												message="Historical analyses may not be available yet."
+											/>
+										)}
 
-                    {!isLoadingHistory && (
-                      <ForestTimeseriesPlot
-                        data={timeseriesData}
-                        armMetadata={armMetadata}
-                        minDate={minDate}
-                        maxDate={maxDate}
-                        onPointClick={handleSelectAnalysis}
-                      />
-                    )}
-                  </Flex>
-                </Tabs.Content>
+										{!isLoadingHistory && (
+											<ForestTimeseriesPlot
+												data={timeseriesData}
+												armMetadata={armMetadata}
+												minDate={minDate}
+												maxDate={maxDate}
+												onPointClick={handleSelectAnalysis}
+											/>
+										)}
+									</Flex>
+								</Tabs.Content>
 
-                <Tabs.Content value="raw">
-                  <Flex direction="column" gap="3" py="3">
-                    <CodeSnippetCard
-                      title="Raw Data"
-                      content={selectedAnalysisState.data ? prettyJSON(selectedAnalysisState.data) : 'NO DATA'}
-                      height="200px"
-                      tooltipContent="Copy raw data"
-                      variant="ghost"
-                    />
-                  </Flex>
-                </Tabs.Content>
-              </Box>
-            </Tabs.Root>
-          </Flex>
-        </SectionCard>
+								<Tabs.Content value="raw">
+									<Flex direction="column" gap="3" py="3">
+										<CodeSnippetCard
+											title="Raw Data"
+											content={
+												selectedAnalysisState.data
+													? prettyJSON(selectedAnalysisState.data)
+													: "NO DATA"
+											}
+											height="200px"
+											tooltipContent="Copy raw data"
+											variant="ghost"
+										/>
+									</Flex>
+								</Tabs.Content>
+							</Box>
+						</Tabs.Root>
+					</Flex>
+				</SectionCard>
 
-        <div id="decision-and-impact" />
-        <DecisionAndImpactSection
-          impact={impact}
-          decision={decision}
-          onUpdate={(updates) => updateExperiment(updates)}
-        />
-      </Flex>
-    </Flex>
-  );
+				<div id="decision-and-impact" />
+				<DecisionAndImpactSection
+					impact={impact}
+					decision={decision}
+					onUpdate={(updates) => updateExperiment(updates)}
+				/>
+			</Flex>
+		</Flex>
+	);
 }

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -214,7 +214,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
 
   const { trigger: triggerCreate, isMutating: createLoading } = useCreateExperiment(
     datasourceId,
-    { desired_n: 0 },
+    {},
     {
       swr: {
         onSuccess: async (response) => {

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -1,53 +1,53 @@
-import { abandonExperiment } from "@/api/admin";
+import { abandonExperiment } from '@/api/admin';
 import {
-	Arm,
-	BayesABExperimentSpecInputExperimentType,
-	ContextType,
-	CreateExperimentResponse,
-	DesignSpecInput,
-	FieldMetadata,
-	FilterInput,
-	GetFiltersResponseElement,
-	PowerResponseOutput,
-} from "@/api/methods.schemas";
+  Arm,
+  BayesABExperimentSpecInputExperimentType,
+  ContextType,
+  CreateExperimentResponse,
+  DesignSpecInput,
+  FieldMetadata,
+  FilterInput,
+  GetFiltersResponseElement,
+  PowerResponseOutput,
+} from '@/api/methods.schemas';
 import {
-	createDefaultBanditParams,
-	toBanditParamsForExperimentType,
-	toCmabBanditParams,
-	toMabBanditParams,
-} from "@/app/experiments/create/experiment-form/experiment-bandit-helpers";
+  createDefaultBanditParams,
+  toBanditParamsForExperimentType,
+  toCmabBanditParams,
+  toMabBanditParams,
+} from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 import {
-	ExperimentDescribeArmsMessage,
-	ExperimentDescribeArmsScreen,
-} from "@/app/experiments/create/experiment-form/experiment-describe-arms-screen";
-import { ExperimentDescribeBanditArmsScreen } from "@/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen";
-import { ExperimentDescribeContextsScreen } from "@/app/experiments/create/experiment-form/experiment-describe-contexts-screen";
+  ExperimentDescribeArmsMessage,
+  ExperimentDescribeArmsScreen,
+} from '@/app/experiments/create/experiment-form/experiment-describe-arms-screen';
+import { ExperimentDescribeBanditArmsScreen } from '@/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen';
+import { ExperimentDescribeContextsScreen } from '@/app/experiments/create/experiment-form/experiment-describe-contexts-screen';
 import {
-	getReasonableEndDate,
-	getReasonableStartDate,
-	removeFieldByName,
-} from "@/app/experiments/create/experiment-form/experiment-form-helpers";
+  getReasonableEndDate,
+  getReasonableStartDate,
+  removeFieldByName,
+} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import {
-	BanditParams,
-	MetricWithMDE,
-	isBanditExperimentType,
-} from "@/app/experiments/create/experiment-form/experiment-form-types";
+  BanditParams,
+  MetricWithMDE,
+  isBanditExperimentType,
+} from '@/app/experiments/create/experiment-form/experiment-form-types';
 import {
-	ExperimentFreqStackScreen,
-	ExperimentFreqStackScreenMessage,
-} from "@/app/experiments/create/experiment-form/experiment-freq-stack-screen";
+  ExperimentFreqStackScreen,
+  ExperimentFreqStackScreenMessage,
+} from '@/app/experiments/create/experiment-form/experiment-freq-stack-screen';
 import {
-	ExperimentMetadataMessages,
-	ExperimentMetadataScreen,
-} from "@/app/experiments/create/experiment-form/experiment-metadata-screen";
-import { ExperimentSelectBinaryOrRealOutcomes } from "@/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes";
-import { ExperimentSelectDatasourceScreen } from "@/app/experiments/create/experiment-form/experiment-select-datasource-screen";
-import { ExperimentsSummarizeBanditScreen } from "@/app/experiments/create/experiment-form/experiment-summarize-bandit-screen";
-import { ExperimentsSummarizeFreqScreen } from "@/app/experiments/create/experiment-form/experiment-summarize-freq-screen";
-import { ExperimentTypeScreen } from "@/app/experiments/create/experiment-form/experiment-type-screen";
-import { ErrorType } from "@/services/orval-fetch";
+  ExperimentMetadataMessages,
+  ExperimentMetadataScreen,
+} from '@/app/experiments/create/experiment-form/experiment-metadata-screen';
+import { ExperimentSelectBinaryOrRealOutcomes } from '@/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes';
+import { ExperimentSelectDatasourceScreen } from '@/app/experiments/create/experiment-form/experiment-select-datasource-screen';
+import { ExperimentsSummarizeBanditScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-bandit-screen';
+import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-freq-screen';
+import { ExperimentTypeScreen } from '@/app/experiments/create/experiment-form/experiment-type-screen';
+import { ErrorType } from '@/services/orval-fetch';
 // Form data types
-import { WizardForm, packScreen } from "@/services/wizard/wizard-types";
+import { WizardForm, packScreen } from '@/services/wizard/wizard-types';
 
 /**
  * ExperimentType in the FE wizard. Includes the FE-only
@@ -56,731 +56,686 @@ import { WizardForm, packScreen } from "@/services/wizard/wizard-types";
  * (see convertToFrequentistDesignSpec).
  */
 export type ExperimentType =
-	| Exclude<DesignSpecInput["experiment_type"], BayesABExperimentSpecInputExperimentType>
-	| "freq_cluster_preassigned";
+  | Exclude<DesignSpecInput['experiment_type'], BayesABExperimentSpecInputExperimentType>
+  | 'freq_cluster_preassigned';
 
 // Defines the entirety of the editable data collected via this wizard flow.
 export type ExperimentFormData = {
-	// experiment-metadata-screen
-	name?: string;
-	hypothesis?: string;
-	designUrl?: string;
-	startDate?: string;
-	endDate?: string;
+  // experiment-metadata-screen
+  name?: string;
+  hypothesis?: string;
+  designUrl?: string;
+  startDate?: string;
+  endDate?: string;
 
-	// experiment-type-screen
-	experimentType?: ExperimentType;
+  // experiment-type-screen
+  experimentType?: ExperimentType;
 
-	// experiment-select-datasource-screen
-	datasourceId?: string;
-	tableName?: string;
+  // experiment-select-datasource-screen
+  datasourceId?: string;
+  tableName?: string;
 
-	// experiment-freq-stack-screen
-	primaryKey?: string;
-	primaryMetric?: MetricWithMDE;
-	secondaryMetrics?: MetricWithMDE[];
-	filters?: FilterInput[];
-	// Cache of available filter fields (and their data types) for lookup/display/search
-	availableFilterFields?: GetFiltersResponseElement[];
-	strata?: FieldMetadata[];
-	// Randomization mode for issue #217. Undefined treated as 'strata' for backwards compat.
-	randomizationType?: "strata" | "cluster";
-	// Selected cluster ID field when randomizationType === 'cluster'.
-	clusterField?: FieldMetadata;
-	// Manual ICC / CV / avg cluster size inputs. Strings to allow empty values;
-	// converted to numbers when building the design spec.
-	clusterIcc?: string;
-	clusterCv?: string;
-	clusterAvgSize?: string;
-	// These next 2 Experiment Parameters are strings to allow for empty values,
-	// which should be converted to numbers when making power or experiment creation requests.
-	confidence?: string;
-	power?: string;
-	// Populated when user clicks "Power Check" on DesignForm
-	desiredN?: number;
-	powerCheckResponse?: PowerResponseOutput;
-	// Populated when the user picks "Use max available" or types a Custom N
-	// on the Power Analysis page. This is the MDE-mode power-check response for
-	// the chosen sample size — it carries the achievable MDE plus a cluster
-	// split that matches `desiredN`. We keep it separate from
-	// `powerCheckResponse` because the "Use minimum sample required" radio
-	// still needs the original sample-size-mode response to show the recommended
-	// cluster count. At save time, prefer this over `powerCheckResponse` so the
-	// saved experiment reflects the user's chosen N.
-	achievablePowerCheckResponse?: PowerResponseOutput;
-	createExperimentResponse?: CreateExperimentResponse;
-	createExperimentError?: ErrorType<unknown>;
+  // experiment-freq-stack-screen
+  primaryKey?: string;
+  primaryMetric?: MetricWithMDE;
+  secondaryMetrics?: MetricWithMDE[];
+  filters?: FilterInput[];
+  // Cache of available filter fields (and their data types) for lookup/display/search
+  availableFilterFields?: GetFiltersResponseElement[];
+  strata?: FieldMetadata[];
+  // Randomization mode for issue #217. Undefined treated as 'strata' for backwards compat.
+  randomizationType?: 'strata' | 'cluster';
+  // Selected cluster ID field when randomizationType === 'cluster'.
+  clusterField?: FieldMetadata;
+  // Manual ICC / CV / avg cluster size inputs. Strings to allow empty values;
+  // converted to numbers when building the design spec.
+  clusterIcc?: string;
+  clusterCv?: string;
+  clusterAvgSize?: string;
+  // These next 2 Experiment Parameters are strings to allow for empty values,
+  // which should be converted to numbers when making power or experiment creation requests.
+  confidence?: string;
+  power?: string;
+  // Populated when user clicks "Power Check" on DesignForm
+  desiredN?: number;
+  powerCheckResponse?: PowerResponseOutput;
+  // Populated when the user picks "Use max available" or types a Custom N
+  // on the Power Analysis page. This is the MDE-mode power-check response for
+  // the chosen sample size — it carries the achievable MDE plus a cluster
+  // split that matches `desiredN`. We keep it separate from
+  // `powerCheckResponse` because the "Use minimum sample required" radio
+  // still needs the original sample-size-mode response to show the recommended
+  // cluster count. At save time, prefer this over `powerCheckResponse` so the
+  // saved experiment reflects the user's chosen N.
+  achievablePowerCheckResponse?: PowerResponseOutput;
+  createExperimentResponse?: CreateExperimentResponse;
+  createExperimentError?: ErrorType<unknown>;
 
-	// experiment-describe-webhooks-screen
-	selectedWebhookIds?: string[];
+  // experiment-describe-webhooks-screen
+  selectedWebhookIds?: string[];
 
-	// experiment-describe-arms-screen
-	arms?: Omit<Arm, "arm_id">[];
+  // experiment-describe-arms-screen
+  arms?: Omit<Arm, 'arm_id'>[];
 
-	// bandit flow config
-	bandit?: BanditParams;
+  // bandit flow config
+  bandit?: BanditParams;
 
-	// experiment-summarize-freq-screen (populated after createExperiment API call)
-	experimentId?: string;
-	commitError?: ErrorType<unknown>;
+  // experiment-summarize-freq-screen (populated after createExperiment API call)
+  experimentId?: string;
+  commitError?: ErrorType<unknown>;
 };
 
 const isFreq = (experimentType: ExperimentType) => {
-	return (
-		experimentType === "freq_online" ||
-		experimentType === "freq_preassigned" ||
-		experimentType === "freq_cluster_preassigned"
-	);
+  return (
+    experimentType === 'freq_online' ||
+    experimentType === 'freq_preassigned' ||
+    experimentType === 'freq_cluster_preassigned'
+  );
 };
 
 const isCmab = (experimentType: ExperimentType) => {
-	return experimentType === "cmab_online";
+  return experimentType === 'cmab_online';
 };
 
 // Defines a type for all known screen IDs for the experiment form. This type is used with screen() to
 // type-check the ids returned by nextScreen and prevScreen.
 export type ExperimentScreenId =
-	| "metadata"
-	| "experiment-type"
-	| "freq-select-datasource"
-	| "bandit-binary-or-real"
-	| "describe-contexts"
-	| "describe-arms"
-	| "describe-bandit-arms"
-	| "freq-stack"
-	| "summarize-freq"
-	| "summarize-bandit";
+  | 'metadata'
+  | 'experiment-type'
+  | 'freq-select-datasource'
+  | 'bandit-binary-or-real'
+  | 'describe-contexts'
+  | 'describe-arms'
+  | 'describe-bandit-arms'
+  | 'freq-stack'
+  | 'summarize-freq'
+  | 'summarize-bandit';
 
 // Helper to create screens with proper type inference
 const screen = packScreen<ExperimentFormData, ExperimentScreenId>();
 
 const FREQUENTIST_BREADCRUMBS: Array<ExperimentScreenId> = [
-	"metadata",
-	"experiment-type",
-	"describe-arms",
-	"freq-select-datasource",
-	"freq-stack",
-	"summarize-freq",
+  'metadata',
+  'experiment-type',
+  'describe-arms',
+  'freq-select-datasource',
+  'freq-stack',
+  'summarize-freq',
 ] as const;
 
 const CMAB_BREADCRUMBS: Array<ExperimentScreenId> = [
-	"metadata",
-	"experiment-type",
-	"describe-contexts",
-	"bandit-binary-or-real",
-	"describe-bandit-arms",
-	"summarize-bandit",
+  'metadata',
+  'experiment-type',
+  'describe-contexts',
+  'bandit-binary-or-real',
+  'describe-bandit-arms',
+  'summarize-bandit',
 ] as const;
 
 const MAB_BREADCRUMBS: Array<ExperimentScreenId> = [
-	"metadata",
-	"experiment-type",
-	"bandit-binary-or-real",
-	"describe-bandit-arms",
-	"summarize-bandit",
+  'metadata',
+  'experiment-type',
+  'bandit-binary-or-real',
+  'describe-bandit-arms',
+  'summarize-bandit',
 ] as const;
 
-const breadcrumbs = ({
-	experimentType,
-}: { experimentType?: ExperimentType }) => {
-	if (experimentType === undefined) {
-		return [];
-	} else if (isFreq(experimentType)) {
-		return FREQUENTIST_BREADCRUMBS;
-	} else if (isCmab(experimentType)) {
-		return CMAB_BREADCRUMBS;
-	} else {
-		return MAB_BREADCRUMBS;
-	}
+const breadcrumbs = ({ experimentType }: { experimentType?: ExperimentType }) => {
+  if (experimentType === undefined) {
+    return [];
+  } else if (isFreq(experimentType)) {
+    return FREQUENTIST_BREADCRUMBS;
+  } else if (isCmab(experimentType)) {
+    return CMAB_BREADCRUMBS;
+  } else {
+    return MAB_BREADCRUMBS;
+  }
 };
 
 const abandonDraftExperiment = async (data: ExperimentFormData) => {
-	const datasourceId = data.datasourceId;
-	const experimentId =
-		data.createExperimentResponse?.experiment_id ?? data.experimentId;
-	if (!datasourceId || !experimentId) {
-		return;
-	}
+  const datasourceId = data.datasourceId;
+  const experimentId = data.createExperimentResponse?.experiment_id ?? data.experimentId;
+  if (!datasourceId || !experimentId) {
+    return;
+  }
 
-	try {
-		await abandonExperiment(datasourceId, experimentId);
-	} catch {
-		// Intentionally ignore abandon failures to avoid blocking navigation.
-	}
+  try {
+    await abandonExperiment(datasourceId, experimentId);
+  } catch {
+    // Intentionally ignore abandon failures to avoid blocking navigation.
+  }
 };
 
-export const ExperimentForm: WizardForm<
-	ExperimentFormData,
-	ExperimentScreenId,
-	undefined
-> = {
-	initialData: () => ({
-		name: "New Hypothesis",
-		experimentType: "freq_online",
-		startDate: getReasonableStartDate(),
-		endDate: getReasonableEndDate(),
-		arms: [
-			{ arm_name: "Control", arm_description: "Control" },
-			{ arm_name: "Treatment", arm_description: "Treatment" },
-		],
-		bandit: createDefaultBanditParams("mab_online"),
-		confidence: "95",
-		power: "80",
-	}),
-	initialScreenId: () => "metadata",
-	breadcrumbs: breadcrumbs,
-	screens: {
-		metadata: screen({
-			breadcrumbTitle: "Experiment Description",
-			render: ExperimentMetadataScreen,
-			reducer: (data, msg: ExperimentMetadataMessages) => {
-				if (msg.type === "set-name") return { ...data, name: msg.value };
-				if (msg.type === "set-hypothesis")
-					return { ...data, hypothesis: msg.value };
-				if (msg.type === "set-design-url")
-					return { ...data, designUrl: msg.value || undefined };
-				if (msg.type === "set-start-date")
-					return { ...data, startDate: msg.value };
-				if (msg.type === "set-end-date") return { ...data, endDate: msg.value };
-				if (msg.type === "set-webhook-ids")
-					return { ...data, selectedWebhookIds: msg.value };
-				return data;
-			},
-			isNextEnabled: (data) => {
-				if (!data.name) return false;
-				if (!data.startDate || !data.endDate) return false;
-				if (data.endDate <= data.startDate) return false;
-				return true;
-			},
-		}),
-		"experiment-type": screen({
-			breadcrumbTitle: "Type",
-			render: ExperimentTypeScreen,
-			reducer: (data, msg) => {
-				if (msg.type === "set-experiment-type") {
-					const experimentType = msg.value;
-					const nextData = {
-						...data,
-						experimentType,
-						datasourceId:
-							isBanditExperimentType(data.experimentType) !=
-							isBanditExperimentType(experimentType)
-								? undefined
-								: data.datasourceId,
-						createExperimentResponse: undefined,
-						createExperimentError: undefined,
-						commitError: undefined,
-					};
+export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, undefined> = {
+  initialData: () => ({
+    name: 'New Hypothesis',
+    experimentType: 'freq_online',
+    startDate: getReasonableStartDate(),
+    endDate: getReasonableEndDate(),
+    arms: [
+      { arm_name: 'Control', arm_description: 'Control' },
+      { arm_name: 'Treatment', arm_description: 'Treatment' },
+    ],
+    bandit: createDefaultBanditParams('mab_online'),
+    confidence: '95',
+    power: '80',
+  }),
+  initialScreenId: () => 'metadata',
+  breadcrumbs: breadcrumbs,
+  screens: {
+    metadata: screen({
+      breadcrumbTitle: 'Experiment Description',
+      render: ExperimentMetadataScreen,
+      reducer: (data, msg: ExperimentMetadataMessages) => {
+        if (msg.type === 'set-name') return { ...data, name: msg.value };
+        if (msg.type === 'set-hypothesis') return { ...data, hypothesis: msg.value };
+        if (msg.type === 'set-design-url') return { ...data, designUrl: msg.value || undefined };
+        if (msg.type === 'set-start-date') return { ...data, startDate: msg.value };
+        if (msg.type === 'set-end-date') return { ...data, endDate: msg.value };
+        if (msg.type === 'set-webhook-ids') return { ...data, selectedWebhookIds: msg.value };
+        return data;
+      },
+      isNextEnabled: (data) => {
+        if (!data.name) return false;
+        if (!data.startDate || !data.endDate) return false;
+        if (data.endDate <= data.startDate) return false;
+        return true;
+      },
+    }),
+    'experiment-type': screen({
+      breadcrumbTitle: 'Type',
+      render: ExperimentTypeScreen,
+      reducer: (data, msg) => {
+        if (msg.type === 'set-experiment-type') {
+          const experimentType = msg.value;
+          const nextData = {
+            ...data,
+            experimentType,
+            datasourceId:
+              isBanditExperimentType(data.experimentType) != isBanditExperimentType(experimentType)
+                ? undefined
+                : data.datasourceId,
+            createExperimentResponse: undefined,
+            createExperimentError: undefined,
+            commitError: undefined,
+          };
 
-					if (!isBanditExperimentType(experimentType)) {
-						return {
-							...nextData,
-							bandit: undefined,
-						};
-					}
+          if (!isBanditExperimentType(experimentType)) {
+            return {
+              ...nextData,
+              bandit: undefined,
+            };
+          }
 
-					return {
-						...nextData,
-						bandit: toBanditParamsForExperimentType(
-							experimentType,
-							data.bandit,
-						),
-					};
-				}
-				return data;
-			},
-			isNextEnabled: (data) => !!data.experimentType,
-		}),
-		"freq-select-datasource": screen({
-			breadcrumbTitle: "Datasource",
-			render: ExperimentSelectDatasourceScreen,
-			reducer: (data, msg) => {
-				const shouldClearDependents =
-					data.datasourceId !== msg.datasourceId ||
-					data.tableName !== msg.tableName;
-				if (msg.type === "set-datasource") {
-					return {
-						...data,
-						datasourceId: msg.datasourceId,
-						tableName: msg.tableName,
-						primaryKey: msg.primaryKey,
+          return {
+            ...nextData,
+            bandit: toBanditParamsForExperimentType(experimentType, data.bandit),
+          };
+        }
+        return data;
+      },
+      isNextEnabled: (data) => !!data.experimentType,
+    }),
+    'freq-select-datasource': screen({
+      breadcrumbTitle: 'Datasource',
+      render: ExperimentSelectDatasourceScreen,
+      reducer: (data, msg) => {
+        const shouldClearDependents = data.datasourceId !== msg.datasourceId || data.tableName !== msg.tableName;
+        if (msg.type === 'set-datasource') {
+          return {
+            ...data,
+            datasourceId: msg.datasourceId,
+            tableName: msg.tableName,
+            primaryKey: msg.primaryKey,
 
-						// Clear metrics and filters if the datasource ID or table have changed. This could be improved by retain
-						// entries based on the inspection results.
-						primaryMetric: shouldClearDependents
-							? undefined
-							: data.primaryMetric,
-						secondaryMetrics: shouldClearDependents
-							? undefined
-							: data.secondaryMetrics,
-						filters: shouldClearDependents ? undefined : data.filters,
-						strata: shouldClearDependents
-							? undefined
-							: removeFieldByName(data.strata, msg.primaryKey),
+            // Clear metrics and filters if the datasource ID or table have changed. This could be improved by retain
+            // entries based on the inspection results.
+            primaryMetric: shouldClearDependents ? undefined : data.primaryMetric,
+            secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
+            filters: shouldClearDependents ? undefined : data.filters,
+            strata: shouldClearDependents ? undefined : removeFieldByName(data.strata, msg.primaryKey),
 
-						// Changing datasource should clear power check
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				return data;
-			},
-			isNextEnabled: (data) => !!data.datasourceId && !!data.tableName,
+            // Changing datasource should clear power check
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        return data;
+      },
+      isNextEnabled: (data) => !!data.datasourceId && !!data.tableName,
 
-			hideNavigation: () => true, // hide navigation because this screen uses a nested wizard.
-		}),
-		"bandit-binary-or-real": screen({
-			breadcrumbTitle: "Outcomes",
+      hideNavigation: () => true, // hide navigation because this screen uses a nested wizard.
+    }),
+    'bandit-binary-or-real': screen({
+      breadcrumbTitle: 'Outcomes',
 
-			render: ExperimentSelectBinaryOrRealOutcomes,
-			reducer: (data, msg) => {
-				if (msg.type === "set-outcome-type") {
-					if (data.bandit === undefined) {
-						return data;
-					}
-					return {
-						...data,
-						bandit:
-							data.bandit.experimentType === "mab_online"
-								? toMabBanditParams(msg.value, data.bandit.arms)
-								: toCmabBanditParams(
-										msg.value,
-										data.bandit.arms,
-										data.bandit.contexts,
-									),
-					};
-				}
-				return data;
-			},
-		}),
-		"describe-contexts": screen({
-			breadcrumbTitle: "Contexts",
-			render: ExperimentDescribeContextsScreen,
-			reducer: (data, msg) => {
-				if (data.bandit?.experimentType !== "cmab_online") {
-					return data;
-				}
-				const contexts = data.bandit.contexts;
-				if (msg.type === "add-context") {
-					return {
-						...data,
-						bandit: {
-							...data.bandit,
-							contexts: [
-								...contexts,
-								{ name: "", description: "", type: "real-valued" },
-							],
-						},
-					};
-				}
-				if (msg.type === "remove-context") {
-					return {
-						...data,
-						bandit: {
-							...data.bandit,
-							contexts: contexts.filter((_, i) => i !== msg.index),
-						},
-					};
-				}
-				if (msg.type === "update-context") {
-					const newContexts = [...contexts];
-					const ctx = newContexts[msg.index];
-					switch (msg.field) {
-						case "name":
-							newContexts[msg.index] = { ...ctx, name: msg.value };
-							break;
-						case "description":
-							newContexts[msg.index] = { ...ctx, description: msg.value };
-							break;
-						case "type":
-							newContexts[msg.index] = {
-								...ctx,
-								type: msg.value as ContextType,
-							};
-							break;
-					}
-					return { ...data, bandit: { ...data.bandit, contexts: newContexts } };
-				}
-				return data;
-			},
-			isNextEnabled: (data) => {
-				const contexts =
-					data.bandit?.experimentType === "cmab_online"
-						? data.bandit.contexts
-						: [];
-				return (
-					contexts.length >= 1 && contexts.every((c) => c.name.trim() !== "")
-				);
-			},
-			isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
-			nextButtonTooltip: (data) => {
-				const contexts =
-					data.bandit?.experimentType === "cmab_online"
-						? data.bandit.contexts
-						: [];
-				if (contexts.length < 1) return "At least one context is required.";
-				const emptyNameIndex = contexts.findIndex((c) => c.name.trim() === "");
-				if (emptyNameIndex >= 0)
-					return `Context ${emptyNameIndex + 1} name is required.`;
-				return undefined;
-			},
-		}),
-		"describe-bandit-arms": screen({
-			breadcrumbTitle: "Arms",
-			render: ExperimentDescribeBanditArmsScreen,
-			reducer: (data, msg) => {
-				if (data.bandit === undefined) {
-					return data;
-				}
-				const arms = data.bandit.arms;
-				if (msg.type === "add-arm") {
-					const priorType = data.bandit.priorType;
-					const newArm =
-						priorType === "beta"
-							? {
-									arm_name: "",
-									arm_description: "",
-									alpha_prior: undefined,
-									beta_prior: undefined,
-									arm_weight: 0,
-								}
-							: {
-									arm_name: "",
-									arm_description: "",
-									mean_prior: undefined,
-									stddev_prior: undefined,
-									arm_weight: 0,
-								};
-					const newArms = [...arms, newArm];
-					const equalWeight = parseFloat((100 / newArms.length).toFixed(1));
-					return {
-						...data,
-						bandit: {
-							...data.bandit,
-							arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })),
-						},
-					};
-				}
-				if (msg.type === "remove-arm") {
-					const newArms = arms.filter((_, i) => i !== msg.index);
-					const equalWeight =
-						newArms.length > 0
-							? parseFloat((100 / newArms.length).toFixed(1))
-							: 0;
-					return {
-						...data,
-						bandit: {
-							...data.bandit,
-							arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })),
-						},
-					};
-				}
-				if (msg.type === "update-arm") {
-					const newArms = [...arms];
-					newArms[msg.index] = {
-						...newArms[msg.index],
-						[msg.field]: msg.value,
-					};
-					return { ...data, bandit: { ...data.bandit, arms: newArms } };
-				}
-				if (msg.type === "set-create-response") {
-					return {
-						...data,
-						createExperimentResponse: msg.response,
-						createExperimentError: undefined,
-						experimentId: msg.response.experiment_id,
-						commitError: undefined,
-					};
-				}
-				if (msg.type === "set-create-error") {
-					return {
-						...data,
-						createExperimentError: msg.response,
-						createExperimentResponse: undefined,
-					};
-				}
-				if (msg.type === "set-datasource-id") {
-					return { ...data, datasourceId: msg.datasourceId };
-				}
-				if (msg.type === "set-weights") {
-					const newArms = arms.map((arm, i) => ({
-						...arm,
-						arm_weight: msg.weights[i],
-					}));
-					return { ...data, bandit: { ...data.bandit, arms: newArms } };
-				}
-				return data;
-			},
+      render: ExperimentSelectBinaryOrRealOutcomes,
+      reducer: (data, msg) => {
+        if (msg.type === 'set-outcome-type') {
+          if (data.bandit === undefined) {
+            return data;
+          }
+          return {
+            ...data,
+            bandit:
+              data.bandit.experimentType === 'mab_online'
+                ? toMabBanditParams(msg.value, data.bandit.arms)
+                : toCmabBanditParams(msg.value, data.bandit.arms, data.bandit.contexts),
+          };
+        }
+        return data;
+      },
+    }),
+    'describe-contexts': screen({
+      breadcrumbTitle: 'Contexts',
+      render: ExperimentDescribeContextsScreen,
+      reducer: (data, msg) => {
+        if (data.bandit?.experimentType !== 'cmab_online') {
+          return data;
+        }
+        const contexts = data.bandit.contexts;
+        if (msg.type === 'add-context') {
+          return {
+            ...data,
+            bandit: {
+              ...data.bandit,
+              contexts: [...contexts, { name: '', description: '', type: 'real-valued' }],
+            },
+          };
+        }
+        if (msg.type === 'remove-context') {
+          return {
+            ...data,
+            bandit: {
+              ...data.bandit,
+              contexts: contexts.filter((_, i) => i !== msg.index),
+            },
+          };
+        }
+        if (msg.type === 'update-context') {
+          const newContexts = [...contexts];
+          const ctx = newContexts[msg.index];
+          switch (msg.field) {
+            case 'name':
+              newContexts[msg.index] = { ...ctx, name: msg.value };
+              break;
+            case 'description':
+              newContexts[msg.index] = { ...ctx, description: msg.value };
+              break;
+            case 'type':
+              newContexts[msg.index] = {
+                ...ctx,
+                type: msg.value as ContextType,
+              };
+              break;
+          }
+          return { ...data, bandit: { ...data.bandit, contexts: newContexts } };
+        }
+        return data;
+      },
+      isNextEnabled: (data) => {
+        const contexts = data.bandit?.experimentType === 'cmab_online' ? data.bandit.contexts : [];
+        return contexts.length >= 1 && contexts.every((c) => c.name.trim() !== '');
+      },
+      isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
+      nextButtonTooltip: (data) => {
+        const contexts = data.bandit?.experimentType === 'cmab_online' ? data.bandit.contexts : [];
+        if (contexts.length < 1) return 'At least one context is required.';
+        const emptyNameIndex = contexts.findIndex((c) => c.name.trim() === '');
+        if (emptyNameIndex >= 0) return `Context ${emptyNameIndex + 1} name is required.`;
+        return undefined;
+      },
+    }),
+    'describe-bandit-arms': screen({
+      breadcrumbTitle: 'Arms',
+      render: ExperimentDescribeBanditArmsScreen,
+      reducer: (data, msg) => {
+        if (data.bandit === undefined) {
+          return data;
+        }
+        const arms = data.bandit.arms;
+        if (msg.type === 'add-arm') {
+          const priorType = data.bandit.priorType;
+          const newArm =
+            priorType === 'beta'
+              ? {
+                  arm_name: '',
+                  arm_description: '',
+                  alpha_prior: undefined,
+                  beta_prior: undefined,
+                  arm_weight: 0,
+                }
+              : {
+                  arm_name: '',
+                  arm_description: '',
+                  mean_prior: undefined,
+                  stddev_prior: undefined,
+                  arm_weight: 0,
+                };
+          const newArms = [...arms, newArm];
+          const equalWeight = parseFloat((100 / newArms.length).toFixed(1));
+          return {
+            ...data,
+            bandit: {
+              ...data.bandit,
+              arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })),
+            },
+          };
+        }
+        if (msg.type === 'remove-arm') {
+          const newArms = arms.filter((_, i) => i !== msg.index);
+          const equalWeight = newArms.length > 0 ? parseFloat((100 / newArms.length).toFixed(1)) : 0;
+          return {
+            ...data,
+            bandit: {
+              ...data.bandit,
+              arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })),
+            },
+          };
+        }
+        if (msg.type === 'update-arm') {
+          const newArms = [...arms];
+          newArms[msg.index] = {
+            ...newArms[msg.index],
+            [msg.field]: msg.value,
+          };
+          return { ...data, bandit: { ...data.bandit, arms: newArms } };
+        }
+        if (msg.type === 'set-create-response') {
+          return {
+            ...data,
+            createExperimentResponse: msg.response,
+            createExperimentError: undefined,
+            experimentId: msg.response.experiment_id,
+            commitError: undefined,
+          };
+        }
+        if (msg.type === 'set-create-error') {
+          return {
+            ...data,
+            createExperimentError: msg.response,
+            createExperimentResponse: undefined,
+          };
+        }
+        if (msg.type === 'set-datasource-id') {
+          return { ...data, datasourceId: msg.datasourceId };
+        }
+        if (msg.type === 'set-weights') {
+          const newArms = arms.map((arm, i) => ({
+            ...arm,
+            arm_weight: msg.weights[i],
+          }));
+          return { ...data, bandit: { ...data.bandit, arms: newArms } };
+        }
+        return data;
+      },
 
-			hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
-			isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
-		}),
-		"describe-arms": screen({
-			breadcrumbTitle: "Arms",
-			render: ExperimentDescribeArmsScreen,
-			reducer: (data, msg: ExperimentDescribeArmsMessage) => {
-				const arms = data.arms ?? [];
+      hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
+      isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
+    }),
+    'describe-arms': screen({
+      breadcrumbTitle: 'Arms',
+      render: ExperimentDescribeArmsScreen,
+      reducer: (data, msg: ExperimentDescribeArmsMessage) => {
+        const arms = data.arms ?? [];
 
-				if (msg.type === "add-arm") {
-					const newArm =
-						arms.length === 0
-							? {
-									arm_name: "Control",
-									arm_description:
-										"Arm 1 will be used as baseline for comparison.",
-								}
-							: { arm_name: "", arm_description: "" };
-					// Reset weights when adding
-					const newArms = [...arms, newArm].map((a) => ({
-						...a,
-						arm_weight: undefined,
-					}));
-					return { ...data, arms: newArms };
-				}
+        if (msg.type === 'add-arm') {
+          const newArm =
+            arms.length === 0
+              ? {
+                  arm_name: 'Control',
+                  arm_description: 'Arm 1 will be used as baseline for comparison.',
+                }
+              : { arm_name: '', arm_description: '' };
+          // Reset weights when adding
+          const newArms = [...arms, newArm].map((a) => ({
+            ...a,
+            arm_weight: undefined,
+          }));
+          return { ...data, arms: newArms };
+        }
 
-				if (msg.type === "remove-arm") {
-					// Reset weights when removing
-					const newArms = arms
-						.filter((_, i) => i !== msg.index)
-						.map((a) => ({ ...a, arm_weight: undefined }));
-					return { ...data, arms: newArms };
-				}
+        if (msg.type === 'remove-arm') {
+          // Reset weights when removing
+          const newArms = arms.filter((_, i) => i !== msg.index).map((a) => ({ ...a, arm_weight: undefined }));
+          return { ...data, arms: newArms };
+        }
 
-				if (msg.type === "update-arm") {
-					const newArms = [...arms];
-					newArms[msg.index] = {
-						...newArms[msg.index],
-						[msg.field]: msg.value,
-					};
-					return { ...data, arms: newArms };
-				}
+        if (msg.type === 'update-arm') {
+          const newArms = [...arms];
+          newArms[msg.index] = {
+            ...newArms[msg.index],
+            [msg.field]: msg.value,
+          };
+          return { ...data, arms: newArms };
+        }
 
-				if (msg.type === "set-weights") {
-					const newArms = arms.map((arm, i) => ({
-						...arm,
-						arm_weight: msg.weights[i],
-					}));
-					return { ...data, arms: newArms };
-				}
+        if (msg.type === 'set-weights') {
+          const newArms = arms.map((arm, i) => ({
+            ...arm,
+            arm_weight: msg.weights[i],
+          }));
+          return { ...data, arms: newArms };
+        }
 
-				return data;
-			},
-			isNextEnabled: (data) => (data.arms?.length ?? 0) >= 2,
-		}),
-		"freq-stack": screen({
-			breadcrumbTitle: "Parameters",
-			render: ExperimentFreqStackScreen,
-			reducer: (data, msg: ExperimentFreqStackScreenMessage) => {
-				// Metric builder actions - all metric changes invalidate power check
-				if (msg.type === "primary-metric-select") {
-					return {
-						...data,
-						primaryMetric: msg.primaryMetric,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "primary-metric-deselect") {
-					return {
-						...data,
-						primaryMetric: msg.primaryMetric,
-						secondaryMetrics: msg.secondaryMetrics,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "promote-secondary-to-primary") {
-					return {
-						...data,
-						primaryMetric: msg.primaryMetric,
-						secondaryMetrics: msg.secondaryMetrics,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "secondary-metric-add") {
-					return {
-						...data,
-						secondaryMetrics: msg.secondaryMetrics,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "secondary-metric-remove") {
-					return {
-						...data,
-						secondaryMetrics: msg.secondaryMetrics,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "mde-change") {
-					return {
-						...data,
-						primaryMetric: msg.primaryMetric ?? data.primaryMetric,
-						secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
+        return data;
+      },
+      isNextEnabled: (data) => (data.arms?.length ?? 0) >= 2,
+    }),
+    'freq-stack': screen({
+      breadcrumbTitle: 'Parameters',
+      render: ExperimentFreqStackScreen,
+      reducer: (data, msg: ExperimentFreqStackScreenMessage) => {
+        // Metric builder actions - all metric changes invalidate power check
+        if (msg.type === 'primary-metric-select') {
+          return {
+            ...data,
+            primaryMetric: msg.primaryMetric,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'primary-metric-deselect') {
+          return {
+            ...data,
+            primaryMetric: msg.primaryMetric,
+            secondaryMetrics: msg.secondaryMetrics,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'promote-secondary-to-primary') {
+          return {
+            ...data,
+            primaryMetric: msg.primaryMetric,
+            secondaryMetrics: msg.secondaryMetrics,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'secondary-metric-add') {
+          return {
+            ...data,
+            secondaryMetrics: msg.secondaryMetrics,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'secondary-metric-remove') {
+          return {
+            ...data,
+            secondaryMetrics: msg.secondaryMetrics,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'mde-change') {
+          return {
+            ...data,
+            primaryMetric: msg.primaryMetric ?? data.primaryMetric,
+            secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
 
-				// Filter builder - filter changes invalidate power check
-				if (msg.type === "set-filters") {
-					return {
-						...data,
-						filters: msg.filters,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
+        // Filter builder - filter changes invalidate power check
+        if (msg.type === 'set-filters') {
+          return {
+            ...data,
+            filters: msg.filters,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
 
-				// Strata builder -
-				// Does NOT invalidate power check for now as we don't currently incorporate strata in
-				// analysis.  When we do, we should also look to incorporate them as covariates in the power
-				// analysis, and if so invalidate here as well.
-				if (msg.type === "set-strata") {
-					return {
-						...data,
-						strata: removeFieldByName(msg.strata, data.primaryKey),
-					};
-				}
+        // Strata builder -
+        // Does NOT invalidate power check for now as we don't currently incorporate strata in
+        // analysis.  When we do, we should also look to incorporate them as covariates in the power
+        // analysis, and if so invalidate here as well.
+        if (msg.type === 'set-strata') {
+          return {
+            ...data,
+            strata: removeFieldByName(msg.strata, data.primaryKey),
+          };
+        }
 
-				// Randomization toggle & cluster builder (issue #217).
-				// Any change to cluster inputs invalidates the previous power-check result
-				// because clustering meaningfully changes the required sample size.
-				if (msg.type === "set-randomization-type") {
-					return {
-						...data,
-						randomizationType: msg.value,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "set-cluster-field") {
-					return {
-						...data,
-						clusterField: msg.field,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "set-cluster-icc") {
-					return {
-						...data,
-						clusterIcc: msg.value,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "set-cluster-cv") {
-					return {
-						...data,
-						clusterCv: msg.value,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "set-cluster-avg-size") {
-					return {
-						...data,
-						clusterAvgSize: msg.value,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
+        // Randomization toggle & cluster builder (issue #217).
+        // Any change to cluster inputs invalidates the previous power-check result
+        // because clustering meaningfully changes the required sample size.
+        if (msg.type === 'set-randomization-type') {
+          return {
+            ...data,
+            randomizationType: msg.value,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-field') {
+          return {
+            ...data,
+            clusterField: msg.field,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-icc') {
+          return {
+            ...data,
+            clusterIcc: msg.value,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-cv') {
+          return {
+            ...data,
+            clusterCv: msg.value,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-avg-size') {
+          return {
+            ...data,
+            clusterAvgSize: msg.value,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
 
-				// Power check - changing confidence/power invalidates power check response
-				if (msg.type === "set-confidence") {
-					return {
-						...data,
-						confidence: msg.value,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "set-power") {
-					return {
-						...data,
-						power: msg.value,
-						powerCheckResponse: undefined,
-						desiredN: undefined,
-					};
-				}
-				if (msg.type === "set-power-check-response") {
-					return {
-						...data,
-						powerCheckResponse: msg.response,
-						// Running a fresh power check invalidates any previously
-						// computed achievable-MDE response — it was tied to a stale
-						// design spec / chosen N.
-						achievablePowerCheckResponse: undefined,
-						desiredN: msg.desiredN,
-					};
-				}
-				if (msg.type === "set-achievable-power-check-response") {
-					return { ...data, achievablePowerCheckResponse: msg.response };
-				}
-				if (msg.type === "set-chosen-n") {
-					// Switching options (e.g. back to recommended) invalidates the
-					// achievable response so the inline display doesn't show a stale
-					// MDE for a different N.
-					return {
-						...data,
-						desiredN: msg.value,
-						achievablePowerCheckResponse: undefined,
-					};
-				}
-				if (msg.type === "set-create-error") {
-					return {
-						...data,
-						createExperimentError: msg.response,
-						createExperimentResponse: undefined,
-					};
-				}
-				if (msg.type === "set-create-response") {
-					return {
-						...data,
-						createExperimentResponse: msg.response,
-						createExperimentError: undefined,
-						commitError: undefined,
-					};
-				}
+        // Power check - changing confidence/power invalidates power check response
+        if (msg.type === 'set-confidence') {
+          return {
+            ...data,
+            confidence: msg.value,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'set-power') {
+          return {
+            ...data,
+            power: msg.value,
+            powerCheckResponse: undefined,
+            desiredN: undefined,
+          };
+        }
+        if (msg.type === 'set-power-check-response') {
+          return {
+            ...data,
+            powerCheckResponse: msg.response,
+            // Running a fresh power check invalidates any previously
+            // computed achievable-MDE response — it was tied to a stale
+            // design spec / chosen N.
+            achievablePowerCheckResponse: undefined,
+            desiredN: msg.desiredN,
+          };
+        }
+        if (msg.type === 'set-achievable-power-check-response') {
+          return { ...data, achievablePowerCheckResponse: msg.response };
+        }
+        if (msg.type === 'set-chosen-n') {
+          // Switching options (e.g. back to recommended) invalidates the
+          // achievable response so the inline display doesn't show a stale
+          // MDE for a different N.
+          return {
+            ...data,
+            desiredN: msg.value,
+            achievablePowerCheckResponse: undefined,
+          };
+        }
+        if (msg.type === 'set-create-error') {
+          return {
+            ...data,
+            createExperimentError: msg.response,
+            createExperimentResponse: undefined,
+          };
+        }
+        if (msg.type === 'set-create-response') {
+          return {
+            ...data,
+            createExperimentResponse: msg.response,
+            createExperimentError: undefined,
+            commitError: undefined,
+          };
+        }
 
-				return data;
-			},
+        return data;
+      },
 
-			hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
-			isBreadcrumbClickable: (data) => !!(data.datasourceId && data.tableName),
-		}),
-		"summarize-freq": screen({
-			breadcrumbTitle: "Summary",
-			render: ExperimentsSummarizeFreqScreen,
-			isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
-			reducer: (data, msg) => {
-				if (msg.type === "set-commit-error") {
-					return { ...data, commitError: msg.response };
-				}
-				return data;
-			},
-			isNextEnabled: (data) => !!data.createExperimentResponse,
-			isPrevEnabled: (data) => !data.createExperimentResponse,
-			hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
-			beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
-		}),
-		"summarize-bandit": screen({
-			breadcrumbTitle: "Summary",
-			render: ExperimentsSummarizeBanditScreen,
-			reducer: (data, msg) => {
-				if (msg.type === "set-commit-error") {
-					return { ...data, commitError: msg.response };
-				}
-				return data;
-			},
-			isNextEnabled: (data) => !!data.createExperimentResponse,
-			isPrevEnabled: (data) => !data.createExperimentResponse,
-			hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
-			isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
-			beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
-		}),
-	},
+      hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
+      isBreadcrumbClickable: (data) => !!(data.datasourceId && data.tableName),
+    }),
+    'summarize-freq': screen({
+      breadcrumbTitle: 'Summary',
+      render: ExperimentsSummarizeFreqScreen,
+      isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
+      reducer: (data, msg) => {
+        if (msg.type === 'set-commit-error') {
+          return { ...data, commitError: msg.response };
+        }
+        return data;
+      },
+      isNextEnabled: (data) => !!data.createExperimentResponse,
+      isPrevEnabled: (data) => !data.createExperimentResponse,
+      hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
+      beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
+    }),
+    'summarize-bandit': screen({
+      breadcrumbTitle: 'Summary',
+      render: ExperimentsSummarizeBanditScreen,
+      reducer: (data, msg) => {
+        if (msg.type === 'set-commit-error') {
+          return { ...data, commitError: msg.response };
+        }
+        return data;
+      },
+      isNextEnabled: (data) => !!data.createExperimentResponse,
+      isPrevEnabled: (data) => !data.createExperimentResponse,
+      hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
+      isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
+      beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
+    }),
+  },
 };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -99,6 +99,15 @@ export type ExperimentFormData = {
 	// Populated when user clicks "Power Check" on DesignForm
 	desiredN?: number;
 	powerCheckResponse?: PowerResponseOutput;
+	// Populated when the user picks "Use max available" or types a Custom N
+	// on the Power Analysis page. This is the MDE-mode power-check response for
+	// the chosen sample size — it carries the achievable MDE plus a cluster
+	// split that matches `desiredN`. We keep it separate from
+	// `powerCheckResponse` because the "Use minimum sample required" radio
+	// still needs the original sample-size-mode response to show the recommended
+	// cluster count. At save time, prefer this over `powerCheckResponse` so the
+	// saved experiment reflects the user's chosen N.
+	achievablePowerCheckResponse?: PowerResponseOutput;
 	createExperimentResponse?: CreateExperimentResponse;
 	createExperimentError?: ErrorType<unknown>;
 
@@ -701,11 +710,25 @@ export const ExperimentForm: WizardForm<
 					return {
 						...data,
 						powerCheckResponse: msg.response,
+						// Running a fresh power check invalidates any previously
+						// computed achievable-MDE response — it was tied to a stale
+						// design spec / chosen N.
+						achievablePowerCheckResponse: undefined,
 						desiredN: msg.desiredN,
 					};
 				}
+				if (msg.type === "set-achievable-power-check-response") {
+					return { ...data, achievablePowerCheckResponse: msg.response };
+				}
 				if (msg.type === "set-chosen-n") {
-					return { ...data, desiredN: msg.value };
+					// Switching options (e.g. back to recommended) invalidates the
+					// achievable response so the inline display doesn't show a stale
+					// MDE for a different N.
+					return {
+						...data,
+						desiredN: msg.value,
+						achievablePowerCheckResponse: undefined,
+					};
 				}
 				if (msg.type === "set-create-error") {
 					return {

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -1,7 +1,6 @@
 import { abandonExperiment } from '@/api/admin';
 import {
   Arm,
-  BayesABExperimentSpecInputExperimentType,
   ContextType,
   CreateExperimentResponse,
   DesignSpecInput,
@@ -55,9 +54,7 @@ import { WizardForm, packScreen } from '@/services/wizard/wizard-types';
  * variant is translated to "freq_preassigned" + cluster_column at submit time
  * (see convertToFrequentistDesignSpec).
  */
-export type ExperimentType =
-  | Exclude<DesignSpecInput['experiment_type'], BayesABExperimentSpecInputExperimentType>
-  | 'freq_cluster_preassigned';
+export type ExperimentType = DesignSpecInput['experiment_type'] | 'freq_cluster_preassigned';
 
 // Defines the entirety of the editable data collected via this wizard flow.
 export type ExperimentFormData = {
@@ -99,15 +96,18 @@ export type ExperimentFormData = {
   // Populated when user clicks "Power Check" on DesignForm
   desiredN?: number;
   powerCheckResponse?: PowerResponseOutput;
-  // Populated when the user picks "Use max available" or types a Custom N
-  // on the Power Analysis page. This is the MDE-mode power-check response for
-  // the chosen sample size — it carries the achievable MDE plus a cluster
-  // split that matches `desiredN`. We keep it separate from
-  // `powerCheckResponse` because the "Use minimum sample required" radio
-  // still needs the original sample-size-mode response to show the recommended
-  // cluster count. At save time, prefer this over `powerCheckResponse` so the
-  // saved experiment reflects the user's chosen N.
-  achievablePowerCheckResponse?: PowerResponseOutput;
+  // Cached MDE-mode power-check responses for the Max-available and Custom
+  // sample-size options on the Power Analysis page. Each is the BE's response
+  // to a power-check call made with `desired_n` set to that option's value.
+  // We cache both so the Achievable MDE annotation on each radio card stays
+  // visible regardless of which option is currently selected — letting the
+  // user compare. At save time the right one is chosen based on the user's
+  // selected option (see handleCreate).
+  achievableMaxPowerCheckResponse?: PowerResponseOutput;
+  achievableCustomPowerCheckResponse?: PowerResponseOutput;
+  // The desired_n the Custom response was computed for. Used to detect when
+  // the user has retyped a new value and the cached response is stale.
+  achievableCustomDesiredN?: number;
   createExperimentResponse?: CreateExperimentResponse;
   createExperimentError?: ErrorType<unknown>;
 
@@ -665,25 +665,29 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             powerCheckResponse: msg.response,
-            // Running a fresh power check invalidates any previously
-            // computed achievable-MDE response — it was tied to a stale
-            // design spec / chosen N.
-            achievablePowerCheckResponse: undefined,
+            // Running a fresh power check invalidates any cached
+            // achievable-MDE responses — they were tied to a stale design
+            // spec.
+            achievableMaxPowerCheckResponse: undefined,
+            achievableCustomPowerCheckResponse: undefined,
+            achievableCustomDesiredN: undefined,
             desiredN: msg.desiredN,
           };
         }
-        if (msg.type === 'set-achievable-power-check-response') {
-          return { ...data, achievablePowerCheckResponse: msg.response };
+        if (msg.type === 'set-achievable-max-response') {
+          return { ...data, achievableMaxPowerCheckResponse: msg.response };
         }
-        if (msg.type === 'set-chosen-n') {
-          // Switching options (e.g. back to recommended) invalidates the
-          // achievable response so the inline display doesn't show a stale
-          // MDE for a different N.
+        if (msg.type === 'set-achievable-custom-response') {
           return {
             ...data,
-            desiredN: msg.value,
-            achievablePowerCheckResponse: undefined,
+            achievableCustomPowerCheckResponse: msg.response,
+            achievableCustomDesiredN: msg.desiredN,
           };
+        }
+        if (msg.type === 'set-chosen-n') {
+          // Switching options just updates the chosen N — the cached
+          // Max/Custom responses stay so each card keeps its own MDE.
+          return { ...data, desiredN: msg.value };
         }
         if (msg.type === 'set-create-error') {
           return {

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -1,570 +1,763 @@
+import { abandonExperiment } from "@/api/admin";
+import {
+	Arm,
+	BayesABExperimentSpecInputExperimentType,
+	ContextType,
+	CreateExperimentResponse,
+	DesignSpecInput,
+	FieldMetadata,
+	FilterInput,
+	GetFiltersResponseElement,
+	PowerResponseOutput,
+} from "@/api/methods.schemas";
+import {
+	createDefaultBanditParams,
+	toBanditParamsForExperimentType,
+	toCmabBanditParams,
+	toMabBanditParams,
+} from "@/app/experiments/create/experiment-form/experiment-bandit-helpers";
+import {
+	ExperimentDescribeArmsMessage,
+	ExperimentDescribeArmsScreen,
+} from "@/app/experiments/create/experiment-form/experiment-describe-arms-screen";
+import { ExperimentDescribeBanditArmsScreen } from "@/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen";
+import { ExperimentDescribeContextsScreen } from "@/app/experiments/create/experiment-form/experiment-describe-contexts-screen";
+import {
+	getReasonableEndDate,
+	getReasonableStartDate,
+	removeFieldByName,
+} from "@/app/experiments/create/experiment-form/experiment-form-helpers";
+import {
+	BanditParams,
+	MetricWithMDE,
+	isBanditExperimentType,
+} from "@/app/experiments/create/experiment-form/experiment-form-types";
+import {
+	ExperimentFreqStackScreen,
+	ExperimentFreqStackScreenMessage,
+} from "@/app/experiments/create/experiment-form/experiment-freq-stack-screen";
+import {
+	ExperimentMetadataMessages,
+	ExperimentMetadataScreen,
+} from "@/app/experiments/create/experiment-form/experiment-metadata-screen";
+import { ExperimentSelectBinaryOrRealOutcomes } from "@/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes";
+import { ExperimentSelectDatasourceScreen } from "@/app/experiments/create/experiment-form/experiment-select-datasource-screen";
+import { ExperimentsSummarizeBanditScreen } from "@/app/experiments/create/experiment-form/experiment-summarize-bandit-screen";
+import { ExperimentsSummarizeFreqScreen } from "@/app/experiments/create/experiment-form/experiment-summarize-freq-screen";
+import { ExperimentTypeScreen } from "@/app/experiments/create/experiment-form/experiment-type-screen";
+import { ErrorType } from "@/services/orval-fetch";
 // Form data types
-import { packScreen, WizardForm } from '@/services/wizard/wizard-types';
-import {
-  ExperimentMetadataMessages,
-  ExperimentMetadataScreen,
-} from '@/app/experiments/create/experiment-form/experiment-metadata-screen';
-import { ExperimentTypeScreen } from '@/app/experiments/create/experiment-form/experiment-type-screen';
-import {
-  Arm,
-  BayesABExperimentSpecInputExperimentType,
-  ContextType,
-  CreateExperimentResponse,
-  DesignSpecInput,
-  FieldMetadata,
-  FilterInput,
-  GetFiltersResponseElement,
-  PowerResponseOutput,
-} from '@/api/methods.schemas';
-import { abandonExperiment } from '@/api/admin';
-import { ExperimentSelectDatasourceScreen } from '@/app/experiments/create/experiment-form/experiment-select-datasource-screen';
-import { ExperimentSelectBinaryOrRealOutcomes } from '@/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes';
-import {
-  ExperimentDescribeArmsMessage,
-  ExperimentDescribeArmsScreen,
-} from '@/app/experiments/create/experiment-form/experiment-describe-arms-screen';
-import { ExperimentDescribeContextsScreen } from '@/app/experiments/create/experiment-form/experiment-describe-contexts-screen';
-import { ExperimentDescribeBanditArmsScreen } from '@/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen';
-import { ExperimentsSummarizeBanditScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-bandit-screen';
-import {
-  ExperimentFreqStackScreen,
-  ExperimentFreqStackScreenMessage,
-} from '@/app/experiments/create/experiment-form/experiment-freq-stack-screen';
-import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-freq-screen';
-import {
-  getReasonableEndDate,
-  getReasonableStartDate,
-  removeFieldByName,
-} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
-import {
-  createDefaultBanditParams,
-  toBanditParamsForExperimentType,
-  toCmabBanditParams,
-  toMabBanditParams,
-} from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
-import { ErrorType } from '@/services/orval-fetch';
-import {
-  BanditParams,
-  isBanditExperimentType,
-  MetricWithMDE,
-} from '@/app/experiments/create/experiment-form/experiment-form-types';
+import { WizardForm, packScreen } from "@/services/wizard/wizard-types";
 
-export type ExperimentType = Exclude<DesignSpecInput['experiment_type'], BayesABExperimentSpecInputExperimentType>;
+/**
+ * ExperimentType in the FE wizard. Includes the FE-only
+ * "freq_cluster_preassigned" variant on top of the BE's enum values; that
+ * variant is translated to "freq_preassigned" + cluster_column at submit time
+ * (see convertToFrequentistDesignSpec).
+ */
+export type ExperimentType =
+	| Exclude<DesignSpecInput["experiment_type"], BayesABExperimentSpecInputExperimentType>
+	| "freq_cluster_preassigned";
 
 // Defines the entirety of the editable data collected via this wizard flow.
 export type ExperimentFormData = {
-  // experiment-metadata-screen
-  name?: string;
-  hypothesis?: string;
-  designUrl?: string;
-  startDate?: string;
-  endDate?: string;
+	// experiment-metadata-screen
+	name?: string;
+	hypothesis?: string;
+	designUrl?: string;
+	startDate?: string;
+	endDate?: string;
 
-  // experiment-type-screen
-  experimentType?: ExperimentType;
+	// experiment-type-screen
+	experimentType?: ExperimentType;
 
-  // experiment-select-datasource-screen
-  datasourceId?: string;
-  tableName?: string;
+	// experiment-select-datasource-screen
+	datasourceId?: string;
+	tableName?: string;
 
-  // experiment-freq-stack-screen
-  primaryKey?: string;
-  primaryMetric?: MetricWithMDE;
-  secondaryMetrics?: MetricWithMDE[];
-  filters?: FilterInput[];
-  // Cache of available filter fields (and their data types) for lookup/display/search
-  availableFilterFields?: GetFiltersResponseElement[];
-  strata?: FieldMetadata[];
-  // These next 2 Experiment Parameters are strings to allow for empty values,
-  // which should be converted to numbers when making power or experiment creation requests.
-  confidence?: string;
-  power?: string;
-  // Populated when user clicks "Power Check" on DesignForm
-  desiredN?: number;
-  powerCheckResponse?: PowerResponseOutput;
-  createExperimentResponse?: CreateExperimentResponse;
-  createExperimentError?: ErrorType<unknown>;
+	// experiment-freq-stack-screen
+	primaryKey?: string;
+	primaryMetric?: MetricWithMDE;
+	secondaryMetrics?: MetricWithMDE[];
+	filters?: FilterInput[];
+	// Cache of available filter fields (and their data types) for lookup/display/search
+	availableFilterFields?: GetFiltersResponseElement[];
+	strata?: FieldMetadata[];
+	// Randomization mode for issue #217. Undefined treated as 'strata' for backwards compat.
+	randomizationType?: "strata" | "cluster";
+	// Selected cluster ID field when randomizationType === 'cluster'.
+	clusterField?: FieldMetadata;
+	// Manual ICC / CV / avg cluster size inputs. Strings to allow empty values;
+	// converted to numbers when building the design spec.
+	clusterIcc?: string;
+	clusterCv?: string;
+	clusterAvgSize?: string;
+	// These next 2 Experiment Parameters are strings to allow for empty values,
+	// which should be converted to numbers when making power or experiment creation requests.
+	confidence?: string;
+	power?: string;
+	// Populated when user clicks "Power Check" on DesignForm
+	desiredN?: number;
+	powerCheckResponse?: PowerResponseOutput;
+	createExperimentResponse?: CreateExperimentResponse;
+	createExperimentError?: ErrorType<unknown>;
 
-  // experiment-describe-webhooks-screen
-  selectedWebhookIds?: string[];
+	// experiment-describe-webhooks-screen
+	selectedWebhookIds?: string[];
 
-  // experiment-describe-arms-screen
-  arms?: Omit<Arm, 'arm_id'>[];
+	// experiment-describe-arms-screen
+	arms?: Omit<Arm, "arm_id">[];
 
-  // bandit flow config
-  bandit?: BanditParams;
+	// bandit flow config
+	bandit?: BanditParams;
 
-  // experiment-summarize-freq-screen (populated after createExperiment API call)
-  experimentId?: string;
-  commitError?: ErrorType<unknown>;
+	// experiment-summarize-freq-screen (populated after createExperiment API call)
+	experimentId?: string;
+	commitError?: ErrorType<unknown>;
 };
 
 const isFreq = (experimentType: ExperimentType) => {
-  return experimentType === 'freq_online' || experimentType === 'freq_preassigned';
+	return (
+		experimentType === "freq_online" ||
+		experimentType === "freq_preassigned" ||
+		experimentType === "freq_cluster_preassigned"
+	);
 };
 
 const isCmab = (experimentType: ExperimentType) => {
-  return experimentType === 'cmab_online';
+	return experimentType === "cmab_online";
 };
 
 // Defines a type for all known screen IDs for the experiment form. This type is used with screen() to
 // type-check the ids returned by nextScreen and prevScreen.
 export type ExperimentScreenId =
-  | 'metadata'
-  | 'experiment-type'
-  | 'freq-select-datasource'
-  | 'bandit-binary-or-real'
-  | 'describe-contexts'
-  | 'describe-arms'
-  | 'describe-bandit-arms'
-  | 'freq-stack'
-  | 'summarize-freq'
-  | 'summarize-bandit';
+	| "metadata"
+	| "experiment-type"
+	| "freq-select-datasource"
+	| "bandit-binary-or-real"
+	| "describe-contexts"
+	| "describe-arms"
+	| "describe-bandit-arms"
+	| "freq-stack"
+	| "summarize-freq"
+	| "summarize-bandit";
 
 // Helper to create screens with proper type inference
 const screen = packScreen<ExperimentFormData, ExperimentScreenId>();
 
 const FREQUENTIST_BREADCRUMBS: Array<ExperimentScreenId> = [
-  'metadata',
-  'experiment-type',
-  'describe-arms',
-  'freq-select-datasource',
-  'freq-stack',
-  'summarize-freq',
+	"metadata",
+	"experiment-type",
+	"describe-arms",
+	"freq-select-datasource",
+	"freq-stack",
+	"summarize-freq",
 ] as const;
 
 const CMAB_BREADCRUMBS: Array<ExperimentScreenId> = [
-  'metadata',
-  'experiment-type',
-  'describe-contexts',
-  'bandit-binary-or-real',
-  'describe-bandit-arms',
-  'summarize-bandit',
+	"metadata",
+	"experiment-type",
+	"describe-contexts",
+	"bandit-binary-or-real",
+	"describe-bandit-arms",
+	"summarize-bandit",
 ] as const;
 
 const MAB_BREADCRUMBS: Array<ExperimentScreenId> = [
-  'metadata',
-  'experiment-type',
-  'bandit-binary-or-real',
-  'describe-bandit-arms',
-  'summarize-bandit',
+	"metadata",
+	"experiment-type",
+	"bandit-binary-or-real",
+	"describe-bandit-arms",
+	"summarize-bandit",
 ] as const;
 
-const breadcrumbs = ({ experimentType }: { experimentType?: ExperimentType }) => {
-  if (experimentType === undefined) {
-    return [];
-  } else if (isFreq(experimentType)) {
-    return FREQUENTIST_BREADCRUMBS;
-  } else if (isCmab(experimentType)) {
-    return CMAB_BREADCRUMBS;
-  } else {
-    return MAB_BREADCRUMBS;
-  }
+const breadcrumbs = ({
+	experimentType,
+}: { experimentType?: ExperimentType }) => {
+	if (experimentType === undefined) {
+		return [];
+	} else if (isFreq(experimentType)) {
+		return FREQUENTIST_BREADCRUMBS;
+	} else if (isCmab(experimentType)) {
+		return CMAB_BREADCRUMBS;
+	} else {
+		return MAB_BREADCRUMBS;
+	}
 };
 
 const abandonDraftExperiment = async (data: ExperimentFormData) => {
-  const datasourceId = data.datasourceId;
-  const experimentId = data.createExperimentResponse?.experiment_id ?? data.experimentId;
-  if (!datasourceId || !experimentId) {
-    return;
-  }
+	const datasourceId = data.datasourceId;
+	const experimentId =
+		data.createExperimentResponse?.experiment_id ?? data.experimentId;
+	if (!datasourceId || !experimentId) {
+		return;
+	}
 
-  try {
-    await abandonExperiment(datasourceId, experimentId);
-  } catch {
-    // Intentionally ignore abandon failures to avoid blocking navigation.
-  }
+	try {
+		await abandonExperiment(datasourceId, experimentId);
+	} catch {
+		// Intentionally ignore abandon failures to avoid blocking navigation.
+	}
 };
 
-export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, undefined> = {
-  initialData: () => ({
-    name: 'New Hypothesis',
-    experimentType: 'freq_online',
-    startDate: getReasonableStartDate(),
-    endDate: getReasonableEndDate(),
-    arms: [
-      { arm_name: 'Control', arm_description: 'Control' },
-      { arm_name: 'Treatment', arm_description: 'Treatment' },
-    ],
-    bandit: createDefaultBanditParams('mab_online'),
-    confidence: '95',
-    power: '80',
-  }),
-  initialScreenId: () => 'metadata',
-  breadcrumbs: breadcrumbs,
-  screens: {
-    metadata: screen({
-      breadcrumbTitle: 'Experiment Description',
-      render: ExperimentMetadataScreen,
-      reducer: (data, msg: ExperimentMetadataMessages) => {
-        if (msg.type === 'set-name') return { ...data, name: msg.value };
-        if (msg.type === 'set-hypothesis') return { ...data, hypothesis: msg.value };
-        if (msg.type === 'set-design-url') return { ...data, designUrl: msg.value || undefined };
-        if (msg.type === 'set-start-date') return { ...data, startDate: msg.value };
-        if (msg.type === 'set-end-date') return { ...data, endDate: msg.value };
-        if (msg.type === 'set-webhook-ids') return { ...data, selectedWebhookIds: msg.value };
-        return data;
-      },
-      isNextEnabled: (data) => {
-        if (!data.name) return false;
-        if (!data.startDate || !data.endDate) return false;
-        if (data.endDate <= data.startDate) return false;
-        return true;
-      },
-    }),
-    'experiment-type': screen({
-      breadcrumbTitle: 'Type',
-      render: ExperimentTypeScreen,
-      reducer: (data, msg) => {
-        if (msg.type === 'set-experiment-type') {
-          const experimentType = msg.value;
-          const nextData = {
-            ...data,
-            experimentType,
-            datasourceId:
-              isBanditExperimentType(data.experimentType) != isBanditExperimentType(experimentType)
-                ? undefined
-                : data.datasourceId,
-            createExperimentResponse: undefined,
-            createExperimentError: undefined,
-            commitError: undefined,
-          };
+export const ExperimentForm: WizardForm<
+	ExperimentFormData,
+	ExperimentScreenId,
+	undefined
+> = {
+	initialData: () => ({
+		name: "New Hypothesis",
+		experimentType: "freq_online",
+		startDate: getReasonableStartDate(),
+		endDate: getReasonableEndDate(),
+		arms: [
+			{ arm_name: "Control", arm_description: "Control" },
+			{ arm_name: "Treatment", arm_description: "Treatment" },
+		],
+		bandit: createDefaultBanditParams("mab_online"),
+		confidence: "95",
+		power: "80",
+	}),
+	initialScreenId: () => "metadata",
+	breadcrumbs: breadcrumbs,
+	screens: {
+		metadata: screen({
+			breadcrumbTitle: "Experiment Description",
+			render: ExperimentMetadataScreen,
+			reducer: (data, msg: ExperimentMetadataMessages) => {
+				if (msg.type === "set-name") return { ...data, name: msg.value };
+				if (msg.type === "set-hypothesis")
+					return { ...data, hypothesis: msg.value };
+				if (msg.type === "set-design-url")
+					return { ...data, designUrl: msg.value || undefined };
+				if (msg.type === "set-start-date")
+					return { ...data, startDate: msg.value };
+				if (msg.type === "set-end-date") return { ...data, endDate: msg.value };
+				if (msg.type === "set-webhook-ids")
+					return { ...data, selectedWebhookIds: msg.value };
+				return data;
+			},
+			isNextEnabled: (data) => {
+				if (!data.name) return false;
+				if (!data.startDate || !data.endDate) return false;
+				if (data.endDate <= data.startDate) return false;
+				return true;
+			},
+		}),
+		"experiment-type": screen({
+			breadcrumbTitle: "Type",
+			render: ExperimentTypeScreen,
+			reducer: (data, msg) => {
+				if (msg.type === "set-experiment-type") {
+					const experimentType = msg.value;
+					const nextData = {
+						...data,
+						experimentType,
+						datasourceId:
+							isBanditExperimentType(data.experimentType) !=
+							isBanditExperimentType(experimentType)
+								? undefined
+								: data.datasourceId,
+						createExperimentResponse: undefined,
+						createExperimentError: undefined,
+						commitError: undefined,
+					};
 
-          if (!isBanditExperimentType(experimentType)) {
-            return {
-              ...nextData,
-              bandit: undefined,
-            };
-          }
+					if (!isBanditExperimentType(experimentType)) {
+						return {
+							...nextData,
+							bandit: undefined,
+						};
+					}
 
-          return {
-            ...nextData,
-            bandit: toBanditParamsForExperimentType(experimentType, data.bandit),
-          };
-        }
-        return data;
-      },
-      isNextEnabled: (data) => !!data.experimentType,
-    }),
-    'freq-select-datasource': screen({
-      breadcrumbTitle: 'Datasource',
-      render: ExperimentSelectDatasourceScreen,
-      reducer: (data, msg) => {
-        const shouldClearDependents = data.datasourceId !== msg.datasourceId || data.tableName !== msg.tableName;
-        if (msg.type === 'set-datasource') {
-          return {
-            ...data,
-            datasourceId: msg.datasourceId,
-            tableName: msg.tableName,
-            primaryKey: msg.primaryKey,
+					return {
+						...nextData,
+						bandit: toBanditParamsForExperimentType(
+							experimentType,
+							data.bandit,
+						),
+					};
+				}
+				return data;
+			},
+			isNextEnabled: (data) => !!data.experimentType,
+		}),
+		"freq-select-datasource": screen({
+			breadcrumbTitle: "Datasource",
+			render: ExperimentSelectDatasourceScreen,
+			reducer: (data, msg) => {
+				const shouldClearDependents =
+					data.datasourceId !== msg.datasourceId ||
+					data.tableName !== msg.tableName;
+				if (msg.type === "set-datasource") {
+					return {
+						...data,
+						datasourceId: msg.datasourceId,
+						tableName: msg.tableName,
+						primaryKey: msg.primaryKey,
 
-            // Clear metrics and filters if the datasource ID or table have changed. This could be improved by retain
-            // entries based on the inspection results.
-            primaryMetric: shouldClearDependents ? undefined : data.primaryMetric,
-            secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
-            filters: shouldClearDependents ? undefined : data.filters,
-            strata: shouldClearDependents ? undefined : removeFieldByName(data.strata, msg.primaryKey),
+						// Clear metrics and filters if the datasource ID or table have changed. This could be improved by retain
+						// entries based on the inspection results.
+						primaryMetric: shouldClearDependents
+							? undefined
+							: data.primaryMetric,
+						secondaryMetrics: shouldClearDependents
+							? undefined
+							: data.secondaryMetrics,
+						filters: shouldClearDependents ? undefined : data.filters,
+						strata: shouldClearDependents
+							? undefined
+							: removeFieldByName(data.strata, msg.primaryKey),
 
-            // Changing datasource should clear power check
-            powerCheckResponse: undefined,
-            desiredN: undefined,
-          };
-        }
-        return data;
-      },
-      isNextEnabled: (data) => !!data.datasourceId && !!data.tableName,
+						// Changing datasource should clear power check
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				return data;
+			},
+			isNextEnabled: (data) => !!data.datasourceId && !!data.tableName,
 
-      hideNavigation: () => true, // hide navigation because this screen uses a nested wizard.
-    }),
-    'bandit-binary-or-real': screen({
-      breadcrumbTitle: 'Outcomes',
+			hideNavigation: () => true, // hide navigation because this screen uses a nested wizard.
+		}),
+		"bandit-binary-or-real": screen({
+			breadcrumbTitle: "Outcomes",
 
-      render: ExperimentSelectBinaryOrRealOutcomes,
-      reducer: (data, msg) => {
-        if (msg.type === 'set-outcome-type') {
-          if (data.bandit === undefined) {
-            return data;
-          }
-          return {
-            ...data,
-            bandit:
-              data.bandit.experimentType === 'mab_online'
-                ? toMabBanditParams(msg.value, data.bandit.arms)
-                : toCmabBanditParams(msg.value, data.bandit.arms, data.bandit.contexts),
-          };
-        }
-        return data;
-      },
-    }),
-    'describe-contexts': screen({
-      breadcrumbTitle: 'Contexts',
-      render: ExperimentDescribeContextsScreen,
-      reducer: (data, msg) => {
-        if (data.bandit?.experimentType !== 'cmab_online') {
-          return data;
-        }
-        const contexts = data.bandit.contexts;
-        if (msg.type === 'add-context') {
-          return {
-            ...data,
-            bandit: { ...data.bandit, contexts: [...contexts, { name: '', description: '', type: 'real-valued' }] },
-          };
-        }
-        if (msg.type === 'remove-context') {
-          return {
-            ...data,
-            bandit: { ...data.bandit, contexts: contexts.filter((_, i) => i !== msg.index) },
-          };
-        }
-        if (msg.type === 'update-context') {
-          const newContexts = [...contexts];
-          const ctx = newContexts[msg.index];
-          switch (msg.field) {
-            case 'name':
-              newContexts[msg.index] = { ...ctx, name: msg.value };
-              break;
-            case 'description':
-              newContexts[msg.index] = { ...ctx, description: msg.value };
-              break;
-            case 'type':
-              newContexts[msg.index] = { ...ctx, type: msg.value as ContextType };
-              break;
-          }
-          return { ...data, bandit: { ...data.bandit, contexts: newContexts } };
-        }
-        return data;
-      },
-      isNextEnabled: (data) => {
-        const contexts = data.bandit?.experimentType === 'cmab_online' ? data.bandit.contexts : [];
-        return contexts.length >= 1 && contexts.every((c) => c.name.trim() !== '');
-      },
-      isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
-      nextButtonTooltip: (data) => {
-        const contexts = data.bandit?.experimentType === 'cmab_online' ? data.bandit.contexts : [];
-        if (contexts.length < 1) return 'At least one context is required.';
-        const emptyNameIndex = contexts.findIndex((c) => c.name.trim() === '');
-        if (emptyNameIndex >= 0) return `Context ${emptyNameIndex + 1} name is required.`;
-        return undefined;
-      },
-    }),
-    'describe-bandit-arms': screen({
-      breadcrumbTitle: 'Arms',
-      render: ExperimentDescribeBanditArmsScreen,
-      reducer: (data, msg) => {
-        if (data.bandit === undefined) {
-          return data;
-        }
-        const arms = data.bandit.arms;
-        if (msg.type === 'add-arm') {
-          const priorType = data.bandit.priorType;
-          const newArm =
-            priorType === 'beta'
-              ? { arm_name: '', arm_description: '', alpha_prior: undefined, beta_prior: undefined, arm_weight: 0 }
-              : { arm_name: '', arm_description: '', mean_prior: undefined, stddev_prior: undefined, arm_weight: 0 };
-          const newArms = [...arms, newArm];
-          const equalWeight = parseFloat((100 / newArms.length).toFixed(1));
-          return { ...data, bandit: { ...data.bandit, arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })) } };
-        }
-        if (msg.type === 'remove-arm') {
-          const newArms = arms.filter((_, i) => i !== msg.index);
-          const equalWeight = newArms.length > 0 ? parseFloat((100 / newArms.length).toFixed(1)) : 0;
-          return { ...data, bandit: { ...data.bandit, arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })) } };
-        }
-        if (msg.type === 'update-arm') {
-          const newArms = [...arms];
-          newArms[msg.index] = { ...newArms[msg.index], [msg.field]: msg.value };
-          return { ...data, bandit: { ...data.bandit, arms: newArms } };
-        }
-        if (msg.type === 'set-create-response') {
-          return {
-            ...data,
-            createExperimentResponse: msg.response,
-            createExperimentError: undefined,
-            experimentId: msg.response.experiment_id,
-            commitError: undefined,
-          };
-        }
-        if (msg.type === 'set-create-error') {
-          return { ...data, createExperimentError: msg.response, createExperimentResponse: undefined };
-        }
-        if (msg.type === 'set-datasource-id') {
-          return { ...data, datasourceId: msg.datasourceId };
-        }
-        if (msg.type === 'set-weights') {
-          const newArms = arms.map((arm, i) => ({ ...arm, arm_weight: msg.weights[i] }));
-          return { ...data, bandit: { ...data.bandit, arms: newArms } };
-        }
-        return data;
-      },
+			render: ExperimentSelectBinaryOrRealOutcomes,
+			reducer: (data, msg) => {
+				if (msg.type === "set-outcome-type") {
+					if (data.bandit === undefined) {
+						return data;
+					}
+					return {
+						...data,
+						bandit:
+							data.bandit.experimentType === "mab_online"
+								? toMabBanditParams(msg.value, data.bandit.arms)
+								: toCmabBanditParams(
+										msg.value,
+										data.bandit.arms,
+										data.bandit.contexts,
+									),
+					};
+				}
+				return data;
+			},
+		}),
+		"describe-contexts": screen({
+			breadcrumbTitle: "Contexts",
+			render: ExperimentDescribeContextsScreen,
+			reducer: (data, msg) => {
+				if (data.bandit?.experimentType !== "cmab_online") {
+					return data;
+				}
+				const contexts = data.bandit.contexts;
+				if (msg.type === "add-context") {
+					return {
+						...data,
+						bandit: {
+							...data.bandit,
+							contexts: [
+								...contexts,
+								{ name: "", description: "", type: "real-valued" },
+							],
+						},
+					};
+				}
+				if (msg.type === "remove-context") {
+					return {
+						...data,
+						bandit: {
+							...data.bandit,
+							contexts: contexts.filter((_, i) => i !== msg.index),
+						},
+					};
+				}
+				if (msg.type === "update-context") {
+					const newContexts = [...contexts];
+					const ctx = newContexts[msg.index];
+					switch (msg.field) {
+						case "name":
+							newContexts[msg.index] = { ...ctx, name: msg.value };
+							break;
+						case "description":
+							newContexts[msg.index] = { ...ctx, description: msg.value };
+							break;
+						case "type":
+							newContexts[msg.index] = {
+								...ctx,
+								type: msg.value as ContextType,
+							};
+							break;
+					}
+					return { ...data, bandit: { ...data.bandit, contexts: newContexts } };
+				}
+				return data;
+			},
+			isNextEnabled: (data) => {
+				const contexts =
+					data.bandit?.experimentType === "cmab_online"
+						? data.bandit.contexts
+						: [];
+				return (
+					contexts.length >= 1 && contexts.every((c) => c.name.trim() !== "")
+				);
+			},
+			isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
+			nextButtonTooltip: (data) => {
+				const contexts =
+					data.bandit?.experimentType === "cmab_online"
+						? data.bandit.contexts
+						: [];
+				if (contexts.length < 1) return "At least one context is required.";
+				const emptyNameIndex = contexts.findIndex((c) => c.name.trim() === "");
+				if (emptyNameIndex >= 0)
+					return `Context ${emptyNameIndex + 1} name is required.`;
+				return undefined;
+			},
+		}),
+		"describe-bandit-arms": screen({
+			breadcrumbTitle: "Arms",
+			render: ExperimentDescribeBanditArmsScreen,
+			reducer: (data, msg) => {
+				if (data.bandit === undefined) {
+					return data;
+				}
+				const arms = data.bandit.arms;
+				if (msg.type === "add-arm") {
+					const priorType = data.bandit.priorType;
+					const newArm =
+						priorType === "beta"
+							? {
+									arm_name: "",
+									arm_description: "",
+									alpha_prior: undefined,
+									beta_prior: undefined,
+									arm_weight: 0,
+								}
+							: {
+									arm_name: "",
+									arm_description: "",
+									mean_prior: undefined,
+									stddev_prior: undefined,
+									arm_weight: 0,
+								};
+					const newArms = [...arms, newArm];
+					const equalWeight = parseFloat((100 / newArms.length).toFixed(1));
+					return {
+						...data,
+						bandit: {
+							...data.bandit,
+							arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })),
+						},
+					};
+				}
+				if (msg.type === "remove-arm") {
+					const newArms = arms.filter((_, i) => i !== msg.index);
+					const equalWeight =
+						newArms.length > 0
+							? parseFloat((100 / newArms.length).toFixed(1))
+							: 0;
+					return {
+						...data,
+						bandit: {
+							...data.bandit,
+							arms: newArms.map((a) => ({ ...a, arm_weight: equalWeight })),
+						},
+					};
+				}
+				if (msg.type === "update-arm") {
+					const newArms = [...arms];
+					newArms[msg.index] = {
+						...newArms[msg.index],
+						[msg.field]: msg.value,
+					};
+					return { ...data, bandit: { ...data.bandit, arms: newArms } };
+				}
+				if (msg.type === "set-create-response") {
+					return {
+						...data,
+						createExperimentResponse: msg.response,
+						createExperimentError: undefined,
+						experimentId: msg.response.experiment_id,
+						commitError: undefined,
+					};
+				}
+				if (msg.type === "set-create-error") {
+					return {
+						...data,
+						createExperimentError: msg.response,
+						createExperimentResponse: undefined,
+					};
+				}
+				if (msg.type === "set-datasource-id") {
+					return { ...data, datasourceId: msg.datasourceId };
+				}
+				if (msg.type === "set-weights") {
+					const newArms = arms.map((arm, i) => ({
+						...arm,
+						arm_weight: msg.weights[i],
+					}));
+					return { ...data, bandit: { ...data.bandit, arms: newArms } };
+				}
+				return data;
+			},
 
-      hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
-      isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
-    }),
-    'describe-arms': screen({
-      breadcrumbTitle: 'Arms',
-      render: ExperimentDescribeArmsScreen,
-      reducer: (data, msg: ExperimentDescribeArmsMessage) => {
-        const arms = data.arms ?? [];
+			hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
+			isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
+		}),
+		"describe-arms": screen({
+			breadcrumbTitle: "Arms",
+			render: ExperimentDescribeArmsScreen,
+			reducer: (data, msg: ExperimentDescribeArmsMessage) => {
+				const arms = data.arms ?? [];
 
-        if (msg.type === 'add-arm') {
-          const newArm =
-            arms.length === 0
-              ? { arm_name: 'Control', arm_description: 'Arm 1 will be used as baseline for comparison.' }
-              : { arm_name: '', arm_description: '' };
-          // Reset weights when adding
-          const newArms = [...arms, newArm].map((a) => ({ ...a, arm_weight: undefined }));
-          return { ...data, arms: newArms };
-        }
+				if (msg.type === "add-arm") {
+					const newArm =
+						arms.length === 0
+							? {
+									arm_name: "Control",
+									arm_description:
+										"Arm 1 will be used as baseline for comparison.",
+								}
+							: { arm_name: "", arm_description: "" };
+					// Reset weights when adding
+					const newArms = [...arms, newArm].map((a) => ({
+						...a,
+						arm_weight: undefined,
+					}));
+					return { ...data, arms: newArms };
+				}
 
-        if (msg.type === 'remove-arm') {
-          // Reset weights when removing
-          const newArms = arms.filter((_, i) => i !== msg.index).map((a) => ({ ...a, arm_weight: undefined }));
-          return { ...data, arms: newArms };
-        }
+				if (msg.type === "remove-arm") {
+					// Reset weights when removing
+					const newArms = arms
+						.filter((_, i) => i !== msg.index)
+						.map((a) => ({ ...a, arm_weight: undefined }));
+					return { ...data, arms: newArms };
+				}
 
-        if (msg.type === 'update-arm') {
-          const newArms = [...arms];
-          newArms[msg.index] = { ...newArms[msg.index], [msg.field]: msg.value };
-          return { ...data, arms: newArms };
-        }
+				if (msg.type === "update-arm") {
+					const newArms = [...arms];
+					newArms[msg.index] = {
+						...newArms[msg.index],
+						[msg.field]: msg.value,
+					};
+					return { ...data, arms: newArms };
+				}
 
-        if (msg.type === 'set-weights') {
-          const newArms = arms.map((arm, i) => ({ ...arm, arm_weight: msg.weights[i] }));
-          return { ...data, arms: newArms };
-        }
+				if (msg.type === "set-weights") {
+					const newArms = arms.map((arm, i) => ({
+						...arm,
+						arm_weight: msg.weights[i],
+					}));
+					return { ...data, arms: newArms };
+				}
 
-        return data;
-      },
-      isNextEnabled: (data) => (data.arms?.length ?? 0) >= 2,
-    }),
-    'freq-stack': screen({
-      breadcrumbTitle: 'Parameters',
-      render: ExperimentFreqStackScreen,
-      reducer: (data, msg: ExperimentFreqStackScreenMessage) => {
-        // Metric builder actions - all metric changes invalidate power check
-        if (msg.type === 'primary-metric-select') {
-          return { ...data, primaryMetric: msg.primaryMetric, powerCheckResponse: undefined, desiredN: undefined };
-        }
-        if (msg.type === 'primary-metric-deselect') {
-          return {
-            ...data,
-            primaryMetric: msg.primaryMetric,
-            secondaryMetrics: msg.secondaryMetrics,
-            powerCheckResponse: undefined,
-            desiredN: undefined,
-          };
-        }
-        if (msg.type === 'promote-secondary-to-primary') {
-          return {
-            ...data,
-            primaryMetric: msg.primaryMetric,
-            secondaryMetrics: msg.secondaryMetrics,
-            powerCheckResponse: undefined,
-            desiredN: undefined,
-          };
-        }
-        if (msg.type === 'secondary-metric-add') {
-          return {
-            ...data,
-            secondaryMetrics: msg.secondaryMetrics,
-            powerCheckResponse: undefined,
-            desiredN: undefined,
-          };
-        }
-        if (msg.type === 'secondary-metric-remove') {
-          return {
-            ...data,
-            secondaryMetrics: msg.secondaryMetrics,
-            powerCheckResponse: undefined,
-            desiredN: undefined,
-          };
-        }
-        if (msg.type === 'mde-change') {
-          return {
-            ...data,
-            primaryMetric: msg.primaryMetric ?? data.primaryMetric,
-            secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
-            powerCheckResponse: undefined,
-            desiredN: undefined,
-          };
-        }
+				return data;
+			},
+			isNextEnabled: (data) => (data.arms?.length ?? 0) >= 2,
+		}),
+		"freq-stack": screen({
+			breadcrumbTitle: "Parameters",
+			render: ExperimentFreqStackScreen,
+			reducer: (data, msg: ExperimentFreqStackScreenMessage) => {
+				// Metric builder actions - all metric changes invalidate power check
+				if (msg.type === "primary-metric-select") {
+					return {
+						...data,
+						primaryMetric: msg.primaryMetric,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "primary-metric-deselect") {
+					return {
+						...data,
+						primaryMetric: msg.primaryMetric,
+						secondaryMetrics: msg.secondaryMetrics,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "promote-secondary-to-primary") {
+					return {
+						...data,
+						primaryMetric: msg.primaryMetric,
+						secondaryMetrics: msg.secondaryMetrics,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "secondary-metric-add") {
+					return {
+						...data,
+						secondaryMetrics: msg.secondaryMetrics,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "secondary-metric-remove") {
+					return {
+						...data,
+						secondaryMetrics: msg.secondaryMetrics,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "mde-change") {
+					return {
+						...data,
+						primaryMetric: msg.primaryMetric ?? data.primaryMetric,
+						secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
 
-        // Filter builder - filter changes invalidate power check
-        if (msg.type === 'set-filters') {
-          return { ...data, filters: msg.filters, powerCheckResponse: undefined, desiredN: undefined };
-        }
+				// Filter builder - filter changes invalidate power check
+				if (msg.type === "set-filters") {
+					return {
+						...data,
+						filters: msg.filters,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
 
-        // Strata builder -
-        // Does NOT invalidate power check for now as we don't currently incorporate strata in
-        // analysis.  When we do, we should also look to incorporate them as covariates in the power
-        // analysis, and if so invalidate here as well.
-        if (msg.type === 'set-strata') {
-          return {
-            ...data,
-            strata: removeFieldByName(msg.strata, data.primaryKey),
-          };
-        }
+				// Strata builder -
+				// Does NOT invalidate power check for now as we don't currently incorporate strata in
+				// analysis.  When we do, we should also look to incorporate them as covariates in the power
+				// analysis, and if so invalidate here as well.
+				if (msg.type === "set-strata") {
+					return {
+						...data,
+						strata: removeFieldByName(msg.strata, data.primaryKey),
+					};
+				}
 
-        // Power check - changing confidence/power invalidates power check response
-        if (msg.type === 'set-confidence') {
-          return { ...data, confidence: msg.value, powerCheckResponse: undefined, desiredN: undefined };
-        }
-        if (msg.type === 'set-power') {
-          return { ...data, power: msg.value, powerCheckResponse: undefined, desiredN: undefined };
-        }
-        if (msg.type === 'set-power-check-response') {
-          return { ...data, powerCheckResponse: msg.response, desiredN: msg.desiredN };
-        }
-        if (msg.type === 'set-chosen-n') {
-          return { ...data, desiredN: msg.value };
-        }
-        if (msg.type === 'set-create-error') {
-          return { ...data, createExperimentError: msg.response, createExperimentResponse: undefined };
-        }
-        if (msg.type === 'set-create-response') {
-          return {
-            ...data,
-            createExperimentResponse: msg.response,
-            createExperimentError: undefined,
-            commitError: undefined,
-          };
-        }
+				// Randomization toggle & cluster builder (issue #217).
+				// Any change to cluster inputs invalidates the previous power-check result
+				// because clustering meaningfully changes the required sample size.
+				if (msg.type === "set-randomization-type") {
+					return {
+						...data,
+						randomizationType: msg.value,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "set-cluster-field") {
+					return {
+						...data,
+						clusterField: msg.field,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "set-cluster-icc") {
+					return {
+						...data,
+						clusterIcc: msg.value,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "set-cluster-cv") {
+					return {
+						...data,
+						clusterCv: msg.value,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "set-cluster-avg-size") {
+					return {
+						...data,
+						clusterAvgSize: msg.value,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
 
-        return data;
-      },
+				// Power check - changing confidence/power invalidates power check response
+				if (msg.type === "set-confidence") {
+					return {
+						...data,
+						confidence: msg.value,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "set-power") {
+					return {
+						...data,
+						power: msg.value,
+						powerCheckResponse: undefined,
+						desiredN: undefined,
+					};
+				}
+				if (msg.type === "set-power-check-response") {
+					return {
+						...data,
+						powerCheckResponse: msg.response,
+						desiredN: msg.desiredN,
+					};
+				}
+				if (msg.type === "set-chosen-n") {
+					return { ...data, desiredN: msg.value };
+				}
+				if (msg.type === "set-create-error") {
+					return {
+						...data,
+						createExperimentError: msg.response,
+						createExperimentResponse: undefined,
+					};
+				}
+				if (msg.type === "set-create-response") {
+					return {
+						...data,
+						createExperimentResponse: msg.response,
+						createExperimentError: undefined,
+						commitError: undefined,
+					};
+				}
 
-      hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
-      isBreadcrumbClickable: (data) => !!(data.datasourceId && data.tableName),
-    }),
-    'summarize-freq': screen({
-      breadcrumbTitle: 'Summary',
-      render: ExperimentsSummarizeFreqScreen,
-      isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
-      reducer: (data, msg) => {
-        if (msg.type === 'set-commit-error') {
-          return { ...data, commitError: msg.response };
-        }
-        return data;
-      },
-      isNextEnabled: (data) => !!data.createExperimentResponse,
-      isPrevEnabled: (data) => !data.createExperimentResponse,
-      hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
-      beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
-    }),
-    'summarize-bandit': screen({
-      breadcrumbTitle: 'Summary',
-      render: ExperimentsSummarizeBanditScreen,
-      reducer: (data, msg) => {
-        if (msg.type === 'set-commit-error') {
-          return { ...data, commitError: msg.response };
-        }
-        return data;
-      },
-      isNextEnabled: (data) => !!data.createExperimentResponse,
-      isPrevEnabled: (data) => !data.createExperimentResponse,
-      hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
-      isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
-      beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
-    }),
-  },
+				return data;
+			},
+
+			hideNavigation: () => true, // screen handles next to handle CreateExperiment API call
+			isBreadcrumbClickable: (data) => !!(data.datasourceId && data.tableName),
+		}),
+		"summarize-freq": screen({
+			breadcrumbTitle: "Summary",
+			render: ExperimentsSummarizeFreqScreen,
+			isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
+			reducer: (data, msg) => {
+				if (msg.type === "set-commit-error") {
+					return { ...data, commitError: msg.response };
+				}
+				return data;
+			},
+			isNextEnabled: (data) => !!data.createExperimentResponse,
+			isPrevEnabled: (data) => !data.createExperimentResponse,
+			hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
+			beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
+		}),
+		"summarize-bandit": screen({
+			breadcrumbTitle: "Summary",
+			render: ExperimentsSummarizeBanditScreen,
+			reducer: (data, msg) => {
+				if (msg.type === "set-commit-error") {
+					return { ...data, commitError: msg.response };
+				}
+				return data;
+			},
+			isNextEnabled: (data) => !!data.createExperimentResponse,
+			isPrevEnabled: (data) => !data.createExperimentResponse,
+			hideNavigation: () => true, // screen handles prev to allow "back" to handle abandonment
+			isBreadcrumbClickable: () => false, // user must enter screen via "next" from previous screen
+			beforeNavigateAway: async (data) => await abandonDraftExperiment(data),
+		}),
+	},
 };

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -144,7 +144,7 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     // biome-ignore lint/suspicious/noExplicitAny: see comment above re: orval.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const specAny = spec as any;
-    specAny.cluster_column = data.clusterField.field_name;
+    specAny.cluster_key = data.clusterField.field_name;
     if (icc !== undefined && cv !== undefined && avgClusterSize !== undefined) {
       specAny.metrics = specAny.metrics.map((m: Record<string, unknown>) => ({
         ...m,

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -110,6 +110,13 @@ export function convertToFrequentistDesignSpec(
 		filters: data.filters ?? [],
 		power: data.power ? Number(data.power) / 100.0 : 0.8,
 		alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
+		// When the user has chosen a sample size (Use max-available or Custom on
+		// the Power Analysis page), pass it through to the BE. The BE then runs
+		// the power analysis in MDE mode and returns the achievable MDE plus the
+		// cluster split that corresponds to the chosen N. Without this, the saved
+		// experiment would carry the original recommended-size power analysis
+		// even when the user picked a different N.
+		...(data.desiredN !== undefined ? { desired_n: data.desiredN } : {}),
 	};
 
 	// The FE-only "freq_cluster_preassigned" type is submitted to the BE as a

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -1,283 +1,245 @@
-import { createExperimentBody } from "@/api/admin.zod";
+import { createExperimentBody } from '@/api/admin.zod';
 import {
-	AnyFrequentistDesignSpecInput,
-	CMABExperimentSpecInputExperimentType,
-	CreateExperimentRequest,
-	DesignSpecMetricRequest,
-	MABExperimentSpecInputExperimentType,
-	OnlineFrequentistExperimentSpecInputExperimentType,
-	PreassignedFrequentistExperimentSpecInputExperimentType,
-	Stratum,
-} from "@/api/methods.schemas";
-import { getCanonicalRewardType } from "@/app/experiments/create/experiment-form/experiment-bandit-helpers";
-import { formatDateUtcYYYYMMDD } from "@/services/date-utils";
-import { z } from "zod";
-import { ExperimentFormData } from "./experiment-form-def";
-import {
-	isFreqExperimentType,
-	isFrequentistSpec,
-} from "./experiment-form-types";
+  AnyFrequentistDesignSpecInput,
+  CMABExperimentSpecInputExperimentType,
+  CreateExperimentRequest,
+  DesignSpecMetricRequest,
+  MABExperimentSpecInputExperimentType,
+  OnlineFrequentistExperimentSpecInputExperimentType,
+  PreassignedFrequentistExperimentSpecInputExperimentType,
+  Stratum,
+} from '@/api/methods.schemas';
+import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
+import { formatDateUtcYYYYMMDD } from '@/services/date-utils';
+import { z } from 'zod';
+import { ExperimentFormData } from './experiment-form-def';
+import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
 
 /**
  * Drops entries whose `field_name` matches `fieldNameToRemove` (e.g. exclude the primary key from
  * stratum lists). Always returns an array; `undefined` input is treated as empty.
  */
 export function removeFieldByName<T extends { field_name: string }>(
-	fields: T[] | undefined,
-	fieldNameToRemove: string | undefined,
+  fields: T[] | undefined,
+  fieldNameToRemove: string | undefined,
 ): T[] {
-	if (!fields?.length) return [];
-	if (!fieldNameToRemove) return fields;
-	return fields.filter((f) => f.field_name !== fieldNameToRemove);
+  if (!fields?.length) return [];
+  if (!fieldNameToRemove) return fields;
+  return fields.filter((f) => f.field_name !== fieldNameToRemove);
 }
 
 export const getReasonableStartDate = (): string => {
-	const date = new Date();
-	date.setDate(0);
-	date.setMonth(date.getMonth() + 2);
-	return formatDateUtcYYYYMMDD(date);
+  const date = new Date();
+  date.setDate(0);
+  date.setMonth(date.getMonth() + 2);
+  return formatDateUtcYYYYMMDD(date);
 };
 
 export const getReasonableEndDate = (): string => {
-	const date = new Date();
-	date.setDate(0);
-	date.setMonth(date.getMonth() + 3);
-	return formatDateUtcYYYYMMDD(date);
+  const date = new Date();
+  date.setDate(0);
+  date.setMonth(date.getMonth() + 3);
+  return formatDateUtcYYYYMMDD(date);
 };
 
 const zodNumberFromForm = (configure?: (num: z.ZodNumber) => z.ZodNumber) =>
-	z.preprocess(
-		(value) => {
-			if (value === undefined) return undefined;
-			if (value instanceof String) value = value.trim();
-			if (value === "") return undefined;
-			return Number(value);
-		},
-		configure ? configure(z.number()) : z.number(),
-	);
+  z.preprocess(
+    (value) => {
+      if (value === undefined) return undefined;
+      if (value instanceof String) value = value.trim();
+      if (value === '') return undefined;
+      return Number(value);
+    },
+    configure ? configure(z.number()) : z.number(),
+  );
 
 const zodMde = zodNumberFromForm((num) => num.int().safe().min(0).max(100));
 
-export function convertToFrequentistDesignSpec(
-	data: ExperimentFormData,
-): AnyFrequentistDesignSpecInput {
-	if (!isFreqExperimentType(data.experimentType)) {
-		throw new Error("Frequentist configuration is required.");
-	}
-	if (!data.name || !data.tableName || !data.primaryKey) {
-		throw new Error(
-			"Experiment name, table name, and primary key are all required.",
-		);
-	}
+export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFrequentistDesignSpecInput {
+  if (!isFreqExperimentType(data.experimentType)) {
+    throw new Error('Frequentist configuration is required.');
+  }
+  if (!data.name || !data.tableName || !data.primaryKey) {
+    throw new Error('Experiment name, table name, and primary key are all required.');
+  }
 
-	const metrics: DesignSpecMetricRequest[] = [];
+  const metrics: DesignSpecMetricRequest[] = [];
 
-	if (data.primaryMetric?.metric.field_name) {
-		zodMde.parse(data.primaryMetric.mde, { path: ["primaryMetric", "mde"] });
-		metrics.push({
-			field_name: data.primaryMetric.metric.field_name,
-			metric_pct_change: Number(data.primaryMetric.mde) / 100.0,
-		});
-	}
+  if (data.primaryMetric?.metric.field_name) {
+    zodMde.parse(data.primaryMetric.mde, { path: ['primaryMetric', 'mde'] });
+    metrics.push({
+      field_name: data.primaryMetric.metric.field_name,
+      metric_pct_change: Number(data.primaryMetric.mde) / 100.0,
+    });
+  }
 
-	(data.secondaryMetrics ?? []).forEach((metric) => {
-		zodMde.parse(metric.mde, {
-			path: ["secondaryMetrics", metric.metric.field_name, "mde"],
-		});
-		metrics.push({
-			field_name: metric.metric.field_name,
-			metric_pct_change: Number(metric.mde) / 100.0,
-		});
-	});
+  (data.secondaryMetrics ?? []).forEach((metric) => {
+    zodMde.parse(metric.mde, {
+      path: ['secondaryMetrics', metric.metric.field_name, 'mde'],
+    });
+    metrics.push({
+      field_name: metric.metric.field_name,
+      metric_pct_change: Number(metric.mde) / 100.0,
+    });
+  });
 
-	const strata: Stratum[] = removeFieldByName(data.strata, data.primaryKey).map(
-		(f) => ({
-			field_name: f.field_name,
-		}),
-	);
+  const strata: Stratum[] = removeFieldByName(data.strata, data.primaryKey).map((f) => ({
+    field_name: f.field_name,
+  }));
 
-	const commonFields = {
-		experiment_name: data.name,
-		description: data.hypothesis ?? "",
-		design_url: data.designUrl ?? null,
-		start_date: new Date(Date.parse(data.startDate!)).toISOString(),
-		end_date: new Date(Date.parse(data.endDate!)).toISOString(),
-		arms: (data.arms ?? []).map((arm) => ({ ...arm, arm_id: null })),
-		table_name: data.tableName,
-		primary_key: data.primaryKey,
-		strata,
-		metrics,
-		filters: data.filters ?? [],
-		power: data.power ? Number(data.power) / 100.0 : 0.8,
-		alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
-		// When the user has chosen a sample size (Use max-available or Custom on
-		// the Power Analysis page), pass it through to the BE. The BE then runs
-		// the power analysis in MDE mode and returns the achievable MDE plus the
-		// cluster split that corresponds to the chosen N. Without this, the saved
-		// experiment would carry the original recommended-size power analysis
-		// even when the user picked a different N.
-		...(data.desiredN !== undefined ? { desired_n: data.desiredN } : {}),
-	};
+  const commonFields = {
+    experiment_name: data.name,
+    description: data.hypothesis ?? '',
+    design_url: data.designUrl ?? null,
+    start_date: new Date(Date.parse(data.startDate!)).toISOString(),
+    end_date: new Date(Date.parse(data.endDate!)).toISOString(),
+    arms: (data.arms ?? []).map((arm) => ({ ...arm, arm_id: null })),
+    table_name: data.tableName,
+    primary_key: data.primaryKey,
+    strata,
+    metrics,
+    filters: data.filters ?? [],
+    power: data.power ? Number(data.power) / 100.0 : 0.8,
+    alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
+    // When the user has chosen a sample size (Use max-available or Custom on
+    // the Power Analysis page), pass it through to the BE. The BE then runs
+    // the power analysis in MDE mode and returns the achievable MDE plus the
+    // cluster split that corresponds to the chosen N. Without this, the saved
+    // experiment would carry the original recommended-size power analysis
+    // even when the user picked a different N.
+    ...(data.desiredN !== undefined ? { desired_n: data.desiredN } : {}),
+  };
 
-	// The FE-only "freq_cluster_preassigned" type is submitted to the BE as a
-	// regular "freq_preassigned" experiment with `cluster_column` set on the
-	// design spec (and `icc`/`cv`/`avg_cluster_size` set on each metric). The
-	// BE has no separate enum value for cluster experiments — PR #163 treats
-	// clustering as a parameter on the existing freq_preassigned type.
-	const isClusterExperiment =
-		data.experimentType === "freq_cluster_preassigned";
-	const wireExperimentType = isClusterExperiment
-		? "freq_preassigned"
-		: data.experimentType;
+  // The FE-only "freq_cluster_preassigned" type is submitted to the BE as a
+  // regular "freq_preassigned" experiment with `cluster_column` set on the
+  // design spec (and `icc`/`cv`/`avg_cluster_size` set on each metric). The
+  // BE has no separate enum value for cluster experiments — PR #163 treats
+  // clustering as a parameter on the existing freq_preassigned type.
+  const isClusterExperiment = data.experimentType === 'freq_cluster_preassigned';
+  const wireExperimentType = isClusterExperiment ? 'freq_preassigned' : data.experimentType;
 
-	const spec = createExperimentBody.strict().parse({
-		design_spec: {
-			...commonFields,
-			experiment_type: wireExperimentType,
-		},
-	}).design_spec;
+  const spec = createExperimentBody.strict().parse({
+    design_spec: {
+      ...commonFields,
+      experiment_type: wireExperimentType,
+    },
+  }).design_spec;
 
-	if (!isFrequentistSpec(spec)) {
-		throw new Error("Frequentist configuration is required.");
-	}
+  if (!isFrequentistSpec(spec)) {
+    throw new Error('Frequentist configuration is required.');
+  }
 
-	// Inject cluster fields AFTER strict zod parsing. We do it here rather than
-	// in commonFields because admin.zod.ts hasn't been regenerated to recognize
-	// the cluster fields yet (orval regeneration is currently broken locally).
-	// The backend accepts these fields per PR #163; we sidestep the FE zod
-	// check rather than patch ~50 places in admin.zod.ts. Once orval is fixed
-	// and admin.zod.ts is regenerated, this post-parse injection becomes
-	// unnecessary.
-	if (isClusterExperiment && data.clusterField) {
-		const icc =
-			data.clusterIcc !== undefined && data.clusterIcc !== ""
-				? Number(data.clusterIcc)
-				: undefined;
-		const cv =
-			data.clusterCv !== undefined && data.clusterCv !== ""
-				? Number(data.clusterCv)
-				: undefined;
-		const avgClusterSize =
-			data.clusterAvgSize !== undefined && data.clusterAvgSize !== ""
-				? Number(data.clusterAvgSize)
-				: undefined;
-		// biome-ignore lint/suspicious/noExplicitAny: see comment above re: orval.
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const specAny = spec as any;
-		specAny.cluster_column = data.clusterField.field_name;
-		if (icc !== undefined && cv !== undefined && avgClusterSize !== undefined) {
-			specAny.metrics = specAny.metrics.map((m: Record<string, unknown>) => ({
-				...m,
-				icc,
-				cv,
-				avg_cluster_size: avgClusterSize,
-			}));
-		}
-	}
+  // Inject cluster fields AFTER strict zod parsing. We do it here rather than
+  // in commonFields because admin.zod.ts hasn't been regenerated to recognize
+  // the cluster fields yet (orval regeneration is currently broken locally).
+  // The backend accepts these fields per PR #163; we sidestep the FE zod
+  // check rather than patch ~50 places in admin.zod.ts. Once orval is fixed
+  // and admin.zod.ts is regenerated, this post-parse injection becomes
+  // unnecessary.
+  if (isClusterExperiment && data.clusterField) {
+    const icc = data.clusterIcc !== undefined && data.clusterIcc !== '' ? Number(data.clusterIcc) : undefined;
+    const cv = data.clusterCv !== undefined && data.clusterCv !== '' ? Number(data.clusterCv) : undefined;
+    const avgClusterSize =
+      data.clusterAvgSize !== undefined && data.clusterAvgSize !== '' ? Number(data.clusterAvgSize) : undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: see comment above re: orval.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const specAny = spec as any;
+    specAny.cluster_column = data.clusterField.field_name;
+    if (icc !== undefined && cv !== undefined && avgClusterSize !== undefined) {
+      specAny.metrics = specAny.metrics.map((m: Record<string, unknown>) => ({
+        ...m,
+        icc,
+        cv,
+        avg_cluster_size: avgClusterSize,
+      }));
+    }
+  }
 
-	return spec;
+  return spec;
 }
 
-export function convertToBanditCreateRequest(
-	data: ExperimentFormData,
-): CreateExperimentRequest {
-	if (data.bandit === undefined) {
-		throw new Error("Bandit configuration is required.");
-	}
-	const { experimentType, outcomeType, priorType, arms } = data.bandit;
-	const canonicalRewardType = getCanonicalRewardType(outcomeType);
+export function convertToBanditCreateRequest(data: ExperimentFormData): CreateExperimentRequest {
+  if (data.bandit === undefined) {
+    throw new Error('Bandit configuration is required.');
+  }
+  const { experimentType, outcomeType, priorType, arms } = data.bandit;
+  const canonicalRewardType = getCanonicalRewardType(outcomeType);
 
-	// Map bandit arms to standard arms format with prior parameters
-	const standardArms = arms.map((arm) => ({
-		arm_id: null,
-		arm_name: arm.arm_name,
-		arm_description: arm.arm_description || "",
-		arm_weight: arm.arm_weight,
-		// Populate only the active prior parameter family.
-		alpha_init:
-			priorType === "beta" && arm.alpha_prior !== undefined
-				? arm.alpha_prior
-				: null,
-		beta_init:
-			priorType === "beta" && arm.beta_prior !== undefined
-				? arm.beta_prior
-				: null,
-		mu_init:
-			priorType === "normal" && arm.mean_prior !== undefined
-				? arm.mean_prior
-				: null,
-		sigma_init:
-			priorType === "normal" && arm.stddev_prior !== undefined
-				? arm.stddev_prior
-				: null,
-	}));
+  // Map bandit arms to standard arms format with prior parameters
+  const standardArms = arms.map((arm) => ({
+    arm_id: null,
+    arm_name: arm.arm_name,
+    arm_description: arm.arm_description || '',
+    arm_weight: arm.arm_weight,
+    // Populate only the active prior parameter family.
+    alpha_init: priorType === 'beta' && arm.alpha_prior !== undefined ? arm.alpha_prior : null,
+    beta_init: priorType === 'beta' && arm.beta_prior !== undefined ? arm.beta_prior : null,
+    mu_init: priorType === 'normal' && arm.mean_prior !== undefined ? arm.mean_prior : null,
+    sigma_init: priorType === 'normal' && arm.stddev_prior !== undefined ? arm.stddev_prior : null,
+  }));
 
-	// Map contexts for CMAB experiments
-	let standardContexts = null;
-	if (experimentType === "cmab_online" && data.bandit.contexts.length > 0) {
-		standardContexts = data.bandit.contexts.map((context) => ({
-			context_id: null,
-			context_name: context.name,
-			context_description: context.description || "",
-			value_type: context.type,
-		}));
-	}
+  // Map contexts for CMAB experiments
+  let standardContexts = null;
+  if (experimentType === 'cmab_online' && data.bandit.contexts.length > 0) {
+    standardContexts = data.bandit.contexts.map((context) => ({
+      context_id: null,
+      context_name: context.name,
+      context_description: context.description || '',
+      value_type: context.type,
+    }));
+  }
 
-	return createExperimentBody.strict().parse({
-		design_spec: {
-			experiment_name: data.name!,
-			experiment_type: experimentType,
-			arms: standardArms,
-			end_date: new Date(Date.parse(data.endDate!)).toISOString(),
-			start_date: new Date(Date.parse(data.startDate!)).toISOString(),
-			description: data.hypothesis ?? "",
-			design_url: data.designUrl ?? null,
-			prior_type: priorType,
-			reward_type: canonicalRewardType,
-			contexts: standardContexts,
-		},
-		webhooks:
-			data.selectedWebhookIds && data.selectedWebhookIds.length > 0
-				? data.selectedWebhookIds
-				: [],
-	});
+  return createExperimentBody.strict().parse({
+    design_spec: {
+      experiment_name: data.name!,
+      experiment_type: experimentType,
+      arms: standardArms,
+      end_date: new Date(Date.parse(data.endDate!)).toISOString(),
+      start_date: new Date(Date.parse(data.startDate!)).toISOString(),
+      description: data.hypothesis ?? '',
+      design_url: data.designUrl ?? null,
+      prior_type: priorType,
+      reward_type: canonicalRewardType,
+      contexts: standardContexts,
+    },
+    webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
+  });
 }
 
 export const ExperimentTypeOptions = [
-	{
-		value:
-			PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned,
-		title: "Preassigned A/B Testing",
-		badge: "A/B",
-		description:
-			"Participants are assigned to experiment arms at design time. Suitable for controlled experiments with fixed sample sizes.",
-	},
-	{
-		value: "freq_cluster_preassigned" as const,
-		title: "Cluster Preassigned A/B Testing",
-		badge: "Cluster",
-		description:
-			"Whole groups of participants (clusters such as schools, villages, or classrooms) are assigned to arms together at design time. Use when the intervention is naturally delivered at the group level.",
-	},
-	{
-		value: OnlineFrequentistExperimentSpecInputExperimentType.freq_online,
-		title: "Online A/B Testing",
-		badge: "A/B",
-		description:
-			"Participants are assigned to experiment arms dynamically as they arrive. Better for real-time experiments with unknown traffic.",
-	},
-	{
-		value: MABExperimentSpecInputExperimentType.mab_online,
-		title: "Multi-Armed Bandit",
-		badge: "MAB",
-		description:
-			"Adaptive allocation that learns and optimizes automatically. Minimizes opportunity cost by converging to the best performing variant.",
-	},
-	{
-		value: CMABExperimentSpecInputExperimentType.cmab_online,
-		title: "Contextual Multi-Armed Bandit",
-		badge: "CMAB",
-		description:
-			"Context-aware optimization for personalized experiences. Adapts recommendations based on user or environmental context.",
-	},
+  {
+    value: PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned,
+    title: 'Preassigned A/B Testing',
+    badge: 'A/B',
+    description:
+      'Participants are assigned to experiment arms at design time. Suitable for controlled experiments with fixed sample sizes.',
+  },
+  {
+    value: 'freq_cluster_preassigned' as const,
+    title: 'Cluster Preassigned A/B Testing',
+    badge: 'Cluster',
+    description:
+      'Whole groups of participants (clusters such as schools, villages, or classrooms) are assigned to arms together at design time. Use when the intervention is naturally delivered at the group level.',
+  },
+  {
+    value: OnlineFrequentistExperimentSpecInputExperimentType.freq_online,
+    title: 'Online A/B Testing',
+    badge: 'A/B',
+    description:
+      'Participants are assigned to experiment arms dynamically as they arrive. Better for real-time experiments with unknown traffic.',
+  },
+  {
+    value: MABExperimentSpecInputExperimentType.mab_online,
+    title: 'Multi-Armed Bandit',
+    badge: 'MAB',
+    description:
+      'Adaptive allocation that learns and optimizes automatically. Minimizes opportunity cost by converging to the best performing variant.',
+  },
+  {
+    value: CMABExperimentSpecInputExperimentType.cmab_online,
+    title: 'Contextual Multi-Armed Bandit',
+    badge: 'CMAB',
+    description:
+      'Context-aware optimization for personalized experiences. Adapts recommendations based on user or environmental context.',
+  },
 ];

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -1,194 +1,276 @@
-import { formatDateUtcYYYYMMDD } from '@/services/date-utils';
-import { z } from 'zod';
+import { createExperimentBody } from "@/api/admin.zod";
 import {
-  AnyFrequentistDesignSpecInput,
-  CMABExperimentSpecInputExperimentType,
-  CreateExperimentRequest,
-  DesignSpecMetricRequest,
-  MABExperimentSpecInputExperimentType,
-  OnlineFrequentistExperimentSpecInputExperimentType,
-  PreassignedFrequentistExperimentSpecInputExperimentType,
-  Stratum,
-} from '@/api/methods.schemas';
-import { createExperimentBody } from '@/api/admin.zod';
-import { ExperimentFormData } from './experiment-form-def';
-import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
-import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
+	AnyFrequentistDesignSpecInput,
+	CMABExperimentSpecInputExperimentType,
+	CreateExperimentRequest,
+	DesignSpecMetricRequest,
+	MABExperimentSpecInputExperimentType,
+	OnlineFrequentistExperimentSpecInputExperimentType,
+	PreassignedFrequentistExperimentSpecInputExperimentType,
+	Stratum,
+} from "@/api/methods.schemas";
+import { getCanonicalRewardType } from "@/app/experiments/create/experiment-form/experiment-bandit-helpers";
+import { formatDateUtcYYYYMMDD } from "@/services/date-utils";
+import { z } from "zod";
+import { ExperimentFormData } from "./experiment-form-def";
+import {
+	isFreqExperimentType,
+	isFrequentistSpec,
+} from "./experiment-form-types";
 
 /**
  * Drops entries whose `field_name` matches `fieldNameToRemove` (e.g. exclude the primary key from
  * stratum lists). Always returns an array; `undefined` input is treated as empty.
  */
 export function removeFieldByName<T extends { field_name: string }>(
-  fields: T[] | undefined,
-  fieldNameToRemove: string | undefined,
+	fields: T[] | undefined,
+	fieldNameToRemove: string | undefined,
 ): T[] {
-  if (!fields?.length) return [];
-  if (!fieldNameToRemove) return fields;
-  return fields.filter((f) => f.field_name !== fieldNameToRemove);
+	if (!fields?.length) return [];
+	if (!fieldNameToRemove) return fields;
+	return fields.filter((f) => f.field_name !== fieldNameToRemove);
 }
 
 export const getReasonableStartDate = (): string => {
-  const date = new Date();
-  date.setDate(0);
-  date.setMonth(date.getMonth() + 2);
-  return formatDateUtcYYYYMMDD(date);
+	const date = new Date();
+	date.setDate(0);
+	date.setMonth(date.getMonth() + 2);
+	return formatDateUtcYYYYMMDD(date);
 };
 
 export const getReasonableEndDate = (): string => {
-  const date = new Date();
-  date.setDate(0);
-  date.setMonth(date.getMonth() + 3);
-  return formatDateUtcYYYYMMDD(date);
+	const date = new Date();
+	date.setDate(0);
+	date.setMonth(date.getMonth() + 3);
+	return formatDateUtcYYYYMMDD(date);
 };
 
 const zodNumberFromForm = (configure?: (num: z.ZodNumber) => z.ZodNumber) =>
-  z.preprocess(
-    (value) => {
-      if (value === undefined) return undefined;
-      if (value instanceof String) value = value.trim();
-      if (value === '') return undefined;
-      return Number(value);
-    },
-    configure ? configure(z.number()) : z.number(),
-  );
+	z.preprocess(
+		(value) => {
+			if (value === undefined) return undefined;
+			if (value instanceof String) value = value.trim();
+			if (value === "") return undefined;
+			return Number(value);
+		},
+		configure ? configure(z.number()) : z.number(),
+	);
 
 const zodMde = zodNumberFromForm((num) => num.int().safe().min(0).max(100));
 
-export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFrequentistDesignSpecInput {
-  if (!isFreqExperimentType(data.experimentType)) {
-    throw new Error('Frequentist configuration is required.');
-  }
-  if (!data.name || !data.tableName || !data.primaryKey) {
-    throw new Error('Experiment name, table name, and primary key are all required.');
-  }
+export function convertToFrequentistDesignSpec(
+	data: ExperimentFormData,
+): AnyFrequentistDesignSpecInput {
+	if (!isFreqExperimentType(data.experimentType)) {
+		throw new Error("Frequentist configuration is required.");
+	}
+	if (!data.name || !data.tableName || !data.primaryKey) {
+		throw new Error(
+			"Experiment name, table name, and primary key are all required.",
+		);
+	}
 
-  const metrics: DesignSpecMetricRequest[] = [];
+	const metrics: DesignSpecMetricRequest[] = [];
 
-  if (data.primaryMetric?.metric.field_name) {
-    zodMde.parse(data.primaryMetric.mde, { path: ['primaryMetric', 'mde'] });
-    metrics.push({
-      field_name: data.primaryMetric.metric.field_name,
-      metric_pct_change: Number(data.primaryMetric.mde) / 100.0,
-    });
-  }
+	if (data.primaryMetric?.metric.field_name) {
+		zodMde.parse(data.primaryMetric.mde, { path: ["primaryMetric", "mde"] });
+		metrics.push({
+			field_name: data.primaryMetric.metric.field_name,
+			metric_pct_change: Number(data.primaryMetric.mde) / 100.0,
+		});
+	}
 
-  (data.secondaryMetrics ?? []).forEach((metric) => {
-    zodMde.parse(metric.mde, { path: ['secondaryMetrics', metric.metric.field_name, 'mde'] });
-    metrics.push({
-      field_name: metric.metric.field_name,
-      metric_pct_change: Number(metric.mde) / 100.0,
-    });
-  });
+	(data.secondaryMetrics ?? []).forEach((metric) => {
+		zodMde.parse(metric.mde, {
+			path: ["secondaryMetrics", metric.metric.field_name, "mde"],
+		});
+		metrics.push({
+			field_name: metric.metric.field_name,
+			metric_pct_change: Number(metric.mde) / 100.0,
+		});
+	});
 
-  const strata: Stratum[] = removeFieldByName(data.strata, data.primaryKey).map((f) => ({
-    field_name: f.field_name,
-  }));
+	const strata: Stratum[] = removeFieldByName(data.strata, data.primaryKey).map(
+		(f) => ({
+			field_name: f.field_name,
+		}),
+	);
 
-  const commonFields = {
-    experiment_name: data.name,
-    description: data.hypothesis ?? '',
-    design_url: data.designUrl ?? null,
-    start_date: new Date(Date.parse(data.startDate!)).toISOString(),
-    end_date: new Date(Date.parse(data.endDate!)).toISOString(),
-    arms: (data.arms ?? []).map((arm) => ({ ...arm, arm_id: null })),
-    table_name: data.tableName,
-    primary_key: data.primaryKey,
-    strata,
-    metrics,
-    filters: data.filters ?? [],
-    power: data.power ? Number(data.power) / 100.0 : 0.8,
-    alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
-  };
+	const commonFields = {
+		experiment_name: data.name,
+		description: data.hypothesis ?? "",
+		design_url: data.designUrl ?? null,
+		start_date: new Date(Date.parse(data.startDate!)).toISOString(),
+		end_date: new Date(Date.parse(data.endDate!)).toISOString(),
+		arms: (data.arms ?? []).map((arm) => ({ ...arm, arm_id: null })),
+		table_name: data.tableName,
+		primary_key: data.primaryKey,
+		strata,
+		metrics,
+		filters: data.filters ?? [],
+		power: data.power ? Number(data.power) / 100.0 : 0.8,
+		alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
+	};
 
-  const spec = createExperimentBody.strict().parse({
-    design_spec: {
-      ...commonFields,
-      experiment_type: data.experimentType,
-    },
-  }).design_spec;
+	// The FE-only "freq_cluster_preassigned" type is submitted to the BE as a
+	// regular "freq_preassigned" experiment with `cluster_column` set on the
+	// design spec (and `icc`/`cv`/`avg_cluster_size` set on each metric). The
+	// BE has no separate enum value for cluster experiments — PR #163 treats
+	// clustering as a parameter on the existing freq_preassigned type.
+	const isClusterExperiment =
+		data.experimentType === "freq_cluster_preassigned";
+	const wireExperimentType = isClusterExperiment
+		? "freq_preassigned"
+		: data.experimentType;
 
-  if (!isFrequentistSpec(spec)) {
-    throw new Error('Frequentist configuration is required.');
-  }
-  return spec;
+	const spec = createExperimentBody.strict().parse({
+		design_spec: {
+			...commonFields,
+			experiment_type: wireExperimentType,
+		},
+	}).design_spec;
+
+	if (!isFrequentistSpec(spec)) {
+		throw new Error("Frequentist configuration is required.");
+	}
+
+	// Inject cluster fields AFTER strict zod parsing. We do it here rather than
+	// in commonFields because admin.zod.ts hasn't been regenerated to recognize
+	// the cluster fields yet (orval regeneration is currently broken locally).
+	// The backend accepts these fields per PR #163; we sidestep the FE zod
+	// check rather than patch ~50 places in admin.zod.ts. Once orval is fixed
+	// and admin.zod.ts is regenerated, this post-parse injection becomes
+	// unnecessary.
+	if (isClusterExperiment && data.clusterField) {
+		const icc =
+			data.clusterIcc !== undefined && data.clusterIcc !== ""
+				? Number(data.clusterIcc)
+				: undefined;
+		const cv =
+			data.clusterCv !== undefined && data.clusterCv !== ""
+				? Number(data.clusterCv)
+				: undefined;
+		const avgClusterSize =
+			data.clusterAvgSize !== undefined && data.clusterAvgSize !== ""
+				? Number(data.clusterAvgSize)
+				: undefined;
+		// biome-ignore lint/suspicious/noExplicitAny: see comment above re: orval.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const specAny = spec as any;
+		specAny.cluster_column = data.clusterField.field_name;
+		if (icc !== undefined && cv !== undefined && avgClusterSize !== undefined) {
+			specAny.metrics = specAny.metrics.map((m: Record<string, unknown>) => ({
+				...m,
+				icc,
+				cv,
+				avg_cluster_size: avgClusterSize,
+			}));
+		}
+	}
+
+	return spec;
 }
 
-export function convertToBanditCreateRequest(data: ExperimentFormData): CreateExperimentRequest {
-  if (data.bandit === undefined) {
-    throw new Error('Bandit configuration is required.');
-  }
-  const { experimentType, outcomeType, priorType, arms } = data.bandit;
-  const canonicalRewardType = getCanonicalRewardType(outcomeType);
+export function convertToBanditCreateRequest(
+	data: ExperimentFormData,
+): CreateExperimentRequest {
+	if (data.bandit === undefined) {
+		throw new Error("Bandit configuration is required.");
+	}
+	const { experimentType, outcomeType, priorType, arms } = data.bandit;
+	const canonicalRewardType = getCanonicalRewardType(outcomeType);
 
-  // Map bandit arms to standard arms format with prior parameters
-  const standardArms = arms.map((arm) => ({
-    arm_id: null,
-    arm_name: arm.arm_name,
-    arm_description: arm.arm_description || '',
-    arm_weight: arm.arm_weight,
-    // Populate only the active prior parameter family.
-    alpha_init: priorType === 'beta' && arm.alpha_prior !== undefined ? arm.alpha_prior : null,
-    beta_init: priorType === 'beta' && arm.beta_prior !== undefined ? arm.beta_prior : null,
-    mu_init: priorType === 'normal' && arm.mean_prior !== undefined ? arm.mean_prior : null,
-    sigma_init: priorType === 'normal' && arm.stddev_prior !== undefined ? arm.stddev_prior : null,
-  }));
+	// Map bandit arms to standard arms format with prior parameters
+	const standardArms = arms.map((arm) => ({
+		arm_id: null,
+		arm_name: arm.arm_name,
+		arm_description: arm.arm_description || "",
+		arm_weight: arm.arm_weight,
+		// Populate only the active prior parameter family.
+		alpha_init:
+			priorType === "beta" && arm.alpha_prior !== undefined
+				? arm.alpha_prior
+				: null,
+		beta_init:
+			priorType === "beta" && arm.beta_prior !== undefined
+				? arm.beta_prior
+				: null,
+		mu_init:
+			priorType === "normal" && arm.mean_prior !== undefined
+				? arm.mean_prior
+				: null,
+		sigma_init:
+			priorType === "normal" && arm.stddev_prior !== undefined
+				? arm.stddev_prior
+				: null,
+	}));
 
-  // Map contexts for CMAB experiments
-  let standardContexts = null;
-  if (experimentType === 'cmab_online' && data.bandit.contexts.length > 0) {
-    standardContexts = data.bandit.contexts.map((context) => ({
-      context_id: null,
-      context_name: context.name,
-      context_description: context.description || '',
-      value_type: context.type,
-    }));
-  }
+	// Map contexts for CMAB experiments
+	let standardContexts = null;
+	if (experimentType === "cmab_online" && data.bandit.contexts.length > 0) {
+		standardContexts = data.bandit.contexts.map((context) => ({
+			context_id: null,
+			context_name: context.name,
+			context_description: context.description || "",
+			value_type: context.type,
+		}));
+	}
 
-  return createExperimentBody.strict().parse({
-    design_spec: {
-      experiment_name: data.name!,
-      experiment_type: experimentType,
-      arms: standardArms,
-      end_date: new Date(Date.parse(data.endDate!)).toISOString(),
-      start_date: new Date(Date.parse(data.startDate!)).toISOString(),
-      description: data.hypothesis ?? '',
-      design_url: data.designUrl ?? null,
-      prior_type: priorType,
-      reward_type: canonicalRewardType,
-      contexts: standardContexts,
-    },
-    webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
-  });
+	return createExperimentBody.strict().parse({
+		design_spec: {
+			experiment_name: data.name!,
+			experiment_type: experimentType,
+			arms: standardArms,
+			end_date: new Date(Date.parse(data.endDate!)).toISOString(),
+			start_date: new Date(Date.parse(data.startDate!)).toISOString(),
+			description: data.hypothesis ?? "",
+			design_url: data.designUrl ?? null,
+			prior_type: priorType,
+			reward_type: canonicalRewardType,
+			contexts: standardContexts,
+		},
+		webhooks:
+			data.selectedWebhookIds && data.selectedWebhookIds.length > 0
+				? data.selectedWebhookIds
+				: [],
+	});
 }
 
 export const ExperimentTypeOptions = [
-  {
-    value: PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned,
-    title: 'Preassigned A/B Testing',
-    badge: 'A/B',
-    description:
-      'Participants are assigned to experiment arms at design time. Suitable for controlled experiments with fixed sample sizes.',
-  },
-  {
-    value: OnlineFrequentistExperimentSpecInputExperimentType.freq_online,
-    title: 'Online A/B Testing',
-    badge: 'A/B',
-    description:
-      'Participants are assigned to experiment arms dynamically as they arrive. Better for real-time experiments with unknown traffic.',
-  },
-  {
-    value: MABExperimentSpecInputExperimentType.mab_online,
-    title: 'Multi-Armed Bandit',
-    badge: 'MAB',
-    description:
-      'Adaptive allocation that learns and optimizes automatically. Minimizes opportunity cost by converging to the best performing variant.',
-  },
-  {
-    value: CMABExperimentSpecInputExperimentType.cmab_online,
-    title: 'Contextual Multi-Armed Bandit',
-    badge: 'CMAB',
-    description:
-      'Context-aware optimization for personalized experiences. Adapts recommendations based on user or environmental context.',
-  },
+	{
+		value:
+			PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned,
+		title: "Preassigned A/B Testing",
+		badge: "A/B",
+		description:
+			"Participants are assigned to experiment arms at design time. Suitable for controlled experiments with fixed sample sizes.",
+	},
+	{
+		value: "freq_cluster_preassigned" as const,
+		title: "Cluster Preassigned A/B Testing",
+		badge: "Cluster",
+		description:
+			"Whole groups of participants (clusters such as schools, villages, or classrooms) are assigned to arms together at design time. Use when the intervention is naturally delivered at the group level.",
+	},
+	{
+		value: OnlineFrequentistExperimentSpecInputExperimentType.freq_online,
+		title: "Online A/B Testing",
+		badge: "A/B",
+		description:
+			"Participants are assigned to experiment arms dynamically as they arrive. Better for real-time experiments with unknown traffic.",
+	},
+	{
+		value: MABExperimentSpecInputExperimentType.mab_online,
+		title: "Multi-Armed Bandit",
+		badge: "MAB",
+		description:
+			"Adaptive allocation that learns and optimizes automatically. Minimizes opportunity cost by converging to the best performing variant.",
+	},
+	{
+		value: CMABExperimentSpecInputExperimentType.cmab_online,
+		title: "Contextual Multi-Armed Bandit",
+		badge: "CMAB",
+		description:
+			"Context-aware optimization for personalized experiences. Adapts recommendations based on user or environmental context.",
+	},
 ];

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -1,100 +1,126 @@
 import {
-  Arm,
-  BayesABExperimentSpecOutput,
-  CMABExperimentSpecInputExperimentType,
-  CMABExperimentSpecOutput,
-  ContextType,
-  DesignSpecOutput,
-  ExperimentConfig,
-  GetExperimentResponse,
-  GetMetricsResponseElement,
-  MABExperimentSpecInput,
-  MABExperimentSpecInputExperimentType,
-  MABExperimentSpecOutput,
-  OnlineFrequentistExperimentSpecInputExperimentType,
-  OnlineFrequentistExperimentSpecOutput,
-  PreassignedFrequentistExperimentSpecInputExperimentType,
-  PreassignedFrequentistExperimentSpecOutput,
-} from '@/api/methods.schemas';
+	Arm,
+	BayesABExperimentSpecOutput,
+	CMABExperimentSpecInputExperimentType,
+	CMABExperimentSpecOutput,
+	ContextType,
+	DesignSpecOutput,
+	ExperimentConfig,
+	GetExperimentResponse,
+	GetMetricsResponseElement,
+	MABExperimentSpecInput,
+	MABExperimentSpecInputExperimentType,
+	MABExperimentSpecOutput,
+	OnlineFrequentistExperimentSpecInputExperimentType,
+	OnlineFrequentistExperimentSpecOutput,
+	PreassignedFrequentistExperimentSpecInputExperimentType,
+	PreassignedFrequentistExperimentSpecOutput,
+} from "@/api/methods.schemas";
 
 // export type ContextVariableType2 = ContextSpec['value_type'];
 export type ContextVariableType = ContextType;
 
 // Context variable configuration for CMAB
 export type Context = {
-  name: string;
-  description: string;
-  type: ContextVariableType;
+	name: string;
+	description: string;
+	type: ContextVariableType;
 };
-export type PriorType = MABExperimentSpecInput['prior_type'];
-export type FormOutcomeType = 'binary' | 'real';
-export type BanditExperimentType = 'mab_online' | 'cmab_online';
+export type PriorType = MABExperimentSpecInput["prior_type"];
+export type FormOutcomeType = "binary" | "real";
+export type BanditExperimentType = "mab_online" | "cmab_online";
 
 // MAB-specific arm configuration with prior parameters
-export type BanditArm = Omit<Arm, 'arm_id'> & {
-  arm_weight?: number;
-  // For Beta distribution
-  alpha_prior?: number;
-  beta_prior?: number;
-  // For Normal distribution
-  mean_prior?: number;
-  stddev_prior?: number;
+export type BanditArm = Omit<Arm, "arm_id"> & {
+	arm_weight?: number;
+	// For Beta distribution
+	alpha_prior?: number;
+	beta_prior?: number;
+	// For Normal distribution
+	mean_prior?: number;
+	stddev_prior?: number;
 };
 
 export type BanditParams =
-  | {
-      experimentType: 'mab_online';
-      outcomeType: 'binary';
-      priorType: 'beta';
-      arms: BanditArm[];
-      contexts?: never;
-    }
-  | {
-      experimentType: 'mab_online';
-      outcomeType: 'real';
-      priorType: 'normal';
-      arms: BanditArm[];
-      contexts?: never;
-    }
-  | {
-      experimentType: 'cmab_online';
-      outcomeType: FormOutcomeType;
-      priorType: 'normal';
-      arms: BanditArm[];
-      contexts: Context[];
-    };
+	| {
+			experimentType: "mab_online";
+			outcomeType: "binary";
+			priorType: "beta";
+			arms: BanditArm[];
+			contexts?: never;
+	  }
+	| {
+			experimentType: "mab_online";
+			outcomeType: "real";
+			priorType: "normal";
+			arms: BanditArm[];
+			contexts?: never;
+	  }
+	| {
+			experimentType: "cmab_online";
+			outcomeType: FormOutcomeType;
+			priorType: "normal";
+			arms: BanditArm[];
+			contexts: Context[];
+	  };
 
 export type MetricWithMDE = {
-  metric: GetMetricsResponseElement;
-  mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value
+	metric: GetMetricsResponseElement;
+	mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value
 };
+
+/**
+ * FE-only experiment-type slug for the "Cluster Preassigned A/B Testing" variant.
+ * Submits to the backend as `freq_preassigned` with `cluster_column` set on the
+ * design spec; the BE has no separate enum value for cluster experiments
+ * (PR #163 treats cluster as a parameter on the existing freq_preassigned type).
+ */
+export const FREQ_CLUSTER_PREASSIGNED = "freq_cluster_preassigned" as const;
 
 // Define the type alias using imported types
 export function isFreqExperimentType(type: string | undefined): boolean {
-  return (
-    !!type &&
-    (type in PreassignedFrequentistExperimentSpecInputExperimentType ||
-      type in OnlineFrequentistExperimentSpecInputExperimentType)
-  );
+	return (
+		!!type &&
+		(type in PreassignedFrequentistExperimentSpecInputExperimentType ||
+			type in OnlineFrequentistExperimentSpecInputExperimentType ||
+			type === FREQ_CLUSTER_PREASSIGNED)
+	);
 }
+
+/** Returns true when this experiment is the new cluster-preassigned variant. */
+export const isClusterPreassignedType = (type: string | undefined): boolean =>
+	type === FREQ_CLUSTER_PREASSIGNED;
 
 export const isFrequentistSpec = (
-  spec: DesignSpecOutput | undefined,
-): spec is OnlineFrequentistExperimentSpecOutput | PreassignedFrequentistExperimentSpecOutput =>
-  !!spec && isFreqExperimentType(spec.experiment_type);
+	spec: DesignSpecOutput | undefined,
+): spec is
+	| OnlineFrequentistExperimentSpecOutput
+	| PreassignedFrequentistExperimentSpecOutput =>
+	!!spec && isFreqExperimentType(spec.experiment_type);
 
 export const isBanditSpec = (
-  spec: DesignSpecOutput | undefined,
-): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput | BayesABExperimentSpecOutput =>
-  !!spec && isBanditExperimentType(spec.experiment_type);
+	spec: DesignSpecOutput | undefined,
+): spec is
+	| MABExperimentSpecOutput
+	| CMABExperimentSpecOutput
+	| BayesABExperimentSpecOutput =>
+	!!spec && isBanditExperimentType(spec.experiment_type);
 
-export function isCmabSpec(spec: DesignSpecOutput | undefined): spec is CMABExperimentSpecOutput {
-  return !!spec && spec.experiment_type === CMABExperimentSpecInputExperimentType.cmab_online;
+export function isCmabSpec(
+	spec: DesignSpecOutput | undefined,
+): spec is CMABExperimentSpecOutput {
+	return (
+		!!spec &&
+		spec.experiment_type === CMABExperimentSpecInputExperimentType.cmab_online
+	);
 }
 
-export const isCmabExperiment = (experiment: GetExperimentResponse | ExperimentConfig | undefined): boolean =>
-  !!experiment && isCmabSpec(experiment.design_spec);
+export const isCmabExperiment = (
+	experiment: GetExperimentResponse | ExperimentConfig | undefined,
+): boolean => !!experiment && isCmabSpec(experiment.design_spec);
 
-export const isBanditExperimentType = (experimentType?: string): experimentType is BanditExperimentType =>
-  experimentType === MABExperimentSpecInputExperimentType.mab_online ||
-  experimentType === CMABExperimentSpecInputExperimentType.cmab_online;
+export const isBanditExperimentType = (
+	experimentType?: string,
+): experimentType is BanditExperimentType =>
+	experimentType === MABExperimentSpecInputExperimentType.mab_online ||
+	experimentType === CMABExperimentSpecInputExperimentType.cmab_online;

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -1,72 +1,72 @@
 import {
-	Arm,
-	BayesABExperimentSpecOutput,
-	CMABExperimentSpecInputExperimentType,
-	CMABExperimentSpecOutput,
-	ContextType,
-	DesignSpecOutput,
-	ExperimentConfig,
-	GetExperimentResponse,
-	GetMetricsResponseElement,
-	MABExperimentSpecInput,
-	MABExperimentSpecInputExperimentType,
-	MABExperimentSpecOutput,
-	OnlineFrequentistExperimentSpecInputExperimentType,
-	OnlineFrequentistExperimentSpecOutput,
-	PreassignedFrequentistExperimentSpecInputExperimentType,
-	PreassignedFrequentistExperimentSpecOutput,
-} from "@/api/methods.schemas";
+  Arm,
+  BayesABExperimentSpecOutput,
+  CMABExperimentSpecInputExperimentType,
+  CMABExperimentSpecOutput,
+  ContextType,
+  DesignSpecOutput,
+  ExperimentConfig,
+  GetExperimentResponse,
+  GetMetricsResponseElement,
+  MABExperimentSpecInput,
+  MABExperimentSpecInputExperimentType,
+  MABExperimentSpecOutput,
+  OnlineFrequentistExperimentSpecInputExperimentType,
+  OnlineFrequentistExperimentSpecOutput,
+  PreassignedFrequentistExperimentSpecInputExperimentType,
+  PreassignedFrequentistExperimentSpecOutput,
+} from '@/api/methods.schemas';
 
 // export type ContextVariableType2 = ContextSpec['value_type'];
 export type ContextVariableType = ContextType;
 
 // Context variable configuration for CMAB
 export type Context = {
-	name: string;
-	description: string;
-	type: ContextVariableType;
+  name: string;
+  description: string;
+  type: ContextVariableType;
 };
-export type PriorType = MABExperimentSpecInput["prior_type"];
-export type FormOutcomeType = "binary" | "real";
-export type BanditExperimentType = "mab_online" | "cmab_online";
+export type PriorType = MABExperimentSpecInput['prior_type'];
+export type FormOutcomeType = 'binary' | 'real';
+export type BanditExperimentType = 'mab_online' | 'cmab_online';
 
 // MAB-specific arm configuration with prior parameters
-export type BanditArm = Omit<Arm, "arm_id"> & {
-	arm_weight?: number;
-	// For Beta distribution
-	alpha_prior?: number;
-	beta_prior?: number;
-	// For Normal distribution
-	mean_prior?: number;
-	stddev_prior?: number;
+export type BanditArm = Omit<Arm, 'arm_id'> & {
+  arm_weight?: number;
+  // For Beta distribution
+  alpha_prior?: number;
+  beta_prior?: number;
+  // For Normal distribution
+  mean_prior?: number;
+  stddev_prior?: number;
 };
 
 export type BanditParams =
-	| {
-			experimentType: "mab_online";
-			outcomeType: "binary";
-			priorType: "beta";
-			arms: BanditArm[];
-			contexts?: never;
-	  }
-	| {
-			experimentType: "mab_online";
-			outcomeType: "real";
-			priorType: "normal";
-			arms: BanditArm[];
-			contexts?: never;
-	  }
-	| {
-			experimentType: "cmab_online";
-			outcomeType: FormOutcomeType;
-			priorType: "normal";
-			arms: BanditArm[];
-			contexts: Context[];
-	  };
+  | {
+      experimentType: 'mab_online';
+      outcomeType: 'binary';
+      priorType: 'beta';
+      arms: BanditArm[];
+      contexts?: never;
+    }
+  | {
+      experimentType: 'mab_online';
+      outcomeType: 'real';
+      priorType: 'normal';
+      arms: BanditArm[];
+      contexts?: never;
+    }
+  | {
+      experimentType: 'cmab_online';
+      outcomeType: FormOutcomeType;
+      priorType: 'normal';
+      arms: BanditArm[];
+      contexts: Context[];
+    };
 
 export type MetricWithMDE = {
-	metric: GetMetricsResponseElement;
-	mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value
+  metric: GetMetricsResponseElement;
+  mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value
 };
 
 /**
@@ -75,52 +75,38 @@ export type MetricWithMDE = {
  * design spec; the BE has no separate enum value for cluster experiments
  * (PR #163 treats cluster as a parameter on the existing freq_preassigned type).
  */
-export const FREQ_CLUSTER_PREASSIGNED = "freq_cluster_preassigned" as const;
+export const FREQ_CLUSTER_PREASSIGNED = 'freq_cluster_preassigned' as const;
 
 // Define the type alias using imported types
 export function isFreqExperimentType(type: string | undefined): boolean {
-	return (
-		!!type &&
-		(type in PreassignedFrequentistExperimentSpecInputExperimentType ||
-			type in OnlineFrequentistExperimentSpecInputExperimentType ||
-			type === FREQ_CLUSTER_PREASSIGNED)
-	);
+  return (
+    !!type &&
+    (type in PreassignedFrequentistExperimentSpecInputExperimentType ||
+      type in OnlineFrequentistExperimentSpecInputExperimentType ||
+      type === FREQ_CLUSTER_PREASSIGNED)
+  );
 }
 
 /** Returns true when this experiment is the new cluster-preassigned variant. */
-export const isClusterPreassignedType = (type: string | undefined): boolean =>
-	type === FREQ_CLUSTER_PREASSIGNED;
+export const isClusterPreassignedType = (type: string | undefined): boolean => type === FREQ_CLUSTER_PREASSIGNED;
 
 export const isFrequentistSpec = (
-	spec: DesignSpecOutput | undefined,
-): spec is
-	| OnlineFrequentistExperimentSpecOutput
-	| PreassignedFrequentistExperimentSpecOutput =>
-	!!spec && isFreqExperimentType(spec.experiment_type);
+  spec: DesignSpecOutput | undefined,
+): spec is OnlineFrequentistExperimentSpecOutput | PreassignedFrequentistExperimentSpecOutput =>
+  !!spec && isFreqExperimentType(spec.experiment_type);
 
 export const isBanditSpec = (
-	spec: DesignSpecOutput | undefined,
-): spec is
-	| MABExperimentSpecOutput
-	| CMABExperimentSpecOutput
-	| BayesABExperimentSpecOutput =>
-	!!spec && isBanditExperimentType(spec.experiment_type);
+  spec: DesignSpecOutput | undefined,
+): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput | BayesABExperimentSpecOutput =>
+  !!spec && isBanditExperimentType(spec.experiment_type);
 
-export function isCmabSpec(
-	spec: DesignSpecOutput | undefined,
-): spec is CMABExperimentSpecOutput {
-	return (
-		!!spec &&
-		spec.experiment_type === CMABExperimentSpecInputExperimentType.cmab_online
-	);
+export function isCmabSpec(spec: DesignSpecOutput | undefined): spec is CMABExperimentSpecOutput {
+  return !!spec && spec.experiment_type === CMABExperimentSpecInputExperimentType.cmab_online;
 }
 
-export const isCmabExperiment = (
-	experiment: GetExperimentResponse | ExperimentConfig | undefined,
-): boolean => !!experiment && isCmabSpec(experiment.design_spec);
+export const isCmabExperiment = (experiment: GetExperimentResponse | ExperimentConfig | undefined): boolean =>
+  !!experiment && isCmabSpec(experiment.design_spec);
 
-export const isBanditExperimentType = (
-	experimentType?: string,
-): experimentType is BanditExperimentType =>
-	experimentType === MABExperimentSpecInputExperimentType.mab_online ||
-	experimentType === CMABExperimentSpecInputExperimentType.cmab_online;
+export const isBanditExperimentType = (experimentType?: string): experimentType is BanditExperimentType =>
+  experimentType === MABExperimentSpecInputExperimentType.mab_online ||
+  experimentType === CMABExperimentSpecInputExperimentType.cmab_online;

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -1,6 +1,5 @@
 import {
   Arm,
-  BayesABExperimentSpecOutput,
   CMABExperimentSpecInputExperimentType,
   CMABExperimentSpecOutput,
   ContextType,
@@ -97,7 +96,7 @@ export const isFrequentistSpec = (
 
 export const isBanditSpec = (
   spec: DesignSpecOutput | undefined,
-): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput | BayesABExperimentSpecOutput =>
+): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput =>
   !!spec && isBanditExperimentType(spec.experiment_type);
 
 export function isCmabSpec(spec: DesignSpecOutput | undefined): spec is CMABExperimentSpecOutput {

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -49,6 +49,13 @@ export type ExperimentFreqStackScreenMessage =
 			response: PowerResponseOutput;
 			desiredN?: number;
 	  }
+	| {
+			// MDE-mode recompute fired when the user picks Max/Custom on the Power
+			// Analysis page. Carries the achievable-MDE response for the chosen N
+			// (separate from the recommended-size response in powerCheckResponse).
+			type: "set-achievable-power-check-response";
+			response: PowerResponseOutput | undefined;
+	  }
 	| { type: "set-create-response"; response: CreateExperimentResponse }
 	| { type: "set-create-error"; response: ErrorType<unknown> }
 	| { type: "set-chosen-n"; value: number | undefined };
@@ -224,9 +231,17 @@ export const ExperimentFreqStackScreen = ({
 
 	const handleCreate = async () => {
 		const designSpec = convertToFrequentistDesignSpec(data);
+		// Prefer the MDE-mode "achievable" response when the user picked
+		// Max-available or Custom on the Power Analysis page. It carries the
+		// cluster split and achievable MDE for the chosen N, which is what
+		// should be persisted on the saved experiment. When the user stuck with
+		// the recommended size, achievablePowerCheckResponse is undefined and we
+		// fall back to the original sample-size-mode response.
+		const powerAnalysesToSave =
+			data.achievablePowerCheckResponse ?? data.powerCheckResponse;
 		const createExperimentRequest = createExperimentBody.strict().parse({
 			design_spec: designSpec,
-			power_analyses: data.powerCheckResponse,
+			power_analyses: powerAnalysesToSave,
 			webhooks:
 				data.selectedWebhookIds && data.selectedWebhookIds.length > 0
 					? data.selectedWebhookIds

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -35,11 +35,21 @@ export type ExperimentFreqStackScreenMessage =
       desiredN?: number;
     }
   | {
-      // MDE-mode recompute fired when the user picks Max/Custom on the Power
-      // Analysis page. Carries the achievable-MDE response for the chosen N
-      // (separate from the recommended-size response in powerCheckResponse).
-      type: 'set-achievable-power-check-response';
+      // MDE-mode response for the Max-available sample size. Fired
+      // proactively after the initial Power Check completes so the
+      // achievable-MDE annotation on the Max radio card is visible even
+      // before the user clicks Max.
+      type: 'set-achievable-max-response';
       response: PowerResponseOutput | undefined;
+    }
+  | {
+      // MDE-mode response for the Custom sample-size value the user typed.
+      // Fired (debounced) when the typed value changes; cached so the
+      // Custom card's achievable-MDE line stays visible after the user
+      // switches to another radio.
+      type: 'set-achievable-custom-response';
+      response: PowerResponseOutput;
+      desiredN: number;
     }
   | { type: 'set-create-response'; response: CreateExperimentResponse }
   | { type: 'set-create-error'; response: ErrorType<unknown> }
@@ -100,11 +110,12 @@ export const ExperimentFreqStackScreen = ({
   const { data: tableData } = useInspectTableInDatasource(data.datasourceId ?? '', data.tableName ?? '', {
     refresh: false,
   });
+  // desired_n used to be a query param on createExperiment but the BE moved it
+  // onto design_spec (set by convertToFrequentistDesignSpec when data.desiredN
+  // is defined). No query params are needed here anymore.
   const { trigger: triggerCreate, isMutating: triggerLoading } = useCreateExperiment(
     data.datasourceId!,
-    {
-      desired_n: data.desiredN,
-    },
+    {},
     {
       swr: {
         onSuccess: async (response) => {
@@ -187,13 +198,50 @@ export const ExperimentFreqStackScreen = ({
 
   const handleCreate = async () => {
     const designSpec = convertToFrequentistDesignSpec(data);
-    // Prefer the MDE-mode "achievable" response when the user picked
-    // Max-available or Custom on the Power Analysis page. It carries the
-    // cluster split and achievable MDE for the chosen N, which is what
-    // should be persisted on the saved experiment. When the user stuck with
-    // the recommended size, achievablePowerCheckResponse is undefined and we
-    // fall back to the original sample-size-mode response.
-    const powerAnalysesToSave = data.achievablePowerCheckResponse ?? data.powerCheckResponse;
+    // Pick the achievable response that matches the user's chosen N. If they
+    // picked Custom, use the cached custom response (only when its desired_n
+    // still matches data.desiredN); if Max, the cached max response.
+    // Otherwise fall back to the recommended (sample-size-mode) response.
+    const achievableForChosenN =
+      data.desiredN !== undefined && data.desiredN === data.achievableCustomDesiredN
+        ? data.achievableCustomPowerCheckResponse
+        : data.achievableMaxPowerCheckResponse;
+    let powerAnalysesToSave = achievableForChosenN ?? data.powerCheckResponse;
+
+    // The BE response's num_clusters_total / clusters_per_arm reflect the
+    // MINIMUM required when sufficient_n is true — not the user's chosen N.
+    // Patch them so the saved experiment header / arms section / power-balance
+    // dialog display the cluster count that matches what the user committed to.
+    if (
+      achievableForChosenN &&
+      data.desiredN !== undefined &&
+      data.experimentType === 'freq_cluster_preassigned' &&
+      data.clusterAvgSize !== undefined &&
+      data.clusterAvgSize !== ''
+    ) {
+      const avg = Number(data.clusterAvgSize);
+      const arms = data.arms ?? [];
+      if (Number.isFinite(avg) && avg > 0 && arms.length > 0) {
+        const totalClusters = Math.ceil(data.desiredN / avg);
+        const perArm = Math.floor(totalClusters / arms.length);
+        const remainder = totalClusters - perArm * arms.length;
+        const clustersPerArm = arms.map((_, i) => perArm + (i < remainder ? 1 : 0));
+        const nPerArm = clustersPerArm.map((c) => Math.round(c * avg));
+        powerAnalysesToSave = {
+          ...achievableForChosenN,
+          analyses: achievableForChosenN.analyses.map((a, i) =>
+            i === 0
+              ? {
+                  ...a,
+                  num_clusters_total: totalClusters,
+                  clusters_per_arm: clustersPerArm,
+                  n_per_arm: nPerArm,
+                }
+              : a,
+          ),
+        };
+      }
+    }
     const createExperimentRequest = createExperimentBody.strict().parse({
       design_spec: designSpec,
       power_analyses: powerAnalysesToSave,
@@ -209,7 +257,7 @@ export const ExperimentFreqStackScreen = ({
       // biome-ignore lint/suspicious/noExplicitAny: orval-stripped fields, see comment above.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const reqAny = createExperimentRequest as any;
-      reqAny.design_spec.cluster_column = data.clusterField.field_name;
+      reqAny.design_spec.cluster_key = data.clusterField.field_name;
       const icc = data.clusterIcc !== undefined && data.clusterIcc !== '' ? Number(data.clusterIcc) : undefined;
       const cv = data.clusterCv !== undefined && data.clusterCv !== '' ? Number(data.clusterCv) : undefined;
       const avg =

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -1,108 +1,88 @@
+import { useCreateExperiment, useInspectTableInDatasource, usePowerCheck } from '@/api/admin';
+import { createExperimentBody } from '@/api/admin.zod';
+import { CreateExperimentResponse, FieldMetadata, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
 import {
-	useCreateExperiment,
-	useInspectTableInDatasource,
-	usePowerCheck,
-} from "@/api/admin";
-import { createExperimentBody } from "@/api/admin.zod";
-import {
-	CreateExperimentResponse,
-	FieldMetadata,
-	FilterInput,
-	PowerResponseOutput,
-} from "@/api/methods.schemas";
-import {
-	ExperimentFormData,
-	ExperimentScreenId,
-} from "@/app/experiments/create/experiment-form/experiment-form-def";
-import {
-	convertToFrequentistDesignSpec,
-	removeFieldByName,
-} from "@/app/experiments/create/experiment-form/experiment-form-helpers";
-import { ClusterBuilder } from "@/components/features/experiments/cluster-builder";
-import {
-	MetricBuilder,
-	MetricBuilderAction,
-} from "@/components/features/experiments/metric-builder";
-import { NavigationButtons } from "@/components/features/experiments/navigation-buttons";
-import { FilterBuilder } from "@/components/features/experiments/querybuilder/filter-builder";
-import { StrataBuilder } from "@/components/features/experiments/strata-builder";
-import { GenericErrorCallout } from "@/components/ui/generic-error";
-import { ErrorType } from "@/services/orval-fetch";
-import { ScreenProps } from "@/services/wizard/wizard-types";
-import { Card, Flex, Heading } from "@radix-ui/themes";
-import { useState } from "react";
-import { PowerCheckSection } from "./power-check-section";
+  convertToFrequentistDesignSpec,
+  removeFieldByName,
+} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import { ClusterBuilder } from '@/components/features/experiments/cluster-builder';
+import { MetricBuilder, MetricBuilderAction } from '@/components/features/experiments/metric-builder';
+import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
+import { FilterBuilder } from '@/components/features/experiments/querybuilder/filter-builder';
+import { StrataBuilder } from '@/components/features/experiments/strata-builder';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { ErrorType } from '@/services/orval-fetch';
+import { ScreenProps } from '@/services/wizard/wizard-types';
+import { Card, Flex, Heading } from '@radix-ui/themes';
+import { useState } from 'react';
+import { PowerCheckSection } from './power-check-section';
 
 export type ExperimentFreqStackScreenMessage =
-	| MetricBuilderAction
-	| { type: "set-filters"; filters: FilterInput[] }
-	| { type: "set-strata"; strata: FieldMetadata[] }
-	| { type: "set-randomization-type"; value: "strata" | "cluster" }
-	| { type: "set-cluster-field"; field?: FieldMetadata }
-	| { type: "set-cluster-icc"; value: string }
-	| { type: "set-cluster-cv"; value: string }
-	| { type: "set-cluster-avg-size"; value: string }
-	| { type: "set-confidence"; value: string }
-	| { type: "set-power"; value: string }
-	| {
-			type: "set-power-check-response";
-			response: PowerResponseOutput;
-			desiredN?: number;
-	  }
-	| {
-			// MDE-mode recompute fired when the user picks Max/Custom on the Power
-			// Analysis page. Carries the achievable-MDE response for the chosen N
-			// (separate from the recommended-size response in powerCheckResponse).
-			type: "set-achievable-power-check-response";
-			response: PowerResponseOutput | undefined;
-	  }
-	| { type: "set-create-response"; response: CreateExperimentResponse }
-	| { type: "set-create-error"; response: ErrorType<unknown> }
-	| { type: "set-chosen-n"; value: number | undefined };
+  | MetricBuilderAction
+  | { type: 'set-filters'; filters: FilterInput[] }
+  | { type: 'set-strata'; strata: FieldMetadata[] }
+  | { type: 'set-randomization-type'; value: 'strata' | 'cluster' }
+  | { type: 'set-cluster-field'; field?: FieldMetadata }
+  | { type: 'set-cluster-icc'; value: string }
+  | { type: 'set-cluster-cv'; value: string }
+  | { type: 'set-cluster-avg-size'; value: string }
+  | { type: 'set-confidence'; value: string }
+  | { type: 'set-power'; value: string }
+  | {
+      type: 'set-power-check-response';
+      response: PowerResponseOutput;
+      desiredN?: number;
+    }
+  | {
+      // MDE-mode recompute fired when the user picks Max/Custom on the Power
+      // Analysis page. Carries the achievable-MDE response for the chosen N
+      // (separate from the recommended-size response in powerCheckResponse).
+      type: 'set-achievable-power-check-response';
+      response: PowerResponseOutput | undefined;
+    }
+  | { type: 'set-create-response'; response: CreateExperimentResponse }
+  | { type: 'set-create-error'; response: ErrorType<unknown> }
+  | { type: 'set-chosen-n'; value: number | undefined };
 
 const isClusterFieldsComplete = (data: ExperimentFormData) => {
-	if (!data.clusterField) return false;
-	const icc = Number(data.clusterIcc);
-	const cv = Number(data.clusterCv);
-	const avg = Number(data.clusterAvgSize);
-	if (
-		data.clusterIcc === "" ||
-		data.clusterCv === "" ||
-		data.clusterAvgSize === ""
-	) {
-		return false;
-	}
-	if (Number.isNaN(icc) || icc < 0 || icc > 1) return false;
-	if (Number.isNaN(cv) || cv < 0) return false;
-	if (Number.isNaN(avg) || avg < 1) return false;
-	return true;
+  if (!data.clusterField) return false;
+  const icc = Number(data.clusterIcc);
+  const cv = Number(data.clusterCv);
+  const avg = Number(data.clusterAvgSize);
+  if (data.clusterIcc === '' || data.clusterCv === '' || data.clusterAvgSize === '') {
+    return false;
+  }
+  if (Number.isNaN(icc) || icc < 0 || icc > 1) return false;
+  if (Number.isNaN(cv) || cv < 0) return false;
+  if (Number.isNaN(avg) || avg < 1) return false;
+  return true;
 };
 
 const isNextEnabled = (data: ExperimentFormData) => {
-	const isFreqPreassigned =
-		data.experimentType === "freq_preassigned" ||
-		data.experimentType === "freq_cluster_preassigned";
-	const isCluster = data.experimentType === "freq_cluster_preassigned";
+  const isFreqPreassigned =
+    data.experimentType === 'freq_preassigned' || data.experimentType === 'freq_cluster_preassigned';
+  const isCluster = data.experimentType === 'freq_cluster_preassigned';
 
-	// Must have primary metric selected
-	if (!data.primaryMetric) return false;
-	// Cluster experiment type requires a cluster field + valid ICC/CV/avg cluster size.
-	if (isCluster && !isClusterFieldsComplete(data)) {
-		return false;
-	}
-	// Must have valid confidence value (50-99)
-	if (isFreqPreassigned) {
-		const confidence = Number(data.confidence);
-		if (isNaN(confidence) || confidence < 50 || confidence > 99) return false;
-		// Must have valid power value (50-99) for pre-assigned frequentist experiment
-		const power = Number(data.power);
-		if (isNaN(power) || power < 50 || power > 99) return false;
-		// Must have run power check for pre-assigned frequentist experiment
-		if (!data.powerCheckResponse) return false;
-		// Must have selected a sample size for pre-assigned frequentist experiment
-		if (data.desiredN === undefined) return false;
-	}
-	return true;
+  // Must have primary metric selected
+  if (!data.primaryMetric) return false;
+  // Cluster experiment type requires a cluster field + valid ICC/CV/avg cluster size.
+  if (isCluster && !isClusterFieldsComplete(data)) {
+    return false;
+  }
+  // Must have valid confidence value (50-99)
+  if (isFreqPreassigned) {
+    const confidence = Number(data.confidence);
+    if (isNaN(confidence) || confidence < 50 || confidence > 99) return false;
+    // Must have valid power value (50-99) for pre-assigned frequentist experiment
+    const power = Number(data.power);
+    if (isNaN(power) || power < 50 || power > 99) return false;
+    // Must have run power check for pre-assigned frequentist experiment
+    if (!data.powerCheckResponse) return false;
+    // Must have selected a sample size for pre-assigned frequentist experiment
+    if (data.desiredN === undefined) return false;
+  }
+  return true;
 };
 
 /** ExperimentFreqStackScreen allows users to define the primary key, metrics, filters, strata, confidence, power,
@@ -112,284 +92,230 @@ const isNextEnabled = (data: ExperimentFormData) => {
  * so please look to that for behavioral and component re-use guidance.
  */
 export const ExperimentFreqStackScreen = ({
-	data,
-	dispatch,
-	navigatePrev,
-	navigateNext,
-}: ScreenProps<
-	ExperimentFormData,
-	ExperimentFreqStackScreenMessage,
-	ExperimentScreenId
->) => {
-	const { data: tableData } = useInspectTableInDatasource(
-		data.datasourceId ?? "",
-		data.tableName ?? "",
-		{
-			refresh: false,
-		},
-	);
-	const { trigger: triggerCreate, isMutating: triggerLoading } =
-		useCreateExperiment(
-			data.datasourceId!,
-			{
-				desired_n: data.desiredN,
-			},
-			{
-				swr: {
-					onSuccess: async (response) => {
-						dispatch({ type: "set-create-response", response: response });
-						navigateNext();
-					},
-					onError: async (response) => {
-						dispatch({ type: "set-create-error", response: response });
-					},
-				},
-			},
-		);
+  data,
+  dispatch,
+  navigatePrev,
+  navigateNext,
+}: ScreenProps<ExperimentFormData, ExperimentFreqStackScreenMessage, ExperimentScreenId>) => {
+  const { data: tableData } = useInspectTableInDatasource(data.datasourceId ?? '', data.tableName ?? '', {
+    refresh: false,
+  });
+  const { trigger: triggerCreate, isMutating: triggerLoading } = useCreateExperiment(
+    data.datasourceId!,
+    {
+      desired_n: data.desiredN,
+    },
+    {
+      swr: {
+        onSuccess: async (response) => {
+          dispatch({ type: 'set-create-response', response: response });
+          navigateNext();
+        },
+        onError: async (response) => {
+          dispatch({ type: 'set-create-error', response: response });
+        },
+      },
+    },
+  );
 
-	// Auto-fill of cluster stats (issue #217). We call power_check with the
-	// current design spec but with cluster ICC/CV/avg unset; the BE auto-
-	// calculates them from the datasource (PR #163) and we copy the response
-	// back into the form so the user sees the values and can override them.
-	const { trigger: triggerPowerCheckForAutoFill } = usePowerCheck(
-		data.datasourceId ?? "",
-	);
-	const [autoFillLoading, setAutoFillLoading] = useState(false);
-	const [autoFillError, setAutoFillError] = useState<string | null>(null);
-	const handleAutoFillCluster = async () => {
-		if (!data.clusterField || !data.primaryMetric) return;
-		setAutoFillLoading(true);
-		setAutoFillError(null);
-		try {
-			const design_spec = convertToFrequentistDesignSpec({
-				...data,
-				// Run the BE auto-calculation by leaving ICC/CV/avg unset.
-				clusterIcc: "",
-				clusterCv: "",
-				clusterAvgSize: "",
-			});
-			const response = await triggerPowerCheckForAutoFill({ design_spec });
-			const primary = response.analyses.find(
-				(a) =>
-					a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-			);
-			// Cluster fields live on metric_spec (DesignSpecMetric). They're
-			// typed loosely here because methods.schemas.ts hasn't been
-			// regenerated to surface them on the output type — see comment in
-			// experiment-form-helpers.tsx.
-			const ms = primary?.metric_spec as
-				| {
-						icc?: number | null;
-						cv?: number | null;
-						avg_cluster_size?: number | null;
-				  }
-				| undefined;
-			if (ms?.icc != null)
-				dispatch({ type: "set-cluster-icc", value: String(ms.icc) });
-			if (ms?.cv != null)
-				dispatch({ type: "set-cluster-cv", value: String(ms.cv) });
-			if (ms?.avg_cluster_size != null)
-				dispatch({
-					type: "set-cluster-avg-size",
-					value: String(ms.avg_cluster_size),
-				});
-		} catch (err) {
-			setAutoFillError(
-				err instanceof Error
-					? err.message
-					: "Failed to calculate cluster stats from datasource.",
-			);
-		} finally {
-			setAutoFillLoading(false);
-		}
-	};
+  // Auto-fill of cluster stats (issue #217). We call power_check with the
+  // current design spec but with cluster ICC/CV/avg unset; the BE auto-
+  // calculates them from the datasource (PR #163) and we copy the response
+  // back into the form so the user sees the values and can override them.
+  const { trigger: triggerPowerCheckForAutoFill } = usePowerCheck(data.datasourceId ?? '');
+  const [autoFillLoading, setAutoFillLoading] = useState(false);
+  const [autoFillError, setAutoFillError] = useState<string | null>(null);
+  const handleAutoFillCluster = async () => {
+    if (!data.clusterField || !data.primaryMetric) return;
+    setAutoFillLoading(true);
+    setAutoFillError(null);
+    try {
+      const design_spec = convertToFrequentistDesignSpec({
+        ...data,
+        // Run the BE auto-calculation by leaving ICC/CV/avg unset.
+        clusterIcc: '',
+        clusterCv: '',
+        clusterAvgSize: '',
+      });
+      const response = await triggerPowerCheckForAutoFill({ design_spec });
+      const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
+      // Cluster fields live on metric_spec (DesignSpecMetric). They're
+      // typed loosely here because methods.schemas.ts hasn't been
+      // regenerated to surface them on the output type — see comment in
+      // experiment-form-helpers.tsx.
+      const ms = primary?.metric_spec as
+        | {
+            icc?: number | null;
+            cv?: number | null;
+            avg_cluster_size?: number | null;
+          }
+        | undefined;
+      if (ms?.icc != null) dispatch({ type: 'set-cluster-icc', value: String(ms.icc) });
+      if (ms?.cv != null) dispatch({ type: 'set-cluster-cv', value: String(ms.cv) });
+      if (ms?.avg_cluster_size != null)
+        dispatch({
+          type: 'set-cluster-avg-size',
+          value: String(ms.avg_cluster_size),
+        });
+    } catch (err) {
+      setAutoFillError(err instanceof Error ? err.message : 'Failed to calculate cluster stats from datasource.');
+    } finally {
+      setAutoFillLoading(false);
+    }
+  };
 
-	const allTableFields = tableData?.fields ?? [];
+  const allTableFields = tableData?.fields ?? [];
 
-	// Filter numeric and boolean fields for metrics
-	const metricFields = allTableFields.filter((f) =>
-		["integer", "bigint", "double precision", "numeric", "boolean"].includes(
-			f.data_type,
-		),
-	);
-	// Exclude primary key from stratum options.
-	const availableStrata = removeFieldByName(
-		allTableFields,
-		data.primaryKey,
-	).toSorted((a, b) => a.field_name.localeCompare(b.field_name));
-	// Reconfirm that the selected strata are still valid options and filter out any undefined if not.
-	const selectedStrata = (data.strata ?? [])
-		.map((s) => availableStrata.find((f) => f.field_name === s.field_name))
-		.filter((f): f is FieldMetadata => Boolean(f));
+  // Filter numeric and boolean fields for metrics
+  const metricFields = allTableFields.filter((f) =>
+    ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
+  );
+  // Exclude primary key from stratum options.
+  const availableStrata = removeFieldByName(allTableFields, data.primaryKey).toSorted((a, b) =>
+    a.field_name.localeCompare(b.field_name),
+  );
+  // Reconfirm that the selected strata are still valid options and filter out any undefined if not.
+  const selectedStrata = (data.strata ?? [])
+    .map((s) => availableStrata.find((f) => f.field_name === s.field_name))
+    .filter((f): f is FieldMetadata => Boolean(f));
 
-	// Cluster ID candidates: the same pool as strata (exclude primary key).
-	const availableClusterFields = availableStrata;
-	const isClusterPreassigned =
-		data.experimentType === "freq_cluster_preassigned";
+  // Cluster ID candidates: the same pool as strata (exclude primary key).
+  const availableClusterFields = availableStrata;
+  const isClusterPreassigned = data.experimentType === 'freq_cluster_preassigned';
 
-	const nextEnabled = isNextEnabled(data);
+  const nextEnabled = isNextEnabled(data);
 
-	const handleCreate = async () => {
-		const designSpec = convertToFrequentistDesignSpec(data);
-		// Prefer the MDE-mode "achievable" response when the user picked
-		// Max-available or Custom on the Power Analysis page. It carries the
-		// cluster split and achievable MDE for the chosen N, which is what
-		// should be persisted on the saved experiment. When the user stuck with
-		// the recommended size, achievablePowerCheckResponse is undefined and we
-		// fall back to the original sample-size-mode response.
-		const powerAnalysesToSave =
-			data.achievablePowerCheckResponse ?? data.powerCheckResponse;
-		const createExperimentRequest = createExperimentBody.strict().parse({
-			design_spec: designSpec,
-			power_analyses: powerAnalysesToSave,
-			webhooks:
-				data.selectedWebhookIds && data.selectedWebhookIds.length > 0
-					? data.selectedWebhookIds
-					: [],
-		});
-		// Issue #217: the strict parse above strips cluster fields because
-		// admin.zod.ts hasn't been regenerated to recognize them (orval
-		// regeneration is currently broken locally). Re-attach the cluster
-		// fields onto the parsed request so they reach the BE. Without this
-		// the BE never persists cluster_column / icc / cv / avg_cluster_size
-		// for the new "Cluster Preassigned A/B Testing" type.
-		if (data.experimentType === "freq_cluster_preassigned" && data.clusterField) {
-			// biome-ignore lint/suspicious/noExplicitAny: orval-stripped fields, see comment above.
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const reqAny = createExperimentRequest as any;
-			reqAny.design_spec.cluster_column = data.clusterField.field_name;
-			const icc =
-				data.clusterIcc !== undefined && data.clusterIcc !== ""
-					? Number(data.clusterIcc)
-					: undefined;
-			const cv =
-				data.clusterCv !== undefined && data.clusterCv !== ""
-					? Number(data.clusterCv)
-					: undefined;
-			const avg =
-				data.clusterAvgSize !== undefined && data.clusterAvgSize !== ""
-					? Number(data.clusterAvgSize)
-					: undefined;
-			if (
-				icc !== undefined &&
-				cv !== undefined &&
-				avg !== undefined &&
-				Number.isFinite(icc) &&
-				Number.isFinite(cv) &&
-				Number.isFinite(avg)
-			) {
-				reqAny.design_spec.metrics = reqAny.design_spec.metrics.map(
-					(m: Record<string, unknown>) => ({
-						...m,
-						icc,
-						cv,
-						avg_cluster_size: avg,
-					}),
-				);
-			}
-		}
-		console.log("converted", createExperimentRequest);
-		await triggerCreate(createExperimentRequest, { throwOnError: false });
-	};
+  const handleCreate = async () => {
+    const designSpec = convertToFrequentistDesignSpec(data);
+    // Prefer the MDE-mode "achievable" response when the user picked
+    // Max-available or Custom on the Power Analysis page. It carries the
+    // cluster split and achievable MDE for the chosen N, which is what
+    // should be persisted on the saved experiment. When the user stuck with
+    // the recommended size, achievablePowerCheckResponse is undefined and we
+    // fall back to the original sample-size-mode response.
+    const powerAnalysesToSave = data.achievablePowerCheckResponse ?? data.powerCheckResponse;
+    const createExperimentRequest = createExperimentBody.strict().parse({
+      design_spec: designSpec,
+      power_analyses: powerAnalysesToSave,
+      webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
+    });
+    // Issue #217: the strict parse above strips cluster fields because
+    // admin.zod.ts hasn't been regenerated to recognize them (orval
+    // regeneration is currently broken locally). Re-attach the cluster
+    // fields onto the parsed request so they reach the BE. Without this
+    // the BE never persists cluster_column / icc / cv / avg_cluster_size
+    // for the new "Cluster Preassigned A/B Testing" type.
+    if (data.experimentType === 'freq_cluster_preassigned' && data.clusterField) {
+      // biome-ignore lint/suspicious/noExplicitAny: orval-stripped fields, see comment above.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const reqAny = createExperimentRequest as any;
+      reqAny.design_spec.cluster_column = data.clusterField.field_name;
+      const icc = data.clusterIcc !== undefined && data.clusterIcc !== '' ? Number(data.clusterIcc) : undefined;
+      const cv = data.clusterCv !== undefined && data.clusterCv !== '' ? Number(data.clusterCv) : undefined;
+      const avg =
+        data.clusterAvgSize !== undefined && data.clusterAvgSize !== '' ? Number(data.clusterAvgSize) : undefined;
+      if (
+        icc !== undefined &&
+        cv !== undefined &&
+        avg !== undefined &&
+        Number.isFinite(icc) &&
+        Number.isFinite(cv) &&
+        Number.isFinite(avg)
+      ) {
+        reqAny.design_spec.metrics = reqAny.design_spec.metrics.map((m: Record<string, unknown>) => ({
+          ...m,
+          icc,
+          cv,
+          avg_cluster_size: avg,
+        }));
+      }
+    }
+    console.log('converted', createExperimentRequest);
+    await triggerCreate(createExperimentRequest, { throwOnError: false });
+  };
 
-	return (
-		<>
-			<Flex direction="column" gap={"3"}>
-				<Heading as="h3" size="3">
-					Metrics
-				</Heading>
-				<Card>
-					<MetricBuilder
-						primaryMetric={data.primaryMetric}
-						secondaryMetrics={data.secondaryMetrics ?? []}
-						dispatch={dispatch}
-						metricFields={metricFields}
-					/>
-				</Card>
+  return (
+    <>
+      <Flex direction="column" gap={'3'}>
+        <Heading as="h3" size="3">
+          Metrics
+        </Heading>
+        <Card>
+          <MetricBuilder
+            primaryMetric={data.primaryMetric}
+            secondaryMetrics={data.secondaryMetrics ?? []}
+            dispatch={dispatch}
+            metricFields={metricFields}
+          />
+        </Card>
 
-				<Heading as="h3" size="3">
-					Filters
-				</Heading>
-				<Card>
-					<FilterBuilder
-						availableFields={allTableFields}
-						initialFilters={data.filters ?? []}
-						onChange={(filters) => dispatch({ type: "set-filters", filters })}
-					/>
-				</Card>
+        <Heading as="h3" size="3">
+          Filters
+        </Heading>
+        <Card>
+          <FilterBuilder
+            availableFields={allTableFields}
+            initialFilters={data.filters ?? []}
+            onChange={(filters) => dispatch({ type: 'set-filters', filters })}
+          />
+        </Card>
 
-				{isClusterPreassigned ? (
-					<>
-						<Heading as="h3" size="3">
-							Cluster
-						</Heading>
-						<Card>
-							<ClusterBuilder
-								availableFields={availableClusterFields}
-								clusterField={data.clusterField}
-								icc={data.clusterIcc ?? ""}
-								cv={data.clusterCv ?? ""}
-								avgClusterSize={data.clusterAvgSize ?? ""}
-								onClusterFieldChange={(field) =>
-									dispatch({ type: "set-cluster-field", field })
-								}
-								onIccChange={(value) =>
-									dispatch({ type: "set-cluster-icc", value })
-								}
-								onCvChange={(value) =>
-									dispatch({ type: "set-cluster-cv", value })
-								}
-								onAvgClusterSizeChange={(value) =>
-									dispatch({ type: "set-cluster-avg-size", value })
-								}
-								onAutoFill={
-									data.primaryMetric ? handleAutoFillCluster : undefined
-								}
-								autoFillLoading={autoFillLoading}
-								autoFillError={autoFillError}
-							/>
-						</Card>
-					</>
-				) : (
-					<>
-						<Heading as="h3" size="3">
-							Strata
-						</Heading>
-						<Card>
-							<StrataBuilder
-								availableStrata={availableStrata}
-								selectedStrata={selectedStrata}
-								onStrataChange={(strata) =>
-									dispatch({ type: "set-strata", strata })
-								}
-							/>
-						</Card>
-					</>
-				)}
+        {isClusterPreassigned ? (
+          <>
+            <Heading as="h3" size="3">
+              Cluster
+            </Heading>
+            <Card>
+              <ClusterBuilder
+                availableFields={availableClusterFields}
+                clusterField={data.clusterField}
+                icc={data.clusterIcc ?? ''}
+                cv={data.clusterCv ?? ''}
+                avgClusterSize={data.clusterAvgSize ?? ''}
+                onClusterFieldChange={(field) => dispatch({ type: 'set-cluster-field', field })}
+                onIccChange={(value) => dispatch({ type: 'set-cluster-icc', value })}
+                onCvChange={(value) => dispatch({ type: 'set-cluster-cv', value })}
+                onAvgClusterSizeChange={(value) => dispatch({ type: 'set-cluster-avg-size', value })}
+                onAutoFill={data.primaryMetric ? handleAutoFillCluster : undefined}
+                autoFillLoading={autoFillLoading}
+                autoFillError={autoFillError}
+              />
+            </Card>
+          </>
+        ) : (
+          <>
+            <Heading as="h3" size="3">
+              Strata
+            </Heading>
+            <Card>
+              <StrataBuilder
+                availableStrata={availableStrata}
+                selectedStrata={selectedStrata}
+                onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
+              />
+            </Card>
+          </>
+        )}
 
-				{(data.experimentType === "freq_preassigned" ||
-					data.experimentType === "freq_cluster_preassigned") && (
-					<Flex direction="column" gap={"3"}>
-						<Heading as="h3" size="3">
-							Power Analysis
-						</Heading>
-						<PowerCheckSection data={data} dispatch={dispatch} />
-					</Flex>
-				)}
-			</Flex>
+        {(data.experimentType === 'freq_preassigned' || data.experimentType === 'freq_cluster_preassigned') && (
+          <Flex direction="column" gap={'3'}>
+            <Heading as="h3" size="3">
+              Power Analysis
+            </Heading>
+            <PowerCheckSection data={data} dispatch={dispatch} />
+          </Flex>
+        )}
+      </Flex>
 
-			{data.createExperimentError && (
-				<GenericErrorCallout
-					title={"Failed to create experiment"}
-					error={data.createExperimentError}
-				/>
-			)}
-			<NavigationButtons
-				onPrev={navigatePrev}
-				onNext={handleCreate}
-				nextDisabled={!nextEnabled}
-				nextLoading={triggerLoading}
-			/>
-		</>
-	);
+      {data.createExperimentError && (
+        <GenericErrorCallout title={'Failed to create experiment'} error={data.createExperimentError} />
+      )}
+      <NavigationButtons
+        onPrev={navigatePrev}
+        onNext={handleCreate}
+        nextDisabled={!nextEnabled}
+        nextLoading={triggerLoading}
+      />
+    </>
+  );
 };

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -1,50 +1,101 @@
-import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
-import { Card, Flex, Heading } from '@radix-ui/themes';
-import { MetricBuilder, MetricBuilderAction } from '@/components/features/experiments/metric-builder';
-import { FilterBuilder } from '@/components/features/experiments/querybuilder/filter-builder';
-import { StrataBuilder } from '@/components/features/experiments/strata-builder';
-import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
-import { CreateExperimentResponse, FieldMetadata, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
-import { PowerCheckSection } from './power-check-section';
-import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import {
-  convertToFrequentistDesignSpec,
-  removeFieldByName,
-} from '@/app/experiments/create/experiment-form/experiment-form-helpers';
-import { createExperimentBody } from '@/api/admin.zod';
-import { ErrorType } from '@/services/orval-fetch';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
+	useCreateExperiment,
+	useInspectTableInDatasource,
+	usePowerCheck,
+} from "@/api/admin";
+import { createExperimentBody } from "@/api/admin.zod";
+import {
+	CreateExperimentResponse,
+	FieldMetadata,
+	FilterInput,
+	PowerResponseOutput,
+} from "@/api/methods.schemas";
+import {
+	ExperimentFormData,
+	ExperimentScreenId,
+} from "@/app/experiments/create/experiment-form/experiment-form-def";
+import {
+	convertToFrequentistDesignSpec,
+	removeFieldByName,
+} from "@/app/experiments/create/experiment-form/experiment-form-helpers";
+import { ClusterBuilder } from "@/components/features/experiments/cluster-builder";
+import {
+	MetricBuilder,
+	MetricBuilderAction,
+} from "@/components/features/experiments/metric-builder";
+import { NavigationButtons } from "@/components/features/experiments/navigation-buttons";
+import { FilterBuilder } from "@/components/features/experiments/querybuilder/filter-builder";
+import { StrataBuilder } from "@/components/features/experiments/strata-builder";
+import { GenericErrorCallout } from "@/components/ui/generic-error";
+import { ErrorType } from "@/services/orval-fetch";
+import { ScreenProps } from "@/services/wizard/wizard-types";
+import { Card, Flex, Heading } from "@radix-ui/themes";
+import { useState } from "react";
+import { PowerCheckSection } from "./power-check-section";
 
 export type ExperimentFreqStackScreenMessage =
-  | MetricBuilderAction
-  | { type: 'set-filters'; filters: FilterInput[] }
-  | { type: 'set-strata'; strata: FieldMetadata[] }
-  | { type: 'set-confidence'; value: string }
-  | { type: 'set-power'; value: string }
-  | { type: 'set-power-check-response'; response: PowerResponseOutput; desiredN?: number }
-  | { type: 'set-create-response'; response: CreateExperimentResponse }
-  | { type: 'set-create-error'; response: ErrorType<unknown> }
-  | { type: 'set-chosen-n'; value: number | undefined };
+	| MetricBuilderAction
+	| { type: "set-filters"; filters: FilterInput[] }
+	| { type: "set-strata"; strata: FieldMetadata[] }
+	| { type: "set-randomization-type"; value: "strata" | "cluster" }
+	| { type: "set-cluster-field"; field?: FieldMetadata }
+	| { type: "set-cluster-icc"; value: string }
+	| { type: "set-cluster-cv"; value: string }
+	| { type: "set-cluster-avg-size"; value: string }
+	| { type: "set-confidence"; value: string }
+	| { type: "set-power"; value: string }
+	| {
+			type: "set-power-check-response";
+			response: PowerResponseOutput;
+			desiredN?: number;
+	  }
+	| { type: "set-create-response"; response: CreateExperimentResponse }
+	| { type: "set-create-error"; response: ErrorType<unknown> }
+	| { type: "set-chosen-n"; value: number | undefined };
+
+const isClusterFieldsComplete = (data: ExperimentFormData) => {
+	if (!data.clusterField) return false;
+	const icc = Number(data.clusterIcc);
+	const cv = Number(data.clusterCv);
+	const avg = Number(data.clusterAvgSize);
+	if (
+		data.clusterIcc === "" ||
+		data.clusterCv === "" ||
+		data.clusterAvgSize === ""
+	) {
+		return false;
+	}
+	if (Number.isNaN(icc) || icc < 0 || icc > 1) return false;
+	if (Number.isNaN(cv) || cv < 0) return false;
+	if (Number.isNaN(avg) || avg < 1) return false;
+	return true;
+};
 
 const isNextEnabled = (data: ExperimentFormData) => {
-  const isFreqPreassigned = data.experimentType === 'freq_preassigned';
+	const isFreqPreassigned =
+		data.experimentType === "freq_preassigned" ||
+		data.experimentType === "freq_cluster_preassigned";
+	const isCluster = data.experimentType === "freq_cluster_preassigned";
 
-  // Must have primary metric selected
-  if (!data.primaryMetric) return false;
-  // Must have valid confidence value (50-99)
-  if (isFreqPreassigned) {
-    const confidence = Number(data.confidence);
-    if (isNaN(confidence) || confidence < 50 || confidence > 99) return false;
-    // Must have valid power value (50-99) for pre-assigned frequentist experiment
-    const power = Number(data.power);
-    if (isNaN(power) || power < 50 || power > 99) return false;
-    // Must have run power check for pre-assigned frequentist experiment
-    if (!data.powerCheckResponse) return false;
-    // Must have selected a sample size for pre-assigned frequentist experiment
-    if (data.desiredN === undefined) return false;
-  }
-  return true;
+	// Must have primary metric selected
+	if (!data.primaryMetric) return false;
+	// Cluster experiment type requires a cluster field + valid ICC/CV/avg cluster size.
+	if (isCluster && !isClusterFieldsComplete(data)) {
+		return false;
+	}
+	// Must have valid confidence value (50-99)
+	if (isFreqPreassigned) {
+		const confidence = Number(data.confidence);
+		if (isNaN(confidence) || confidence < 50 || confidence > 99) return false;
+		// Must have valid power value (50-99) for pre-assigned frequentist experiment
+		const power = Number(data.power);
+		if (isNaN(power) || power < 50 || power > 99) return false;
+		// Must have run power check for pre-assigned frequentist experiment
+		if (!data.powerCheckResponse) return false;
+		// Must have selected a sample size for pre-assigned frequentist experiment
+		if (data.desiredN === undefined) return false;
+	}
+	return true;
 };
 
 /** ExperimentFreqStackScreen allows users to define the primary key, metrics, filters, strata, confidence, power,
@@ -54,116 +105,276 @@ const isNextEnabled = (data: ExperimentFormData) => {
  * so please look to that for behavioral and component re-use guidance.
  */
 export const ExperimentFreqStackScreen = ({
-  data,
-  dispatch,
-  navigatePrev,
-  navigateNext,
-}: ScreenProps<ExperimentFormData, ExperimentFreqStackScreenMessage, ExperimentScreenId>) => {
-  const { data: tableData } = useInspectTableInDatasource(data.datasourceId ?? '', data.tableName ?? '', {
-    refresh: false,
-  });
-  const { trigger: triggerCreate, isMutating: triggerLoading } = useCreateExperiment(
-    data.datasourceId!,
-    {
-      desired_n: data.desiredN,
-    },
-    {
-      swr: {
-        onSuccess: async (response) => {
-          dispatch({ type: 'set-create-response', response: response });
-          navigateNext();
-        },
-        onError: async (response) => {
-          dispatch({ type: 'set-create-error', response: response });
-        },
-      },
-    },
-  );
+	data,
+	dispatch,
+	navigatePrev,
+	navigateNext,
+}: ScreenProps<
+	ExperimentFormData,
+	ExperimentFreqStackScreenMessage,
+	ExperimentScreenId
+>) => {
+	const { data: tableData } = useInspectTableInDatasource(
+		data.datasourceId ?? "",
+		data.tableName ?? "",
+		{
+			refresh: false,
+		},
+	);
+	const { trigger: triggerCreate, isMutating: triggerLoading } =
+		useCreateExperiment(
+			data.datasourceId!,
+			{
+				desired_n: data.desiredN,
+			},
+			{
+				swr: {
+					onSuccess: async (response) => {
+						dispatch({ type: "set-create-response", response: response });
+						navigateNext();
+					},
+					onError: async (response) => {
+						dispatch({ type: "set-create-error", response: response });
+					},
+				},
+			},
+		);
 
-  const allTableFields = tableData?.fields ?? [];
+	// Auto-fill of cluster stats (issue #217). We call power_check with the
+	// current design spec but with cluster ICC/CV/avg unset; the BE auto-
+	// calculates them from the datasource (PR #163) and we copy the response
+	// back into the form so the user sees the values and can override them.
+	const { trigger: triggerPowerCheckForAutoFill } = usePowerCheck(
+		data.datasourceId ?? "",
+	);
+	const [autoFillLoading, setAutoFillLoading] = useState(false);
+	const [autoFillError, setAutoFillError] = useState<string | null>(null);
+	const handleAutoFillCluster = async () => {
+		if (!data.clusterField || !data.primaryMetric) return;
+		setAutoFillLoading(true);
+		setAutoFillError(null);
+		try {
+			const design_spec = convertToFrequentistDesignSpec({
+				...data,
+				// Run the BE auto-calculation by leaving ICC/CV/avg unset.
+				clusterIcc: "",
+				clusterCv: "",
+				clusterAvgSize: "",
+			});
+			const response = await triggerPowerCheckForAutoFill({ design_spec });
+			const primary = response.analyses.find(
+				(a) =>
+					a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+			);
+			// Cluster fields live on metric_spec (DesignSpecMetric). They're
+			// typed loosely here because methods.schemas.ts hasn't been
+			// regenerated to surface them on the output type — see comment in
+			// experiment-form-helpers.tsx.
+			const ms = primary?.metric_spec as
+				| {
+						icc?: number | null;
+						cv?: number | null;
+						avg_cluster_size?: number | null;
+				  }
+				| undefined;
+			if (ms?.icc != null)
+				dispatch({ type: "set-cluster-icc", value: String(ms.icc) });
+			if (ms?.cv != null)
+				dispatch({ type: "set-cluster-cv", value: String(ms.cv) });
+			if (ms?.avg_cluster_size != null)
+				dispatch({
+					type: "set-cluster-avg-size",
+					value: String(ms.avg_cluster_size),
+				});
+		} catch (err) {
+			setAutoFillError(
+				err instanceof Error
+					? err.message
+					: "Failed to calculate cluster stats from datasource.",
+			);
+		} finally {
+			setAutoFillLoading(false);
+		}
+	};
 
-  // Filter numeric and boolean fields for metrics
-  const metricFields = allTableFields.filter((f) =>
-    ['integer', 'bigint', 'double precision', 'numeric', 'boolean'].includes(f.data_type),
-  );
-  // Exclude primary key from stratum options.
-  const availableStrata = removeFieldByName(allTableFields, data.primaryKey).toSorted((a, b) =>
-    a.field_name.localeCompare(b.field_name),
-  );
-  // Reconfirm that the selected strata are still valid options and filter out any undefined if not.
-  const selectedStrata = (data.strata ?? [])
-    .map((s) => availableStrata.find((f) => f.field_name === s.field_name))
-    .filter((f): f is FieldMetadata => Boolean(f));
+	const allTableFields = tableData?.fields ?? [];
 
-  const nextEnabled = isNextEnabled(data);
+	// Filter numeric and boolean fields for metrics
+	const metricFields = allTableFields.filter((f) =>
+		["integer", "bigint", "double precision", "numeric", "boolean"].includes(
+			f.data_type,
+		),
+	);
+	// Exclude primary key from stratum options.
+	const availableStrata = removeFieldByName(
+		allTableFields,
+		data.primaryKey,
+	).toSorted((a, b) => a.field_name.localeCompare(b.field_name));
+	// Reconfirm that the selected strata are still valid options and filter out any undefined if not.
+	const selectedStrata = (data.strata ?? [])
+		.map((s) => availableStrata.find((f) => f.field_name === s.field_name))
+		.filter((f): f is FieldMetadata => Boolean(f));
 
-  const handleCreate = async () => {
-    const designSpec = convertToFrequentistDesignSpec(data);
-    const createExperimentRequest = createExperimentBody.strict().parse({
-      design_spec: designSpec,
-      power_analyses: data.powerCheckResponse,
-      webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
-    });
-    console.log('converted', createExperimentRequest);
-    await triggerCreate(createExperimentRequest, { throwOnError: false });
-  };
+	// Cluster ID candidates: the same pool as strata (exclude primary key).
+	const availableClusterFields = availableStrata;
+	const isClusterPreassigned =
+		data.experimentType === "freq_cluster_preassigned";
 
-  return (
-    <>
-      <Flex direction="column" gap={'3'}>
-        <Heading as="h3" size="3">
-          Metrics
-        </Heading>
-        <Card>
-          <MetricBuilder
-            primaryMetric={data.primaryMetric}
-            secondaryMetrics={data.secondaryMetrics ?? []}
-            dispatch={dispatch}
-            metricFields={metricFields}
-          />
-        </Card>
+	const nextEnabled = isNextEnabled(data);
 
-        <Heading as="h3" size="3">
-          Filters
-        </Heading>
-        <Card>
-          <FilterBuilder
-            availableFields={allTableFields}
-            initialFilters={data.filters ?? []}
-            onChange={(filters) => dispatch({ type: 'set-filters', filters })}
-          />
-        </Card>
+	const handleCreate = async () => {
+		const designSpec = convertToFrequentistDesignSpec(data);
+		const createExperimentRequest = createExperimentBody.strict().parse({
+			design_spec: designSpec,
+			power_analyses: data.powerCheckResponse,
+			webhooks:
+				data.selectedWebhookIds && data.selectedWebhookIds.length > 0
+					? data.selectedWebhookIds
+					: [],
+		});
+		// Issue #217: the strict parse above strips cluster fields because
+		// admin.zod.ts hasn't been regenerated to recognize them (orval
+		// regeneration is currently broken locally). Re-attach the cluster
+		// fields onto the parsed request so they reach the BE. Without this
+		// the BE never persists cluster_column / icc / cv / avg_cluster_size
+		// for the new "Cluster Preassigned A/B Testing" type.
+		if (data.experimentType === "freq_cluster_preassigned" && data.clusterField) {
+			// biome-ignore lint/suspicious/noExplicitAny: orval-stripped fields, see comment above.
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const reqAny = createExperimentRequest as any;
+			reqAny.design_spec.cluster_column = data.clusterField.field_name;
+			const icc =
+				data.clusterIcc !== undefined && data.clusterIcc !== ""
+					? Number(data.clusterIcc)
+					: undefined;
+			const cv =
+				data.clusterCv !== undefined && data.clusterCv !== ""
+					? Number(data.clusterCv)
+					: undefined;
+			const avg =
+				data.clusterAvgSize !== undefined && data.clusterAvgSize !== ""
+					? Number(data.clusterAvgSize)
+					: undefined;
+			if (
+				icc !== undefined &&
+				cv !== undefined &&
+				avg !== undefined &&
+				Number.isFinite(icc) &&
+				Number.isFinite(cv) &&
+				Number.isFinite(avg)
+			) {
+				reqAny.design_spec.metrics = reqAny.design_spec.metrics.map(
+					(m: Record<string, unknown>) => ({
+						...m,
+						icc,
+						cv,
+						avg_cluster_size: avg,
+					}),
+				);
+			}
+		}
+		console.log("converted", createExperimentRequest);
+		await triggerCreate(createExperimentRequest, { throwOnError: false });
+	};
 
-        <Heading as="h3" size="3">
-          Strata
-        </Heading>
-        <Card>
-          <StrataBuilder
-            availableStrata={availableStrata}
-            selectedStrata={selectedStrata}
-            onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
-          />
-        </Card>
+	return (
+		<>
+			<Flex direction="column" gap={"3"}>
+				<Heading as="h3" size="3">
+					Metrics
+				</Heading>
+				<Card>
+					<MetricBuilder
+						primaryMetric={data.primaryMetric}
+						secondaryMetrics={data.secondaryMetrics ?? []}
+						dispatch={dispatch}
+						metricFields={metricFields}
+					/>
+				</Card>
 
-        {data.experimentType == 'freq_preassigned' && (
-          <Flex direction="column" gap={'3'}>
-            <Heading as="h3" size="3">
-              Power Analysis
-            </Heading>
-            <PowerCheckSection data={data} dispatch={dispatch} />
-          </Flex>
-        )}
-      </Flex>
+				<Heading as="h3" size="3">
+					Filters
+				</Heading>
+				<Card>
+					<FilterBuilder
+						availableFields={allTableFields}
+						initialFilters={data.filters ?? []}
+						onChange={(filters) => dispatch({ type: "set-filters", filters })}
+					/>
+				</Card>
 
-      {data.createExperimentError && (
-        <GenericErrorCallout title={'Failed to create experiment'} error={data.createExperimentError} />
-      )}
-      <NavigationButtons
-        onPrev={navigatePrev}
-        onNext={handleCreate}
-        nextDisabled={!nextEnabled}
-        nextLoading={triggerLoading}
-      />
-    </>
-  );
+				{isClusterPreassigned ? (
+					<>
+						<Heading as="h3" size="3">
+							Cluster
+						</Heading>
+						<Card>
+							<ClusterBuilder
+								availableFields={availableClusterFields}
+								clusterField={data.clusterField}
+								icc={data.clusterIcc ?? ""}
+								cv={data.clusterCv ?? ""}
+								avgClusterSize={data.clusterAvgSize ?? ""}
+								onClusterFieldChange={(field) =>
+									dispatch({ type: "set-cluster-field", field })
+								}
+								onIccChange={(value) =>
+									dispatch({ type: "set-cluster-icc", value })
+								}
+								onCvChange={(value) =>
+									dispatch({ type: "set-cluster-cv", value })
+								}
+								onAvgClusterSizeChange={(value) =>
+									dispatch({ type: "set-cluster-avg-size", value })
+								}
+								onAutoFill={
+									data.primaryMetric ? handleAutoFillCluster : undefined
+								}
+								autoFillLoading={autoFillLoading}
+								autoFillError={autoFillError}
+							/>
+						</Card>
+					</>
+				) : (
+					<>
+						<Heading as="h3" size="3">
+							Strata
+						</Heading>
+						<Card>
+							<StrataBuilder
+								availableStrata={availableStrata}
+								selectedStrata={selectedStrata}
+								onStrataChange={(strata) =>
+									dispatch({ type: "set-strata", strata })
+								}
+							/>
+						</Card>
+					</>
+				)}
+
+				{(data.experimentType === "freq_preassigned" ||
+					data.experimentType === "freq_cluster_preassigned") && (
+					<Flex direction="column" gap={"3"}>
+						<Heading as="h3" size="3">
+							Power Analysis
+						</Heading>
+						<PowerCheckSection data={data} dispatch={dispatch} />
+					</Flex>
+				)}
+			</Flex>
+
+			{data.createExperimentError && (
+				<GenericErrorCallout
+					title={"Failed to create experiment"}
+					error={data.createExperimentError}
+				/>
+			)}
+			<NavigationButtons
+				onPrev={navigatePrev}
+				onNext={handleCreate}
+				nextDisabled={!nextEnabled}
+				nextLoading={triggerLoading}
+			/>
+		</>
+	);
 };

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -29,18 +29,34 @@ export const ExperimentsSummarizeFreqScreen = ({
 		data.experimentType === "freq_cluster_preassigned";
 	const isClusterExperiment =
 		data.experimentType === "freq_cluster_preassigned";
+	// Look up the achievable MDE for a metric from the MDE-mode power-check
+	// response. Returns null when the user picked the recommended sample size
+	// (no achievable response was computed) or when the BE didn't return a
+	// pct_change_possible — in which case the target MDE is the right thing
+	// to show alone.
+	const achievableFor = (fieldName: string): number | null => {
+		const analyses = data.achievablePowerCheckResponse?.analyses ?? [];
+		const match = analyses.find(
+			(a) => a.metric_spec.field_name === fieldName,
+		);
+		const pct = match?.pct_change_possible;
+		if (pct == null || !Number.isFinite(pct)) return null;
+		return pct * 100;
+	};
 	const metrics: ExperimentConfirmationDisplayProps["metrics"] = {
 		primary: data.primaryMetric
 			? {
 					field_name: data.primaryMetric.metric.field_name,
 					data_type: data.primaryMetric.metric.data_type,
 					mde: data.primaryMetric.mde,
+					achievable: achievableFor(data.primaryMetric.metric.field_name),
 				}
 			: undefined,
 		secondary: (data.secondaryMetrics ?? []).map((m) => ({
 			field_name: m.metric.field_name,
 			data_type: m.metric.data_type,
 			mde: m.mde,
+			achievable: achievableFor(m.metric.field_name),
 		})),
 	};
 	const cluster = isClusterExperiment && data.clusterField

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -1,95 +1,83 @@
-"use client";
+'use client';
 
-import {
-	ExperimentFormData,
-	ExperimentScreenId,
-} from "@/app/experiments/create/experiment-form/experiment-form-def";
-import { ExperimentsSummarizeScreenBase } from "@/app/experiments/create/experiment-form/experiment-summarize-screen-base";
-import { ExperimentConfirmationDisplayProps } from "@/components/features/experiments/experiment-confirmation-display";
-import { ErrorType } from "@/services/orval-fetch";
-import { ScreenProps } from "@/services/wizard/wizard-types";
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';
+import { ExperimentConfirmationDisplayProps } from '@/components/features/experiments/experiment-confirmation-display';
+import { ErrorType } from '@/services/orval-fetch';
+import { ScreenProps } from '@/services/wizard/wizard-types';
 
 type ExperimentsSummarizeFreqScreenMessage = {
-	type: "set-commit-error";
-	response: ErrorType<unknown>;
+  type: 'set-commit-error';
+  response: ErrorType<unknown>;
 };
 
 export const ExperimentsSummarizeFreqScreen = ({
-	data,
-	navigatePrev,
-	navigateTo,
-	dispatch,
-}: ScreenProps<
-	ExperimentFormData,
-	ExperimentsSummarizeFreqScreenMessage,
-	ExperimentScreenId
->) => {
-	const isFreqPreassigned =
-		data.experimentType === "freq_preassigned" ||
-		data.experimentType === "freq_cluster_preassigned";
-	const isClusterExperiment =
-		data.experimentType === "freq_cluster_preassigned";
-	// Look up the achievable MDE for a metric from the MDE-mode power-check
-	// response. Returns null when the user picked the recommended sample size
-	// (no achievable response was computed) or when the BE didn't return a
-	// pct_change_possible — in which case the target MDE is the right thing
-	// to show alone.
-	const achievableFor = (fieldName: string): number | null => {
-		const analyses = data.achievablePowerCheckResponse?.analyses ?? [];
-		const match = analyses.find(
-			(a) => a.metric_spec.field_name === fieldName,
-		);
-		const pct = match?.pct_change_possible;
-		if (pct == null || !Number.isFinite(pct)) return null;
-		return pct * 100;
-	};
-	const metrics: ExperimentConfirmationDisplayProps["metrics"] = {
-		primary: data.primaryMetric
-			? {
-					field_name: data.primaryMetric.metric.field_name,
-					data_type: data.primaryMetric.metric.data_type,
-					mde: data.primaryMetric.mde,
-					achievable: achievableFor(data.primaryMetric.metric.field_name),
-				}
-			: undefined,
-		secondary: (data.secondaryMetrics ?? []).map((m) => ({
-			field_name: m.metric.field_name,
-			data_type: m.metric.data_type,
-			mde: m.mde,
-			achievable: achievableFor(m.metric.field_name),
-		})),
-	};
-	const cluster = isClusterExperiment && data.clusterField
-		? {
-				field_name: data.clusterField.field_name,
-				icc: data.clusterIcc ?? "",
-				cv: data.clusterCv ?? "",
-				avg_cluster_size: data.clusterAvgSize ?? "",
-			}
-		: undefined;
+  data,
+  navigatePrev,
+  navigateTo,
+  dispatch,
+}: ScreenProps<ExperimentFormData, ExperimentsSummarizeFreqScreenMessage, ExperimentScreenId>) => {
+  const isFreqPreassigned =
+    data.experimentType === 'freq_preassigned' || data.experimentType === 'freq_cluster_preassigned';
+  const isClusterExperiment = data.experimentType === 'freq_cluster_preassigned';
+  // Look up the achievable MDE for a metric from the MDE-mode power-check
+  // response. Returns null when the user picked the recommended sample size
+  // (no achievable response was computed) or when the BE didn't return a
+  // pct_change_possible — in which case the target MDE is the right thing
+  // to show alone.
+  const achievableFor = (fieldName: string): number | null => {
+    const analyses = data.achievablePowerCheckResponse?.analyses ?? [];
+    const match = analyses.find((a) => a.metric_spec.field_name === fieldName);
+    const pct = match?.pct_change_possible;
+    if (pct == null || !Number.isFinite(pct)) return null;
+    return pct * 100;
+  };
+  const metrics: ExperimentConfirmationDisplayProps['metrics'] = {
+    primary: data.primaryMetric
+      ? {
+          field_name: data.primaryMetric.metric.field_name,
+          data_type: data.primaryMetric.metric.data_type,
+          mde: data.primaryMetric.mde,
+          achievable: achievableFor(data.primaryMetric.metric.field_name),
+        }
+      : undefined,
+    secondary: (data.secondaryMetrics ?? []).map((m) => ({
+      field_name: m.metric.field_name,
+      data_type: m.metric.data_type,
+      mde: m.mde,
+      achievable: achievableFor(m.metric.field_name),
+    })),
+  };
+  const cluster =
+    isClusterExperiment && data.clusterField
+      ? {
+          field_name: data.clusterField.field_name,
+          icc: data.clusterIcc ?? '',
+          cv: data.clusterCv ?? '',
+          avg_cluster_size: data.clusterAvgSize ?? '',
+        }
+      : undefined;
 
-	return (
-		<ExperimentsSummarizeScreenBase
-			data={data}
-			navigatePrev={navigatePrev}
-			navigateTo={navigateTo}
-			onCommitError={(response) =>
-				dispatch({ type: "set-commit-error", response })
-			}
-			infoCalloutText={
-				isFreqPreassigned
-					? "Assignments will be downloadable after the experiment is saved."
-					: "For online A/B testing, assignments are generated on the fly as users enter the experiment. No power analysis or sample size planning is required."
-			}
-			editTargets={{
-				metadata: "metadata",
-				treatmentArms: "describe-arms",
-				datasource: "freq-select-datasource",
-				filters: "freq-stack",
-				metrics: "freq-stack",
-				powerBalance: "freq-stack",
-			}}
-			frequentistInfo={{ metrics, desiredN: data.desiredN, cluster }}
-		/>
-	);
+  return (
+    <ExperimentsSummarizeScreenBase
+      data={data}
+      navigatePrev={navigatePrev}
+      navigateTo={navigateTo}
+      onCommitError={(response) => dispatch({ type: 'set-commit-error', response })}
+      infoCalloutText={
+        isFreqPreassigned
+          ? 'Assignments will be downloadable after the experiment is saved.'
+          : 'For online A/B testing, assignments are generated on the fly as users enter the experiment. No power analysis or sample size planning is required.'
+      }
+      editTargets={{
+        metadata: 'metadata',
+        treatmentArms: 'describe-arms',
+        datasource: 'freq-select-datasource',
+        filters: 'freq-stack',
+        metrics: 'freq-stack',
+        powerBalance: 'freq-stack',
+      }}
+      frequentistInfo={{ metrics, desiredN: data.desiredN, cluster }}
+    />
+  );
 };

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -26,9 +26,20 @@ export const ExperimentsSummarizeFreqScreen = ({
   // pct_change_possible — in which case the target MDE is the right thing
   // to show alone.
   const achievableFor = (fieldName: string): number | null => {
-    const analyses = data.achievablePowerCheckResponse?.analyses ?? [];
-    const match = analyses.find((a) => a.metric_spec.field_name === fieldName);
-    const pct = match?.pct_change_possible;
+    // Pick the cached response matching the user's chosen N (Custom takes
+    // priority when its desired_n still matches, otherwise Max).
+    const chosen =
+      data.desiredN !== undefined && data.desiredN === data.achievableCustomDesiredN
+        ? data.achievableCustomPowerCheckResponse
+        : data.achievableMaxPowerCheckResponse;
+    const match = chosen?.analyses.find((a) => a.metric_spec.field_name === fieldName);
+    if (!match) return null;
+    // BE puts achievable MDE in pct_change_with_desired_n when desired_n was
+    // sufficient; falls back to pct_change_possible otherwise.
+    const pct =
+      (match as { pct_change_with_desired_n?: number | null }).pct_change_with_desired_n ??
+      match.pct_change_possible ??
+      null;
     if (pct == null || !Number.isFinite(pct)) return null;
     return pct * 100;
   };

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -1,55 +1,79 @@
-'use client';
+"use client";
 
-import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
-import { ErrorType } from '@/services/orval-fetch';
-import { ExperimentConfirmationDisplayProps } from '@/components/features/experiments/experiment-confirmation-display';
-import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';
+import {
+	ExperimentFormData,
+	ExperimentScreenId,
+} from "@/app/experiments/create/experiment-form/experiment-form-def";
+import { ExperimentsSummarizeScreenBase } from "@/app/experiments/create/experiment-form/experiment-summarize-screen-base";
+import { ExperimentConfirmationDisplayProps } from "@/components/features/experiments/experiment-confirmation-display";
+import { ErrorType } from "@/services/orval-fetch";
+import { ScreenProps } from "@/services/wizard/wizard-types";
 
-type ExperimentsSummarizeFreqScreenMessage = { type: 'set-commit-error'; response: ErrorType<unknown> };
+type ExperimentsSummarizeFreqScreenMessage = {
+	type: "set-commit-error";
+	response: ErrorType<unknown>;
+};
 
 export const ExperimentsSummarizeFreqScreen = ({
-  data,
-  navigatePrev,
-  navigateTo,
-  dispatch,
-}: ScreenProps<ExperimentFormData, ExperimentsSummarizeFreqScreenMessage, ExperimentScreenId>) => {
-  const isFreqPreassigned = data.experimentType === 'freq_preassigned';
-  const metrics: ExperimentConfirmationDisplayProps['metrics'] = {
-    primary: data.primaryMetric
-      ? {
-          field_name: data.primaryMetric.metric.field_name,
-          data_type: data.primaryMetric.metric.data_type,
-          mde: data.primaryMetric.mde,
-        }
-      : undefined,
-    secondary: (data.secondaryMetrics ?? []).map((m) => ({
-      field_name: m.metric.field_name,
-      data_type: m.metric.data_type,
-      mde: m.mde,
-    })),
-  };
+	data,
+	navigatePrev,
+	navigateTo,
+	dispatch,
+}: ScreenProps<
+	ExperimentFormData,
+	ExperimentsSummarizeFreqScreenMessage,
+	ExperimentScreenId
+>) => {
+	const isFreqPreassigned =
+		data.experimentType === "freq_preassigned" ||
+		data.experimentType === "freq_cluster_preassigned";
+	const isClusterExperiment =
+		data.experimentType === "freq_cluster_preassigned";
+	const metrics: ExperimentConfirmationDisplayProps["metrics"] = {
+		primary: data.primaryMetric
+			? {
+					field_name: data.primaryMetric.metric.field_name,
+					data_type: data.primaryMetric.metric.data_type,
+					mde: data.primaryMetric.mde,
+				}
+			: undefined,
+		secondary: (data.secondaryMetrics ?? []).map((m) => ({
+			field_name: m.metric.field_name,
+			data_type: m.metric.data_type,
+			mde: m.mde,
+		})),
+	};
+	const cluster = isClusterExperiment && data.clusterField
+		? {
+				field_name: data.clusterField.field_name,
+				icc: data.clusterIcc ?? "",
+				cv: data.clusterCv ?? "",
+				avg_cluster_size: data.clusterAvgSize ?? "",
+			}
+		: undefined;
 
-  return (
-    <ExperimentsSummarizeScreenBase
-      data={data}
-      navigatePrev={navigatePrev}
-      navigateTo={navigateTo}
-      onCommitError={(response) => dispatch({ type: 'set-commit-error', response })}
-      infoCalloutText={
-        isFreqPreassigned
-          ? 'Assignments will be downloadable after the experiment is saved.'
-          : 'For online A/B testing, assignments are generated on the fly as users enter the experiment. No power analysis or sample size planning is required.'
-      }
-      editTargets={{
-        metadata: 'metadata',
-        treatmentArms: 'describe-arms',
-        datasource: 'freq-select-datasource',
-        filters: 'freq-stack',
-        metrics: 'freq-stack',
-        powerBalance: 'freq-stack',
-      }}
-      frequentistInfo={{ metrics, desiredN: data.desiredN }}
-    />
-  );
+	return (
+		<ExperimentsSummarizeScreenBase
+			data={data}
+			navigatePrev={navigatePrev}
+			navigateTo={navigateTo}
+			onCommitError={(response) =>
+				dispatch({ type: "set-commit-error", response })
+			}
+			infoCalloutText={
+				isFreqPreassigned
+					? "Assignments will be downloadable after the experiment is saved."
+					: "For online A/B testing, assignments are generated on the fly as users enter the experiment. No power analysis or sample size planning is required."
+			}
+			editTargets={{
+				metadata: "metadata",
+				treatmentArms: "describe-arms",
+				datasource: "freq-select-datasource",
+				filters: "freq-stack",
+				metrics: "freq-stack",
+				powerBalance: "freq-stack",
+			}}
+			frequentistInfo={{ metrics, desiredN: data.desiredN, cluster }}
+		/>
+	);
 };

--- a/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
@@ -1,143 +1,128 @@
-"use client";
+'use client';
 
-import { useCommitExperiment } from "@/api/admin";
+import { useCommitExperiment } from '@/api/admin';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
 import {
-	ExperimentFormData,
-	ExperimentScreenId,
-} from "@/app/experiments/create/experiment-form/experiment-form-def";
-import {
-	ExperimentConfirmationDisplay,
-	ExperimentConfirmationDisplayProps,
-} from "@/components/features/experiments/experiment-confirmation-display";
-import { NavigationButtons } from "@/components/features/experiments/navigation-buttons";
-import { GenericErrorCallout } from "@/components/ui/generic-error";
-import { ErrorType } from "@/services/orval-fetch";
-import { InfoCircledIcon } from "@radix-ui/react-icons";
-import { Callout, Flex } from "@radix-ui/themes";
-import { useRouter } from "next/navigation";
+  ExperimentConfirmationDisplay,
+  ExperimentConfirmationDisplayProps,
+} from '@/components/features/experiments/experiment-confirmation-display';
+import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { ErrorType } from '@/services/orval-fetch';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Callout, Flex } from '@radix-ui/themes';
+import { useRouter } from 'next/navigation';
 
 // The "Edit" buttons on the confirmation screen are temporarily disabled pending further UX effort.
 const FEATURE_EDIT_BUTTONS_ENABLED = false;
 
 type EditTargets = {
-	metadata?: ExperimentScreenId;
-	treatmentArms?: ExperimentScreenId;
-	datasource?: ExperimentScreenId;
-	filters?: ExperimentScreenId;
-	outcomesPrior?: ExperimentScreenId;
-	contexts?: ExperimentScreenId;
-	metrics?: ExperimentScreenId;
-	powerBalance?: ExperimentScreenId;
+  metadata?: ExperimentScreenId;
+  treatmentArms?: ExperimentScreenId;
+  datasource?: ExperimentScreenId;
+  filters?: ExperimentScreenId;
+  outcomesPrior?: ExperimentScreenId;
+  contexts?: ExperimentScreenId;
+  metrics?: ExperimentScreenId;
+  powerBalance?: ExperimentScreenId;
 };
 
 interface ExperimentsSummarizeScreenBaseProps {
-	data: ExperimentFormData;
-	navigatePrev: () => void;
-	navigateTo: (screenId: ExperimentScreenId) => void;
-	onCommitError: (response: ErrorType<unknown>) => void;
-	infoCalloutText: React.ReactNode;
-	editTargets: EditTargets;
-	frequentistInfo?: Pick<
-		ExperimentConfirmationDisplayProps,
-		"metrics" | "desiredN" | "cluster"
-	>;
+  data: ExperimentFormData;
+  navigatePrev: () => void;
+  navigateTo: (screenId: ExperimentScreenId) => void;
+  onCommitError: (response: ErrorType<unknown>) => void;
+  infoCalloutText: React.ReactNode;
+  editTargets: EditTargets;
+  frequentistInfo?: Pick<ExperimentConfirmationDisplayProps, 'metrics' | 'desiredN' | 'cluster'>;
 }
 
 export function ExperimentsSummarizeScreenBase({
-	data,
-	navigatePrev,
-	navigateTo,
-	onCommitError,
-	infoCalloutText,
-	editTargets,
-	frequentistInfo,
+  data,
+  navigatePrev,
+  navigateTo,
+  onCommitError,
+  infoCalloutText,
+  editTargets,
+  frequentistInfo,
 }: ExperimentsSummarizeScreenBaseProps) {
-	const router = useRouter();
+  const router = useRouter();
 
-	const experimentId = data.createExperimentResponse?.experiment_id ?? "";
-	const datasourceId = data.datasourceId ?? "";
+  const experimentId = data.createExperimentResponse?.experiment_id ?? '';
+  const datasourceId = data.datasourceId ?? '';
 
-	const { trigger: triggerCommit, isMutating: commitLoading } =
-		useCommitExperiment(datasourceId, experimentId, {
-			swr: {
-				onSuccess: () => {
-					router.push("/experiments");
-				},
-				onError: async (response: ErrorType<unknown>) => {
-					onCommitError(response);
-				},
-			},
-		});
+  const { trigger: triggerCommit, isMutating: commitLoading } = useCommitExperiment(datasourceId, experimentId, {
+    swr: {
+      onSuccess: () => {
+        router.push('/experiments');
+      },
+      onError: async (response: ErrorType<unknown>) => {
+        onCommitError(response);
+      },
+    },
+  });
 
-	const handleCommit = async () => {
-		if (!datasourceId || !experimentId) return;
-		try {
-			await triggerCommit();
-		} catch {
-			// Error handled by onError callback
-		}
-	};
+  const handleCommit = async () => {
+    if (!datasourceId || !experimentId) return;
+    try {
+      await triggerCommit();
+    } catch {
+      // Error handled by onError callback
+    }
+  };
 
-	const toEditHandler = FEATURE_EDIT_BUTTONS_ENABLED
-		? (target?: ExperimentScreenId) =>
-				target ? () => navigateTo(target) : undefined
-		: () => undefined;
+  const toEditHandler = FEATURE_EDIT_BUTTONS_ENABLED
+    ? (target?: ExperimentScreenId) => (target ? () => navigateTo(target) : undefined)
+    : () => undefined;
 
-	if (data.commitError) {
-		return (
-			<>
-				<Flex direction="column" gap="3">
-					<GenericErrorCallout
-						title="Failed to create experiment"
-						error={data.commitError}
-					/>
-				</Flex>
-				<NavigationButtons
-					onPrev={navigatePrev}
-					onNext={() => {}}
-					nextDisabled
-				/>
-			</>
-		);
-	}
+  if (data.commitError) {
+    return (
+      <>
+        <Flex direction="column" gap="3">
+          <GenericErrorCallout title="Failed to create experiment" error={data.commitError} />
+        </Flex>
+        <NavigationButtons onPrev={navigatePrev} onNext={() => {}} nextDisabled />
+      </>
+    );
+  }
 
-	return (
-		<>
-			<Flex direction="column" gap="4">
-				{data.createExperimentResponse !== undefined && (
-					<>
-						<ExperimentConfirmationDisplay
-							response={data.createExperimentResponse}
-							tableName={data.tableName}
-							primaryKey={data.primaryKey}
-							metrics={frequentistInfo?.metrics}
-							desiredN={frequentistInfo?.desiredN}
-							cluster={frequentistInfo?.cluster}
-							onEditMetadata={toEditHandler(editTargets.metadata)}
-							onEditTreatmentArms={toEditHandler(editTargets.treatmentArms)}
-							onEditDatasource={toEditHandler(editTargets.datasource)}
-							onEditFilters={toEditHandler(editTargets.filters)}
-							onEditOutcomesPrior={toEditHandler(editTargets.outcomesPrior)}
-							onEditContexts={toEditHandler(editTargets.contexts)}
-							onEditMetrics={toEditHandler(editTargets.metrics)}
-							onEditPowerBalance={toEditHandler(editTargets.powerBalance)}
-						/>
-						<Callout.Root>
-							<Callout.Icon>
-								<InfoCircledIcon />
-							</Callout.Icon>
-							<Callout.Text>{infoCalloutText}</Callout.Text>
-						</Callout.Root>
-					</>
-				)}
-			</Flex>
-			<NavigationButtons
-				onPrev={navigatePrev} // navigatePrev will handle abandonment
-				onNext={handleCommit}
-				nextDisabled={!data.createExperimentResponse}
-				nextLoading={commitLoading}
-				nextLabel="Save Experiment"
-			/>
-		</>
-	);
+  return (
+    <>
+      <Flex direction="column" gap="4">
+        {data.createExperimentResponse !== undefined && (
+          <>
+            <ExperimentConfirmationDisplay
+              response={data.createExperimentResponse}
+              tableName={data.tableName}
+              primaryKey={data.primaryKey}
+              metrics={frequentistInfo?.metrics}
+              desiredN={frequentistInfo?.desiredN}
+              cluster={frequentistInfo?.cluster}
+              onEditMetadata={toEditHandler(editTargets.metadata)}
+              onEditTreatmentArms={toEditHandler(editTargets.treatmentArms)}
+              onEditDatasource={toEditHandler(editTargets.datasource)}
+              onEditFilters={toEditHandler(editTargets.filters)}
+              onEditOutcomesPrior={toEditHandler(editTargets.outcomesPrior)}
+              onEditContexts={toEditHandler(editTargets.contexts)}
+              onEditMetrics={toEditHandler(editTargets.metrics)}
+              onEditPowerBalance={toEditHandler(editTargets.powerBalance)}
+            />
+            <Callout.Root>
+              <Callout.Icon>
+                <InfoCircledIcon />
+              </Callout.Icon>
+              <Callout.Text>{infoCalloutText}</Callout.Text>
+            </Callout.Root>
+          </>
+        )}
+      </Flex>
+      <NavigationButtons
+        onPrev={navigatePrev} // navigatePrev will handle abandonment
+        onNext={handleCommit}
+        nextDisabled={!data.createExperimentResponse}
+        nextLoading={commitLoading}
+        nextLabel="Save Experiment"
+      />
+    </>
+  );
 }

--- a/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
@@ -1,127 +1,143 @@
-'use client';
+"use client";
 
-import { useRouter } from 'next/navigation';
-import { Callout, Flex } from '@radix-ui/themes';
-import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { useCommitExperiment } from '@/api/admin';
-import { ErrorType } from '@/services/orval-fetch';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
-import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
+import { useCommitExperiment } from "@/api/admin";
 import {
-  ExperimentConfirmationDisplay,
-  ExperimentConfirmationDisplayProps,
-} from '@/components/features/experiments/experiment-confirmation-display';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+	ExperimentFormData,
+	ExperimentScreenId,
+} from "@/app/experiments/create/experiment-form/experiment-form-def";
+import {
+	ExperimentConfirmationDisplay,
+	ExperimentConfirmationDisplayProps,
+} from "@/components/features/experiments/experiment-confirmation-display";
+import { NavigationButtons } from "@/components/features/experiments/navigation-buttons";
+import { GenericErrorCallout } from "@/components/ui/generic-error";
+import { ErrorType } from "@/services/orval-fetch";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { Callout, Flex } from "@radix-ui/themes";
+import { useRouter } from "next/navigation";
 
 // The "Edit" buttons on the confirmation screen are temporarily disabled pending further UX effort.
 const FEATURE_EDIT_BUTTONS_ENABLED = false;
 
 type EditTargets = {
-  metadata?: ExperimentScreenId;
-  treatmentArms?: ExperimentScreenId;
-  datasource?: ExperimentScreenId;
-  filters?: ExperimentScreenId;
-  outcomesPrior?: ExperimentScreenId;
-  contexts?: ExperimentScreenId;
-  metrics?: ExperimentScreenId;
-  powerBalance?: ExperimentScreenId;
+	metadata?: ExperimentScreenId;
+	treatmentArms?: ExperimentScreenId;
+	datasource?: ExperimentScreenId;
+	filters?: ExperimentScreenId;
+	outcomesPrior?: ExperimentScreenId;
+	contexts?: ExperimentScreenId;
+	metrics?: ExperimentScreenId;
+	powerBalance?: ExperimentScreenId;
 };
 
 interface ExperimentsSummarizeScreenBaseProps {
-  data: ExperimentFormData;
-  navigatePrev: () => void;
-  navigateTo: (screenId: ExperimentScreenId) => void;
-  onCommitError: (response: ErrorType<unknown>) => void;
-  infoCalloutText: React.ReactNode;
-  editTargets: EditTargets;
-  frequentistInfo?: Pick<ExperimentConfirmationDisplayProps, 'metrics' | 'desiredN'>;
+	data: ExperimentFormData;
+	navigatePrev: () => void;
+	navigateTo: (screenId: ExperimentScreenId) => void;
+	onCommitError: (response: ErrorType<unknown>) => void;
+	infoCalloutText: React.ReactNode;
+	editTargets: EditTargets;
+	frequentistInfo?: Pick<
+		ExperimentConfirmationDisplayProps,
+		"metrics" | "desiredN" | "cluster"
+	>;
 }
 
 export function ExperimentsSummarizeScreenBase({
-  data,
-  navigatePrev,
-  navigateTo,
-  onCommitError,
-  infoCalloutText,
-  editTargets,
-  frequentistInfo,
+	data,
+	navigatePrev,
+	navigateTo,
+	onCommitError,
+	infoCalloutText,
+	editTargets,
+	frequentistInfo,
 }: ExperimentsSummarizeScreenBaseProps) {
-  const router = useRouter();
+	const router = useRouter();
 
-  const experimentId = data.createExperimentResponse?.experiment_id ?? '';
-  const datasourceId = data.datasourceId ?? '';
+	const experimentId = data.createExperimentResponse?.experiment_id ?? "";
+	const datasourceId = data.datasourceId ?? "";
 
-  const { trigger: triggerCommit, isMutating: commitLoading } = useCommitExperiment(datasourceId, experimentId, {
-    swr: {
-      onSuccess: () => {
-        router.push('/experiments');
-      },
-      onError: async (response: ErrorType<unknown>) => {
-        onCommitError(response);
-      },
-    },
-  });
+	const { trigger: triggerCommit, isMutating: commitLoading } =
+		useCommitExperiment(datasourceId, experimentId, {
+			swr: {
+				onSuccess: () => {
+					router.push("/experiments");
+				},
+				onError: async (response: ErrorType<unknown>) => {
+					onCommitError(response);
+				},
+			},
+		});
 
-  const handleCommit = async () => {
-    if (!datasourceId || !experimentId) return;
-    try {
-      await triggerCommit();
-    } catch {
-      // Error handled by onError callback
-    }
-  };
+	const handleCommit = async () => {
+		if (!datasourceId || !experimentId) return;
+		try {
+			await triggerCommit();
+		} catch {
+			// Error handled by onError callback
+		}
+	};
 
-  const toEditHandler = FEATURE_EDIT_BUTTONS_ENABLED
-    ? (target?: ExperimentScreenId) => (target ? () => navigateTo(target) : undefined)
-    : () => undefined;
+	const toEditHandler = FEATURE_EDIT_BUTTONS_ENABLED
+		? (target?: ExperimentScreenId) =>
+				target ? () => navigateTo(target) : undefined
+		: () => undefined;
 
-  if (data.commitError) {
-    return (
-      <>
-        <Flex direction="column" gap="3">
-          <GenericErrorCallout title="Failed to create experiment" error={data.commitError} />
-        </Flex>
-        <NavigationButtons onPrev={navigatePrev} onNext={() => {}} nextDisabled />
-      </>
-    );
-  }
+	if (data.commitError) {
+		return (
+			<>
+				<Flex direction="column" gap="3">
+					<GenericErrorCallout
+						title="Failed to create experiment"
+						error={data.commitError}
+					/>
+				</Flex>
+				<NavigationButtons
+					onPrev={navigatePrev}
+					onNext={() => {}}
+					nextDisabled
+				/>
+			</>
+		);
+	}
 
-  return (
-    <>
-      <Flex direction="column" gap="4">
-        {data.createExperimentResponse !== undefined && (
-          <>
-            <ExperimentConfirmationDisplay
-              response={data.createExperimentResponse}
-              tableName={data.tableName}
-              primaryKey={data.primaryKey}
-              metrics={frequentistInfo?.metrics}
-              desiredN={frequentistInfo?.desiredN}
-              onEditMetadata={toEditHandler(editTargets.metadata)}
-              onEditTreatmentArms={toEditHandler(editTargets.treatmentArms)}
-              onEditDatasource={toEditHandler(editTargets.datasource)}
-              onEditFilters={toEditHandler(editTargets.filters)}
-              onEditOutcomesPrior={toEditHandler(editTargets.outcomesPrior)}
-              onEditContexts={toEditHandler(editTargets.contexts)}
-              onEditMetrics={toEditHandler(editTargets.metrics)}
-              onEditPowerBalance={toEditHandler(editTargets.powerBalance)}
-            />
-            <Callout.Root>
-              <Callout.Icon>
-                <InfoCircledIcon />
-              </Callout.Icon>
-              <Callout.Text>{infoCalloutText}</Callout.Text>
-            </Callout.Root>
-          </>
-        )}
-      </Flex>
-      <NavigationButtons
-        onPrev={navigatePrev} // navigatePrev will handle abandonment
-        onNext={handleCommit}
-        nextDisabled={!data.createExperimentResponse}
-        nextLoading={commitLoading}
-        nextLabel="Save Experiment"
-      />
-    </>
-  );
+	return (
+		<>
+			<Flex direction="column" gap="4">
+				{data.createExperimentResponse !== undefined && (
+					<>
+						<ExperimentConfirmationDisplay
+							response={data.createExperimentResponse}
+							tableName={data.tableName}
+							primaryKey={data.primaryKey}
+							metrics={frequentistInfo?.metrics}
+							desiredN={frequentistInfo?.desiredN}
+							cluster={frequentistInfo?.cluster}
+							onEditMetadata={toEditHandler(editTargets.metadata)}
+							onEditTreatmentArms={toEditHandler(editTargets.treatmentArms)}
+							onEditDatasource={toEditHandler(editTargets.datasource)}
+							onEditFilters={toEditHandler(editTargets.filters)}
+							onEditOutcomesPrior={toEditHandler(editTargets.outcomesPrior)}
+							onEditContexts={toEditHandler(editTargets.contexts)}
+							onEditMetrics={toEditHandler(editTargets.metrics)}
+							onEditPowerBalance={toEditHandler(editTargets.powerBalance)}
+						/>
+						<Callout.Root>
+							<Callout.Icon>
+								<InfoCircledIcon />
+							</Callout.Icon>
+							<Callout.Text>{infoCalloutText}</Callout.Text>
+						</Callout.Root>
+					</>
+				)}
+			</Flex>
+			<NavigationButtons
+				onPrev={navigatePrev} // navigatePrev will handle abandonment
+				onNext={handleCommit}
+				nextDisabled={!data.createExperimentResponse}
+				nextLoading={commitLoading}
+				nextLabel="Save Experiment"
+			/>
+		</>
+	);
 }

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -1,942 +1,764 @@
-"use client";
+'use client';
 
-import { usePowerCheck } from "@/api/admin";
-import { SectionCard } from "@/components/ui/cards/section-card";
-import { GenericErrorCallout } from "@/components/ui/generic-error";
+import { usePowerCheck } from '@/api/admin';
+import { SectionCard } from '@/components/ui/cards/section-card';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
 import {
-	CheckCircledIcon,
-	CrossCircledIcon,
-	LightningBoltIcon,
-} from "@radix-ui/react-icons";
-import {
-	Badge,
-	Button,
-	Callout,
-	Card,
-	DataList,
-	Flex,
-	Grid,
-	Heading,
-	RadioCards,
-	Spinner,
-	Table,
-	Text,
-	TextField,
-} from "@radix-ui/themes";
-import { useEffect, useRef, useState } from "react";
-import { ZodError } from "zod";
-import { ExperimentFormData } from "./experiment-form-def";
-import { convertToFrequentistDesignSpec } from "./experiment-form-helpers";
-import { ExperimentFreqStackScreenMessage } from "./experiment-freq-stack-screen";
+  Badge,
+  Button,
+  Callout,
+  Card,
+  DataList,
+  Flex,
+  Grid,
+  Heading,
+  RadioCards,
+  Spinner,
+  Table,
+  Text,
+  TextField,
+} from '@radix-ui/themes';
+import { useEffect, useRef, useState } from 'react';
+import { ZodError } from 'zod';
+import { ExperimentFormData } from './experiment-form-def';
+import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
+import { ExperimentFreqStackScreenMessage } from './experiment-freq-stack-screen';
 
 enum PowerCheckOption {
-	USE_POWER_CHECK = "use_power_check",
-	USE_ALL_NON_NULL_SAMPLES = "use_all_non_null_samples",
-	ENTER_OWN = "enter_own",
-	NONE = "",
+  USE_POWER_CHECK = 'use_power_check',
+  USE_ALL_NON_NULL_SAMPLES = 'use_all_non_null_samples',
+  ENTER_OWN = 'enter_own',
+  NONE = '',
 }
 
 interface PowerCheckSectionProps {
-	data: ExperimentFormData;
-	dispatch: (msg: ExperimentFreqStackScreenMessage) => void;
+  data: ExperimentFormData;
+  dispatch: (msg: ExperimentFreqStackScreenMessage) => void;
 }
 
-const isPowerCheckButtonEnabled = (
-	isMutating: boolean,
-	data: ExperimentFormData,
-) => {
-	const reasons = [];
-	if (isMutating) {
-		reasons.push("Running power check");
-	}
-	if (data.primaryKey === undefined) {
-		reasons.push("Please select a unique ID field.");
-	}
-	if (data.primaryMetric === undefined) {
-		reasons.push("Please select a primary metric.");
-	}
-	return { enabled: !reasons.length, reason: reasons.join("\n") };
+const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData) => {
+  const reasons = [];
+  if (isMutating) {
+    reasons.push('Running power check');
+  }
+  if (data.primaryKey === undefined) {
+    reasons.push('Please select a unique ID field.');
+  }
+  if (data.primaryMetric === undefined) {
+    reasons.push('Please select a primary metric.');
+  }
+  return { enabled: !reasons.length, reason: reasons.join('\n') };
 };
 
 interface PowerCheckButtonProps {
-	enabled: boolean;
-	onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
-	loading: boolean;
+  enabled: boolean;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
+  loading: boolean;
 }
 
-function RunPowerCheckButton({
-	enabled,
-	onClick,
-	loading,
-}: PowerCheckButtonProps) {
-	return (
-		<Button disabled={!enabled} onClick={onClick} style={{ minWidth: "25%" }}>
-			<Spinner loading={loading}>
-				<LightningBoltIcon />
-			</Spinner>
-			Run Power Check
-		</Button>
-	);
+function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProps) {
+  return (
+    <Button disabled={!enabled} onClick={onClick} style={{ minWidth: '25%' }}>
+      <Spinner loading={loading}>
+        <LightningBoltIcon />
+      </Spinner>
+      Run Power Check
+    </Button>
+  );
 }
 
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
-	const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
-	const [validationError, setValidationError] = useState<ZodError | null>(null);
+  const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
+  const [validationError, setValidationError] = useState<ZodError | null>(null);
 
-	// Derived from the saved power-check response. We deliberately do NOT
-	// hold these as useState — that's what caused the "0 participants /
-	// undefined samples" bug when navigating away to the Summary screen and
-	// hitting Back: the component remounts, useState resets to undefined,
-	// but data.powerCheckResponse (form state) persists, so the displays
-	// went out of sync with the underlying data. Computing them from the
-	// response makes them survive remounts for free.
-	const primaryFromSaved = data.powerCheckResponse?.analyses.find(
-		(a) =>
-			a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-	);
-	const powerCheckTarget: number | undefined =
-		primaryFromSaved?.target_n ?? undefined;
-	const nonNullSamples: number | undefined =
-		primaryFromSaved?.metric_spec.available_nonnull_n ?? undefined;
-	const allSamples: number | undefined =
-		primaryFromSaved?.metric_spec.available_n ?? undefined;
+  // Derived from the saved power-check response. We deliberately do NOT
+  // hold these as useState — that's what caused the "0 participants /
+  // undefined samples" bug when navigating away to the Summary screen and
+  // hitting Back: the component remounts, useState resets to undefined,
+  // but data.powerCheckResponse (form state) persists, so the displays
+  // went out of sync with the underlying data. Computing them from the
+  // response makes them survive remounts for free.
+  const primaryFromSaved = data.powerCheckResponse?.analyses.find(
+    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+  );
+  const powerCheckTarget: number | undefined = primaryFromSaved?.target_n ?? undefined;
+  const nonNullSamples: number | undefined = primaryFromSaved?.metric_spec.available_nonnull_n ?? undefined;
+  const allSamples: number | undefined = primaryFromSaved?.metric_spec.available_n ?? undefined;
 
-	// selectedSampleOption is the radio's local UI state. We seed it lazily
-	// (once, on mount) from data.desiredN compared against the saved
-	// target/non-null sizes so the user's previous choice survives
-	// navigating away and back. After mount, it's driven by user clicks /
-	// handlePowerCheck like before — keeping it as state lets the user
-	// click "Custom" without immediately committing a desiredN.
-	const [selectedSampleOption, setSelectedSampleOption] =
-		useState<PowerCheckOption>(() => {
-			if (!data.powerCheckResponse) return PowerCheckOption.USE_POWER_CHECK;
-			const primary = data.powerCheckResponse.analyses.find(
-				(a) =>
-					a.metric_spec.field_name ===
-					data.primaryMetric?.metric.field_name,
-			);
-			const target = primary?.target_n ?? undefined;
-			const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
-			if (data.desiredN === undefined) return PowerCheckOption.NONE;
-			if (data.desiredN === target) return PowerCheckOption.USE_POWER_CHECK;
-			if (data.desiredN === nonNull)
-				return PowerCheckOption.USE_ALL_NON_NULL_SAMPLES;
-			return PowerCheckOption.ENTER_OWN;
-		});
+  // selectedSampleOption is the radio's local UI state. We seed it lazily
+  // (once, on mount) from data.desiredN compared against the saved
+  // target/non-null sizes so the user's previous choice survives
+  // navigating away and back. After mount, it's driven by user clicks /
+  // handlePowerCheck like before — keeping it as state lets the user
+  // click "Custom" without immediately committing a desiredN.
+  const [selectedSampleOption, setSelectedSampleOption] = useState<PowerCheckOption>(() => {
+    if (!data.powerCheckResponse) return PowerCheckOption.USE_POWER_CHECK;
+    const primary = data.powerCheckResponse.analyses.find(
+      (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+    );
+    const target = primary?.target_n ?? undefined;
+    const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
+    if (data.desiredN === undefined) return PowerCheckOption.NONE;
+    if (data.desiredN === target) return PowerCheckOption.USE_POWER_CHECK;
+    if (data.desiredN === nonNull) return PowerCheckOption.USE_ALL_NON_NULL_SAMPLES;
+    return PowerCheckOption.ENTER_OWN;
+  });
 
-	// Issue #217: cluster experiments show "clusters first, participants underneath".
-	const isClusterExperiment =
-		data.experimentType === "freq_cluster_preassigned";
-	// CV > 0.5 triggers a high-variability warning per the issue mockups.
-	const cvNum = Number(data.clusterCv ?? "");
-	const hasHighVariability =
-		isClusterExperiment &&
-		data.clusterCv !== undefined &&
-		data.clusterCv !== "" &&
-		!Number.isNaN(cvNum) &&
-		cvNum > 0.5;
+  // Issue #217: cluster experiments show "clusters first, participants underneath".
+  const isClusterExperiment = data.experimentType === 'freq_cluster_preassigned';
+  // CV > 0.5 triggers a high-variability warning per the issue mockups.
+  const cvNum = Number(data.clusterCv ?? '');
+  const hasHighVariability =
+    isClusterExperiment && data.clusterCv !== undefined && data.clusterCv !== '' && !Number.isNaN(cvNum) && cvNum > 0.5;
 
-	// Issue #217: linked Clusters ↔ Participants inputs on the custom-N option,
-	// with a 0.5s debounce that auto-fills the other field. We track each input
-	// as a string so the user can type freely; the debounce timer commits the
-	// derived sibling value (and the participants value to set-chosen-n) after
-	// they stop typing.
-	const avgClusterSize = Number(data.clusterAvgSize ?? "");
+  // Issue #217: linked Clusters ↔ Participants inputs on the custom-N option,
+  // with a 0.5s debounce that auto-fills the other field. We track each input
+  // as a string so the user can type freely; the debounce timer commits the
+  // derived sibling value (and the participants value to set-chosen-n) after
+  // they stop typing.
+  const avgClusterSize = Number(data.clusterAvgSize ?? '');
 
-	// Lazy-init the Custom inputs from data.desiredN so a previously-entered
-	// custom value survives navigating to Summary and clicking Back. Only
-	// seed when desiredN is set AND it doesn't match the recommended or
-	// max-available size (those are handled by the other two radio cards).
-	const initialCustomFromState = (() => {
-		if (data.desiredN === undefined) return { clusters: "", participants: "" };
-		const primary = data.powerCheckResponse?.analyses.find(
-			(a) =>
-				a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-		);
-		const target = primary?.target_n ?? undefined;
-		const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
-		if (data.desiredN === target || data.desiredN === nonNull) {
-			return { clusters: "", participants: "" };
-		}
-		const participants = String(data.desiredN);
-		const clusters =
-			Number.isFinite(avgClusterSize) && avgClusterSize > 0
-				? String(Math.ceil(data.desiredN / avgClusterSize))
-				: "";
-		return { clusters, participants };
-	})();
+  // Lazy-init the Custom inputs from data.desiredN so a previously-entered
+  // custom value survives navigating to Summary and clicking Back. Only
+  // seed when desiredN is set AND it doesn't match the recommended or
+  // max-available size (those are handled by the other two radio cards).
+  const initialCustomFromState = (() => {
+    if (data.desiredN === undefined) return { clusters: '', participants: '' };
+    const primary = data.powerCheckResponse?.analyses.find(
+      (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+    );
+    const target = primary?.target_n ?? undefined;
+    const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
+    if (data.desiredN === target || data.desiredN === nonNull) {
+      return { clusters: '', participants: '' };
+    }
+    const participants = String(data.desiredN);
+    const clusters =
+      Number.isFinite(avgClusterSize) && avgClusterSize > 0 ? String(Math.ceil(data.desiredN / avgClusterSize)) : '';
+    return { clusters, participants };
+  })();
 
-	const [clustersInput, setClustersInput] = useState<string>(
-		initialCustomFromState.clusters,
-	);
-	const [participantsInput, setParticipantsInput] = useState<string>(
-		initialCustomFromState.participants,
-	);
-	// Which field the user is actively editing; used to avoid feedback loops
-	// when the debounce timer writes the derived value into the other field.
-	const editingRef = useRef<"clusters" | "participants" | null>(null);
-	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [clustersInput, setClustersInput] = useState<string>(initialCustomFromState.clusters);
+  const [participantsInput, setParticipantsInput] = useState<string>(initialCustomFromState.participants);
+  // Which field the user is actively editing; used to avoid feedback loops
+  // when the debounce timer writes the derived value into the other field.
+  const editingRef = useRef<'clusters' | 'participants' | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	useEffect(() => {
-		if (!isClusterExperiment) return;
-		if (debounceRef.current !== null) clearTimeout(debounceRef.current);
-		const which = editingRef.current;
-		if (which === null) return;
-		debounceRef.current = setTimeout(() => {
-			if (!Number.isFinite(avgClusterSize) || avgClusterSize <= 0) return;
-			if (which === "clusters") {
-				const n = Number(clustersInput);
-				if (!Number.isFinite(n) || n <= 0) {
-					setParticipantsInput("");
-					dispatch({ type: "set-chosen-n", value: undefined });
-					return;
-				}
-				const participants = Math.round(n * avgClusterSize);
-				setParticipantsInput(String(participants));
-				dispatch({ type: "set-chosen-n", value: participants });
-			} else {
-				const n = Number(participantsInput);
-				if (!Number.isFinite(n) || n <= 0) {
-					setClustersInput("");
-					dispatch({ type: "set-chosen-n", value: undefined });
-					return;
-				}
-				setClustersInput(String(Math.ceil(n / avgClusterSize)));
-				dispatch({ type: "set-chosen-n", value: n });
-			}
-			editingRef.current = null;
-		}, 500);
-		return () => {
-			if (debounceRef.current !== null) clearTimeout(debounceRef.current);
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [clustersInput, participantsInput, avgClusterSize, isClusterExperiment]);
+  useEffect(() => {
+    if (!isClusterExperiment) return;
+    if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+    const which = editingRef.current;
+    if (which === null) return;
+    debounceRef.current = setTimeout(() => {
+      if (!Number.isFinite(avgClusterSize) || avgClusterSize <= 0) return;
+      if (which === 'clusters') {
+        const n = Number(clustersInput);
+        if (!Number.isFinite(n) || n <= 0) {
+          setParticipantsInput('');
+          dispatch({ type: 'set-chosen-n', value: undefined });
+          return;
+        }
+        const participants = Math.round(n * avgClusterSize);
+        setParticipantsInput(String(participants));
+        dispatch({ type: 'set-chosen-n', value: participants });
+      } else {
+        const n = Number(participantsInput);
+        if (!Number.isFinite(n) || n <= 0) {
+          setClustersInput('');
+          dispatch({ type: 'set-chosen-n', value: undefined });
+          return;
+        }
+        setClustersInput(String(Math.ceil(n / avgClusterSize)));
+        dispatch({ type: 'set-chosen-n', value: n });
+      }
+      editingRef.current = null;
+    }, 500);
+    return () => {
+      if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clustersInput, participantsInput, avgClusterSize, isClusterExperiment]);
 
-	const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
+  const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
-	// Achievable MDE recompute: when the user picks Max-available or Custom, fire
-	// a fresh power-check call with desired_n included in the design spec. The BE
-	// switches to MDE mode and returns the achievable MDE plus the cluster split
-	// for the chosen N. The result is stored on form state so it can be (a) shown
-	// inline next to the radio option and (b) persisted as the experiment's
-	// power_analyses at save time. Custom typing is already debounced upstream
-	// (set-chosen-n only fires after 500ms), so this effect only sees the final
-	// committed value.
-	const [isRecomputingMde, setIsRecomputingMde] = useState(false);
-	useEffect(() => {
-		// Recompute only makes sense when the user has chosen a non-recommended
-		// sample size. For "Use minimum sample required" the original
-		// powerCheckResponse already carries the right answer (achievable MDE
-		// equals the user's target MDE by construction).
-		if (data.desiredN === undefined) return;
-		if (selectedSampleOption === PowerCheckOption.USE_POWER_CHECK) return;
-		if (selectedSampleOption === PowerCheckOption.NONE) return;
-		if (data.desiredN === powerCheckTarget) return;
-		if (!data.tableName || !data.primaryKey || !data.primaryMetric) return;
+  // Achievable MDE recompute: when the user picks Max-available or Custom, fire
+  // a fresh power-check call with desired_n included in the design spec. The BE
+  // switches to MDE mode and returns the achievable MDE plus the cluster split
+  // for the chosen N. The result is stored on form state so it can be (a) shown
+  // inline next to the radio option and (b) persisted as the experiment's
+  // power_analyses at save time. Custom typing is already debounced upstream
+  // (set-chosen-n only fires after 500ms), so this effect only sees the final
+  // committed value.
+  const [isRecomputingMde, setIsRecomputingMde] = useState(false);
+  useEffect(() => {
+    // Recompute only makes sense when the user has chosen a non-recommended
+    // sample size. For "Use minimum sample required" the original
+    // powerCheckResponse already carries the right answer (achievable MDE
+    // equals the user's target MDE by construction).
+    if (data.desiredN === undefined) return;
+    if (selectedSampleOption === PowerCheckOption.USE_POWER_CHECK) return;
+    if (selectedSampleOption === PowerCheckOption.NONE) return;
+    if (data.desiredN === powerCheckTarget) return;
+    if (!data.tableName || !data.primaryKey || !data.primaryMetric) return;
 
-		let cancelled = false;
-		setIsRecomputingMde(true);
-		// `void` here intentionally discards the promise — the IIFE manages its
-		// own lifecycle via the `cancelled` flag and the cleanup function below.
-		void (async () => {
-			try {
-				const design_spec = convertToFrequentistDesignSpec(data);
-				const response = await trigger({ design_spec });
-				if (cancelled) return;
-				dispatch({
-					type: "set-achievable-power-check-response",
-					response,
-				});
-			} catch {
-				// Swallow: if the recompute fails the inline display just doesn't
-				// show an achievable MDE. Validation issues are already surfaced
-				// by the manual Run-Power-Check flow on the same page.
-			} finally {
-				if (!cancelled) setIsRecomputingMde(false);
-			}
-		})();
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [data.desiredN, selectedSampleOption, powerCheckTarget]);
+    let cancelled = false;
+    setIsRecomputingMde(true);
+    // `void` here intentionally discards the promise — the IIFE manages its
+    // own lifecycle via the `cancelled` flag and the cleanup function below.
+    void (async () => {
+      try {
+        const design_spec = convertToFrequentistDesignSpec(data);
+        const response = await trigger({ design_spec });
+        if (cancelled) return;
+        dispatch({
+          type: 'set-achievable-power-check-response',
+          response,
+        });
+      } catch {
+        // Swallow: if the recompute fails the inline display just doesn't
+        // show an achievable MDE. Validation issues are already surfaced
+        // by the manual Run-Power-Check flow on the same page.
+      } finally {
+        if (!cancelled) setIsRecomputingMde(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.desiredN, selectedSampleOption, powerCheckTarget]);
 
-	// Read the achievable MDE for the primary metric (cluster-aware fields are
-	// populated by solve_for_mde_cluster on the BE; for non-cluster experiments
-	// pct_change_possible is still populated, so this works for both).
-	const achievablePrimary = data.achievablePowerCheckResponse?.analyses.find(
-		(a) =>
-			a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-	);
-	const achievablePctChange = achievablePrimary?.pct_change_possible ?? null;
+  // Read the achievable MDE for the primary metric (cluster-aware fields are
+  // populated by solve_for_mde_cluster on the BE; for non-cluster experiments
+  // pct_change_possible is still populated, so this works for both).
+  const achievablePrimary = data.achievablePowerCheckResponse?.analyses.find(
+    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+  );
+  const achievablePctChange = achievablePrimary?.pct_change_possible ?? null;
 
-	// Target MDE the user requested (string from the form, expressed as a
-	// percent). Used as the "achievable MDE" for the recommended option, since
-	// by construction the recommended sample size hits the target exactly.
-	const targetMdeStr = data.primaryMetric?.mde;
-	const targetMdePctNum =
-		targetMdeStr !== undefined && targetMdeStr !== ""
-			? Number(targetMdeStr)
-			: null;
+  // Target MDE the user requested (string from the form, expressed as a
+  // percent). Used as the "achievable MDE" for the recommended option, since
+  // by construction the recommended sample size hits the target exactly.
+  const targetMdeStr = data.primaryMetric?.mde;
+  const targetMdePctNum = targetMdeStr !== undefined && targetMdeStr !== '' ? Number(targetMdeStr) : null;
 
-	/** One-line "Achievable MDE: X%" annotation, sized to fit under a radio card.
-	 * Blue mirrors how Target MDE is shown on the saved-experiment Analysis bar
-	 * — same statistical concept, different perspective. Green stays reserved
-	 * for cluster counts (clusters/participants colorway) to keep that signal
-	 * unambiguous. Loading stays gray so users can tell "computing" from a real
-	 * value at a glance. */
-	const renderAchievableMdeLine = (
-		pctChange: number | null | undefined,
-		opts: { loading?: boolean; note?: string } = {},
-	) => {
-		if (opts.loading) {
-			return (
-				<Text size="1" color="gray">
-					Achievable MDE: computing…
-				</Text>
-			);
-		}
-		if (pctChange == null) return null;
-		const pct = (pctChange * 100).toFixed(2);
-		return (
-			<Text size="1" color="blue">
-				Achievable MDE: <strong>{pct}%</strong>
-				{opts.note ? ` ${opts.note}` : ""}
-			</Text>
-		);
-	};
+  /** One-line "Achievable MDE: X%" annotation, sized to fit under a radio card.
+   * Blue mirrors how Target MDE is shown on the saved-experiment Analysis bar
+   * — same statistical concept, different perspective. Green stays reserved
+   * for cluster counts (clusters/participants colorway) to keep that signal
+   * unambiguous. Loading stays gray so users can tell "computing" from a real
+   * value at a glance. */
+  const renderAchievableMdeLine = (
+    pctChange: number | null | undefined,
+    opts: { loading?: boolean; note?: string } = {},
+  ) => {
+    if (opts.loading) {
+      return (
+        <Text size="1" color="gray">
+          Achievable MDE: computing…
+        </Text>
+      );
+    }
+    if (pctChange == null) return null;
+    const pct = (pctChange * 100).toFixed(2);
+    return (
+      <Text size="1" color="blue">
+        Achievable MDE: <strong>{pct}%</strong>
+        {opts.note ? ` ${opts.note}` : ''}
+      </Text>
+    );
+  };
 
-	const handlePowerCheck = async (
-		event: React.MouseEvent<HTMLButtonElement>,
-	) => {
-		event.preventDefault();
-		setValidationError(null);
+  const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setValidationError(null);
 
-		if (!data.tableName || !data.primaryKey || !data.primaryMetric) {
-			return;
-		}
+    if (!data.tableName || !data.primaryKey || !data.primaryMetric) {
+      return;
+    }
 
-		// TODO: reimplement this to be simpler
-		try {
-			const design_spec = convertToFrequentistDesignSpec(data);
-			const response = await trigger({ design_spec });
-			const primary = response.analyses.find(
-				(a) =>
-					a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-			);
+    // TODO: reimplement this to be simpler
+    try {
+      const design_spec = convertToFrequentistDesignSpec(data);
+      const response = await trigger({ design_spec });
+      const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
 
-			dispatch({
-				type: "set-power-check-response",
-				response,
-				desiredN: undefined,
-			});
-			// powerCheckTarget / nonNullSamples / allSamples are derived from
-			// data.powerCheckResponse now (see top of component), so the dispatch
-			// above is enough — no separate setters needed.
-			if (primary?.sufficient_n) {
-				setSelectedSampleOption(PowerCheckOption.USE_POWER_CHECK);
-				dispatch({
-					type: "set-chosen-n",
-					value: primary?.target_n ?? undefined,
-				});
-			} else {
-				setSelectedSampleOption(PowerCheckOption.NONE);
-			}
-		} catch (err) {
-			if (err instanceof ZodError) {
-				setValidationError(err);
-				return;
-			}
-			throw err;
-		}
-	};
+      dispatch({
+        type: 'set-power-check-response',
+        response,
+        desiredN: undefined,
+      });
+      // powerCheckTarget / nonNullSamples / allSamples are derived from
+      // data.powerCheckResponse now (see top of component), so the dispatch
+      // above is enough — no separate setters needed.
+      if (primary?.sufficient_n) {
+        setSelectedSampleOption(PowerCheckOption.USE_POWER_CHECK);
+        dispatch({
+          type: 'set-chosen-n',
+          value: primary?.target_n ?? undefined,
+        });
+      } else {
+        setSelectedSampleOption(PowerCheckOption.NONE);
+      }
+    } catch (err) {
+      if (err instanceof ZodError) {
+        setValidationError(err);
+        return;
+      }
+      throw err;
+    }
+  };
 
-	const handleSampleOptionChange = (value: PowerCheckOption) => {
-		setSelectedSampleOption(value);
-		switch (value) {
-			case PowerCheckOption.USE_POWER_CHECK:
-				dispatch({ type: "set-chosen-n", value: powerCheckTarget });
-				break;
-			case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
-				dispatch({ type: "set-chosen-n", value: nonNullSamples });
-				break;
-			case PowerCheckOption.ENTER_OWN:
-			case PowerCheckOption.NONE:
-				dispatch({ type: "set-chosen-n", value: undefined });
-				break;
-		}
-	};
+  const handleSampleOptionChange = (value: PowerCheckOption) => {
+    setSelectedSampleOption(value);
+    switch (value) {
+      case PowerCheckOption.USE_POWER_CHECK:
+        dispatch({ type: 'set-chosen-n', value: powerCheckTarget });
+        break;
+      case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
+        dispatch({ type: 'set-chosen-n', value: nonNullSamples });
+        break;
+      case PowerCheckOption.ENTER_OWN:
+      case PowerCheckOption.NONE:
+        dispatch({ type: 'set-chosen-n', value: undefined });
+        break;
+    }
+  };
 
-	const primaryPower =
-		data.powerCheckResponse !== undefined && !validationError
-			? data.powerCheckResponse.analyses[0]
-			: undefined;
-	const restPower =
-		data.powerCheckResponse !== undefined &&
-		!validationError &&
-		data.powerCheckResponse.analyses.length > 1
-			? data.powerCheckResponse.analyses.slice(1)
-			: undefined;
+  const primaryPower =
+    data.powerCheckResponse !== undefined && !validationError ? data.powerCheckResponse.analyses[0] : undefined;
+  const restPower =
+    data.powerCheckResponse !== undefined && !validationError && data.powerCheckResponse.analyses.length > 1
+      ? data.powerCheckResponse.analyses.slice(1)
+      : undefined;
 
-	return (
-		<Flex direction="column" gap={"3"}>
-			<Flex direction="row" gap="4">
-				<Flex direction="column" gap="1" flexGrow="1">
-					<Text as="label" size="2" weight="medium">
-						Confidence (%)
-					</Text>
-					<TextField.Root
-						type="number"
-						min={50}
-						max={99}
-						value={data.confidence ?? "95"}
-						onChange={(e) =>
-							dispatch({ type: "set-confidence", value: e.target.value })
-						}
-						placeholder="95"
-					/>
-				</Flex>
-				<Flex direction="column" gap="1" flexGrow="1">
-					<Text as="label" size="2" weight="medium">
-						Power (%)
-					</Text>
-					<TextField.Root
-						type="number"
-						min={50}
-						max={99}
-						value={data.power ?? "80"}
-						onChange={(e) =>
-							dispatch({ type: "set-power", value: e.target.value })
-						}
-						placeholder="80"
-					/>
-				</Flex>
-			</Flex>
+  return (
+    <Flex direction="column" gap={'3'}>
+      <Flex direction="row" gap="4">
+        <Flex direction="column" gap="1" flexGrow="1">
+          <Text as="label" size="2" weight="medium">
+            Confidence (%)
+          </Text>
+          <TextField.Root
+            type="number"
+            min={50}
+            max={99}
+            value={data.confidence ?? '95'}
+            onChange={(e) => dispatch({ type: 'set-confidence', value: e.target.value })}
+            placeholder="95"
+          />
+        </Flex>
+        <Flex direction="column" gap="1" flexGrow="1">
+          <Text as="label" size="2" weight="medium">
+            Power (%)
+          </Text>
+          <TextField.Root
+            type="number"
+            min={50}
+            max={99}
+            value={data.power ?? '80'}
+            onChange={(e) => dispatch({ type: 'set-power', value: e.target.value })}
+            placeholder="80"
+          />
+        </Flex>
+      </Flex>
 
-			<SectionCard title="Analysis">
-				<Flex direction="column" gap="3" align="center">
-					<RunPowerCheckButton
-						enabled={enabled}
-						onClick={handlePowerCheck}
-						loading={isMutating}
-					/>
+      <SectionCard title="Analysis">
+        <Flex direction="column" gap="3" align="center">
+          <RunPowerCheckButton enabled={enabled} onClick={handlePowerCheck} loading={isMutating} />
 
-					{error && (
-						<Flex align="center" gap="2">
-							<GenericErrorCallout title={"Power check failed"} error={error} />
-						</Flex>
-					)}
+          {error && (
+            <Flex align="center" gap="2">
+              <GenericErrorCallout title={'Power check failed'} error={error} />
+            </Flex>
+          )}
 
-					{validationError && (
-						<Flex align="center" gap="2">
-							<GenericErrorCallout
-								title={"Validation failed"}
-								message={validationError.issues
-									.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-									.join("\n")}
-							/>
-						</Flex>
-					)}
+          {validationError && (
+            <Flex align="center" gap="2">
+              <GenericErrorCallout
+                title={'Validation failed'}
+                message={validationError.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('\n')}
+              />
+            </Flex>
+          )}
 
-					{primaryPower && (
-						<Callout.Root color={primaryPower.sufficient_n ? "green" : "red"}>
-							<Callout.Icon>
-								{primaryPower.sufficient_n ? (
-									<CheckCircledIcon />
-								) : (
-									<CrossCircledIcon />
-								)}
-							</Callout.Icon>
-							<Callout.Text>
-								{isClusterExperiment &&
-								primaryPower.num_clusters_total != null ? (
-									<>
-										There are{" "}
-										<strong>
-											{(
-												primaryPower.metric_spec.available_n ?? 0
-											).toLocaleString()}{" "}
-											participants
-										</strong>{" "}
-										available. A minimum of{" "}
-										<strong>
-											{primaryPower.num_clusters_total.toLocaleString()}{" "}
-											clusters
-										</strong>{" "}
-										(
-										{(primaryPower.target_n ?? 0).toLocaleString()}{" "}
-										participants) are needed to meet your design specs.{" "}
-										{primaryPower.sufficient_n
-											? "There are enough units available."
-											: "Insufficient units available."}
-									</>
-								) : (
-									primaryPower.msg?.msg ||
-									(primaryPower.sufficient_n
-										? "The experiment has sufficient power."
-										: "The experiment does not have sufficient power.")
-								)}
-							</Callout.Text>
-							{/* Issue #217: CV > 0.5 warning nested inside the success/result box. */}
-							{hasHighVariability && (
-								<Callout.Root color="amber" mt="2">
-									<Callout.Text>
-										⚠ CV = {data.clusterCv}: cluster size variability is high.
-										The cluster count estimate may be unreliable.
-									</Callout.Text>
-								</Callout.Root>
-							)}
-						</Callout.Root>
-					)}
+          {primaryPower && (
+            <Callout.Root color={primaryPower.sufficient_n ? 'green' : 'red'}>
+              <Callout.Icon>{primaryPower.sufficient_n ? <CheckCircledIcon /> : <CrossCircledIcon />}</Callout.Icon>
+              <Callout.Text>
+                {isClusterExperiment && primaryPower.num_clusters_total != null ? (
+                  <>
+                    There are{' '}
+                    <strong>{(primaryPower.metric_spec.available_n ?? 0).toLocaleString()} participants</strong>{' '}
+                    available. A minimum of <strong>{primaryPower.num_clusters_total.toLocaleString()} clusters</strong>{' '}
+                    ({(primaryPower.target_n ?? 0).toLocaleString()} participants) are needed to meet your design specs.{' '}
+                    {primaryPower.sufficient_n ? 'There are enough units available.' : 'Insufficient units available.'}
+                  </>
+                ) : (
+                  primaryPower.msg?.msg ||
+                  (primaryPower.sufficient_n
+                    ? 'The experiment has sufficient power.'
+                    : 'The experiment does not have sufficient power.')
+                )}
+              </Callout.Text>
+              {/* Issue #217: CV > 0.5 warning nested inside the success/result box. */}
+              {hasHighVariability && (
+                <Callout.Root color="amber" mt="2">
+                  <Callout.Text>
+                    ⚠ CV = {data.clusterCv}: cluster size variability is high. The cluster count estimate may be
+                    unreliable.
+                  </Callout.Text>
+                </Callout.Root>
+              )}
+            </Callout.Root>
+          )}
 
-					<Grid rows={"1"} columns={restPower ? "2" : "1"} gap={"3"}>
-						{primaryPower && (
-							<>
-								<Card>
-									<Flex direction="column" gap={"3"}>
-										<Heading size={"3"}>
-											Primary Metric: {primaryPower.metric_spec.field_name}
-										</Heading>
-										<DataList.Root>
-											<DataList.Item>
-												<DataList.Label>Status</DataList.Label>
-												<DataList.Value>
-													{primaryPower.sufficient_n ? (
-														<Badge color={"green"}>Pass</Badge>
-													) : (
-														<Badge color={"red"}>Failed</Badge>
-													)}
-												</DataList.Value>
-											</DataList.Item>
-											<DataList.Item>
-												<DataList.Label>Required</DataList.Label>
-												<DataList.Value>
-													{isClusterExperiment &&
-													primaryPower.num_clusters_total != null ? (
-														<Flex direction="column" align="end">
-															<Text color="green" weight="bold">
-																{primaryPower.num_clusters_total.toLocaleString()}{" "}
-																clusters
-															</Text>
-															<Text size="1" color="gray">
-																{(
-																	primaryPower.target_n ?? 0
-																).toLocaleString()}{" "}
-																participants
-															</Text>
-														</Flex>
-													) : (
-														primaryPower.target_n || "?"
-													)}
-												</DataList.Value>
-											</DataList.Item>
-											<DataList.Item>
-												<DataList.Label>Available</DataList.Label>
-												<DataList.Value>
-													{isClusterExperiment &&
-													data.clusterAvgSize !== "" &&
-													primaryPower.metric_spec.available_n != null ? (
-														<Flex direction="column" align="end">
-															<Text color="green" weight="bold">
-																{Math.floor(
-																	primaryPower.metric_spec.available_n /
-																		Number(data.clusterAvgSize),
-																).toLocaleString()}{" "}
-																clusters
-															</Text>
-															<Text size="1" color="gray">
-																{primaryPower.metric_spec.available_n.toLocaleString()}{" "}
-																participants
-															</Text>
-														</Flex>
-													) : primaryPower.metric_spec.available_n == null ? (
-														"?"
-													) : primaryPower.metric_spec.available_n === 0 ||
-														primaryPower.metric_spec.available_n <
-															(primaryPower.target_n ?? 0) ? (
-														<Text color="crimson">
-															{primaryPower.metric_spec.available_n}
-														</Text>
-													) : (
-														primaryPower.metric_spec.available_n
-													)}
-												</DataList.Value>
-											</DataList.Item>
-											<DataList.Item>
-												<DataList.Label>Available (non-null)</DataList.Label>
-												<DataList.Value>
-													{isClusterExperiment &&
-													data.clusterAvgSize !== "" &&
-													primaryPower.metric_spec.available_nonnull_n !=
-														null ? (
-														<Flex direction="column" align="end">
-															<Text color="green" weight="bold">
-																{Math.floor(
-																	primaryPower.metric_spec
-																		.available_nonnull_n /
-																		Number(data.clusterAvgSize),
-																).toLocaleString()}{" "}
-																clusters
-															</Text>
-															<Text size="1" color="gray">
-																{primaryPower.metric_spec.available_nonnull_n.toLocaleString()}{" "}
-																participants
-															</Text>
-														</Flex>
-													) : primaryPower.metric_spec.available_nonnull_n ==
-													null ? (
-														"?"
-													) : primaryPower.metric_spec.available_nonnull_n ===
-															0 ||
-														primaryPower.metric_spec.available_nonnull_n <
-															(primaryPower.target_n ?? 0) ||
-														primaryPower.metric_spec.available_nonnull_n <
-															(primaryPower.metric_spec.available_n ?? 0) ? (
-														<Text color="orange">
-															{primaryPower.metric_spec.available_nonnull_n}
-														</Text>
-													) : (
-														primaryPower.metric_spec.available_nonnull_n
-													)}
-												</DataList.Value>
-											</DataList.Item>
-											{primaryPower.pct_change_possible !== null &&
-												primaryPower.pct_change_possible !== undefined && (
-													<DataList.Item>
-														<DataList.Label>Target MDE</DataList.Label>
-														<DataList.Value>
-															{(primaryPower.pct_change_possible * 100).toFixed(
-																4,
-															)}
-															%
-														</DataList.Value>
-													</DataList.Item>
-												)}
-										</DataList.Root>
-									</Flex>
-								</Card>
-							</>
-						)}
-						{restPower ? (
-							<Card key={"secondary"}>
-								<Flex direction="column" gap={"3"}>
-									<Heading size={"3"}>Secondary Metrics</Heading>
-									<Table.Root>
-										<Table.Header>
-											<Table.Row>
-												<Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
-												<Table.ColumnHeaderCell></Table.ColumnHeaderCell>
-												<Table.ColumnHeaderCell>
-													Required
-												</Table.ColumnHeaderCell>
-												<Table.ColumnHeaderCell>
-													Available
-												</Table.ColumnHeaderCell>
-												<Table.ColumnHeaderCell>
-													Available (non-null)
-												</Table.ColumnHeaderCell>
-											</Table.Row>
-										</Table.Header>
-										<Table.Body>
-											{restPower.map((metricAnalysis, i) => (
-												<Table.Row key={`rest${i}`}>
-													<Table.Cell>
-														{metricAnalysis.metric_spec.field_name}
-													</Table.Cell>
-													<Table.Cell>
-														{metricAnalysis.sufficient_n ? (
-															<Badge color={"green"}>Pass</Badge>
-														) : (
-															<Badge color={"orange"}>Failed</Badge>
-														)}
-													</Table.Cell>
-													<Table.Cell align={"right"}>
-														{metricAnalysis.target_n ?? ""}
-													</Table.Cell>
-													<Table.Cell align={"right"}>
-														{metricAnalysis.metric_spec.available_n == null ? (
-															"?"
-														) : metricAnalysis.metric_spec.available_n === 0 ||
-															metricAnalysis.metric_spec.available_n <
-																(metricAnalysis.target_n ?? 0) ? (
-															<Text color="crimson">
-																{metricAnalysis.metric_spec.available_n}
-															</Text>
-														) : (
-															metricAnalysis.metric_spec.available_n
-														)}
-													</Table.Cell>
-													<Table.Cell align={"right"}>
-														{metricAnalysis.metric_spec.available_nonnull_n ==
-														null ? (
-															"?"
-														) : metricAnalysis.metric_spec
-																.available_nonnull_n === 0 ||
-															metricAnalysis.metric_spec.available_nonnull_n <
-																(metricAnalysis.target_n ?? 0) ? (
-															<Text color="crimson">
-																{metricAnalysis.metric_spec.available_nonnull_n}
-															</Text>
-														) : (
-															metricAnalysis.metric_spec.available_nonnull_n
-														)}
-													</Table.Cell>
-												</Table.Row>
-											))}
-										</Table.Body>
-									</Table.Root>
-								</Flex>
-							</Card>
-						) : null}
-					</Grid>
-				</Flex>
-			</SectionCard>
+          <Grid rows={'1'} columns={restPower ? '2' : '1'} gap={'3'}>
+            {primaryPower && (
+              <>
+                <Card>
+                  <Flex direction="column" gap={'3'}>
+                    <Heading size={'3'}>Primary Metric: {primaryPower.metric_spec.field_name}</Heading>
+                    <DataList.Root>
+                      <DataList.Item>
+                        <DataList.Label>Status</DataList.Label>
+                        <DataList.Value>
+                          {primaryPower.sufficient_n ? (
+                            <Badge color={'green'}>Pass</Badge>
+                          ) : (
+                            <Badge color={'red'}>Failed</Badge>
+                          )}
+                        </DataList.Value>
+                      </DataList.Item>
+                      <DataList.Item>
+                        <DataList.Label>Required</DataList.Label>
+                        <DataList.Value>
+                          {isClusterExperiment && primaryPower.num_clusters_total != null ? (
+                            <Flex direction="column" align="end">
+                              <Text color="green" weight="bold">
+                                {primaryPower.num_clusters_total.toLocaleString()} clusters
+                              </Text>
+                              <Text size="1" color="gray">
+                                {(primaryPower.target_n ?? 0).toLocaleString()} participants
+                              </Text>
+                            </Flex>
+                          ) : (
+                            primaryPower.target_n || '?'
+                          )}
+                        </DataList.Value>
+                      </DataList.Item>
+                      <DataList.Item>
+                        <DataList.Label>Available</DataList.Label>
+                        <DataList.Value>
+                          {isClusterExperiment &&
+                          data.clusterAvgSize !== '' &&
+                          primaryPower.metric_spec.available_n != null ? (
+                            <Flex direction="column" align="end">
+                              <Text color="green" weight="bold">
+                                {Math.floor(
+                                  primaryPower.metric_spec.available_n / Number(data.clusterAvgSize),
+                                ).toLocaleString()}{' '}
+                                clusters
+                              </Text>
+                              <Text size="1" color="gray">
+                                {primaryPower.metric_spec.available_n.toLocaleString()} participants
+                              </Text>
+                            </Flex>
+                          ) : primaryPower.metric_spec.available_n == null ? (
+                            '?'
+                          ) : primaryPower.metric_spec.available_n === 0 ||
+                            primaryPower.metric_spec.available_n < (primaryPower.target_n ?? 0) ? (
+                            <Text color="crimson">{primaryPower.metric_spec.available_n}</Text>
+                          ) : (
+                            primaryPower.metric_spec.available_n
+                          )}
+                        </DataList.Value>
+                      </DataList.Item>
+                      <DataList.Item>
+                        <DataList.Label>Available (non-null)</DataList.Label>
+                        <DataList.Value>
+                          {isClusterExperiment &&
+                          data.clusterAvgSize !== '' &&
+                          primaryPower.metric_spec.available_nonnull_n != null ? (
+                            <Flex direction="column" align="end">
+                              <Text color="green" weight="bold">
+                                {Math.floor(
+                                  primaryPower.metric_spec.available_nonnull_n / Number(data.clusterAvgSize),
+                                ).toLocaleString()}{' '}
+                                clusters
+                              </Text>
+                              <Text size="1" color="gray">
+                                {primaryPower.metric_spec.available_nonnull_n.toLocaleString()} participants
+                              </Text>
+                            </Flex>
+                          ) : primaryPower.metric_spec.available_nonnull_n == null ? (
+                            '?'
+                          ) : primaryPower.metric_spec.available_nonnull_n === 0 ||
+                            primaryPower.metric_spec.available_nonnull_n < (primaryPower.target_n ?? 0) ||
+                            primaryPower.metric_spec.available_nonnull_n <
+                              (primaryPower.metric_spec.available_n ?? 0) ? (
+                            <Text color="orange">{primaryPower.metric_spec.available_nonnull_n}</Text>
+                          ) : (
+                            primaryPower.metric_spec.available_nonnull_n
+                          )}
+                        </DataList.Value>
+                      </DataList.Item>
+                      {primaryPower.pct_change_possible !== null && primaryPower.pct_change_possible !== undefined && (
+                        <DataList.Item>
+                          <DataList.Label>Target MDE</DataList.Label>
+                          <DataList.Value>{(primaryPower.pct_change_possible * 100).toFixed(4)}%</DataList.Value>
+                        </DataList.Item>
+                      )}
+                    </DataList.Root>
+                  </Flex>
+                </Card>
+              </>
+            )}
+            {restPower ? (
+              <Card key={'secondary'}>
+                <Flex direction="column" gap={'3'}>
+                  <Heading size={'3'}>Secondary Metrics</Heading>
+                  <Table.Root>
+                    <Table.Header>
+                      <Table.Row>
+                        <Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Required</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Available</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Available (non-null)</Table.ColumnHeaderCell>
+                      </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                      {restPower.map((metricAnalysis, i) => (
+                        <Table.Row key={`rest${i}`}>
+                          <Table.Cell>{metricAnalysis.metric_spec.field_name}</Table.Cell>
+                          <Table.Cell>
+                            {metricAnalysis.sufficient_n ? (
+                              <Badge color={'green'}>Pass</Badge>
+                            ) : (
+                              <Badge color={'orange'}>Failed</Badge>
+                            )}
+                          </Table.Cell>
+                          <Table.Cell align={'right'}>{metricAnalysis.target_n ?? ''}</Table.Cell>
+                          <Table.Cell align={'right'}>
+                            {metricAnalysis.metric_spec.available_n == null ? (
+                              '?'
+                            ) : metricAnalysis.metric_spec.available_n === 0 ||
+                              metricAnalysis.metric_spec.available_n < (metricAnalysis.target_n ?? 0) ? (
+                              <Text color="crimson">{metricAnalysis.metric_spec.available_n}</Text>
+                            ) : (
+                              metricAnalysis.metric_spec.available_n
+                            )}
+                          </Table.Cell>
+                          <Table.Cell align={'right'}>
+                            {metricAnalysis.metric_spec.available_nonnull_n == null ? (
+                              '?'
+                            ) : metricAnalysis.metric_spec.available_nonnull_n === 0 ||
+                              metricAnalysis.metric_spec.available_nonnull_n < (metricAnalysis.target_n ?? 0) ? (
+                              <Text color="crimson">{metricAnalysis.metric_spec.available_nonnull_n}</Text>
+                            ) : (
+                              metricAnalysis.metric_spec.available_nonnull_n
+                            )}
+                          </Table.Cell>
+                        </Table.Row>
+                      ))}
+                    </Table.Body>
+                  </Table.Root>
+                </Flex>
+              </Card>
+            ) : null}
+          </Grid>
+        </Flex>
+      </SectionCard>
 
-			{data.powerCheckResponse !== undefined && !validationError && (
-				<SectionCard title="Select Target Sample Size">
-					<Flex direction="column" gap="3" align="start">
-						<Text>
-							Select target sample size to distribute across all arms:
-						</Text>
-						<Flex direction="column" gap="2" align="center">
-							{!data.powerCheckResponse.analyses
-								.map((a) => a.sufficient_n)
-								.every((sufficient) => sufficient) && (
-								<Callout.Root color="orange">
-									<Callout.Icon>
-										<CrossCircledIcon />
-									</Callout.Icon>
-									<Callout.Text>
-										You don&apos;t have sufficient samples for one or more
-										metrics. You can still proceed with a custom sample size,
-										but consider adjusting your experiment design.
-									</Callout.Text>
-								</Callout.Root>
-							)}
-							<RadioCards.Root
-								columns="1"
-								value={selectedSampleOption}
-								onValueChange={handleSampleOptionChange}
-							>
-								<Flex direction={"row"} gap={"3"} justify={"between"}>
-									<RadioCards.Item
-										value={PowerCheckOption.USE_POWER_CHECK}
-										disabled={
-											powerCheckTarget === undefined || powerCheckTarget === 0
-										}
-									>
-										{isClusterExperiment &&
-										primaryPower?.num_clusters_total != null ? (
-											<Flex direction="column" align="start">
-												<Text>Use minimum sample required:</Text>
-												<Text color="green" weight="bold">
-													{primaryPower.num_clusters_total.toLocaleString()}{" "}
-													clusters
-												</Text>
-												<Text size="1" color="gray">
-													{(powerCheckTarget ?? 0).toLocaleString()}{" "}
-													participants
-												</Text>
-												{/* The recommended size is by definition the
+      {data.powerCheckResponse !== undefined && !validationError && (
+        <SectionCard title="Select Target Sample Size">
+          <Flex direction="column" gap="3" align="start">
+            <Text>Select target sample size to distribute across all arms:</Text>
+            <Flex direction="column" gap="2" align="center">
+              {!data.powerCheckResponse.analyses.map((a) => a.sufficient_n).every((sufficient) => sufficient) && (
+                <Callout.Root color="orange">
+                  <Callout.Icon>
+                    <CrossCircledIcon />
+                  </Callout.Icon>
+                  <Callout.Text>
+                    You don&apos;t have sufficient samples for one or more metrics. You can still proceed with a custom
+                    sample size, but consider adjusting your experiment design.
+                  </Callout.Text>
+                </Callout.Root>
+              )}
+              <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleSampleOptionChange}>
+                <Flex direction={'row'} gap={'3'} justify={'between'}>
+                  <RadioCards.Item
+                    value={PowerCheckOption.USE_POWER_CHECK}
+                    disabled={powerCheckTarget === undefined || powerCheckTarget === 0}
+                  >
+                    {isClusterExperiment && primaryPower?.num_clusters_total != null ? (
+                      <Flex direction="column" align="start">
+                        <Text>Use minimum sample required:</Text>
+                        <Text color="green" weight="bold">
+                          {primaryPower.num_clusters_total.toLocaleString()} clusters
+                        </Text>
+                        <Text size="1" color="gray">
+                          {(powerCheckTarget ?? 0).toLocaleString()} participants
+                        </Text>
+                        {/* The recommended size is by definition the
 													minimum N that achieves the target MDE, so
 													achievable MDE = target MDE here. We render the
 													same line shape as Max/Custom for consistency. */}
-												{renderAchievableMdeLine(
-													targetMdePctNum != null ? targetMdePctNum / 100 : null,
-													{ note: "(matches your Target MDE)" },
-												)}
-											</Flex>
-										) : (
-											<Flex direction="column" align="start">
-												<Text>{`Use minimum sample required: ${powerCheckTarget ?? "N/A"}`}</Text>
-												{renderAchievableMdeLine(
-													targetMdePctNum != null ? targetMdePctNum / 100 : null,
-													{ note: "(matches your Target MDE)" },
-												)}
-											</Flex>
-										)}
-									</RadioCards.Item>
-									<RadioCards.Item
-										value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-										disabled={
-											nonNullSamples === undefined || nonNullSamples === 0
-										}
-									>
-										{isClusterExperiment &&
-										data.clusterAvgSize !== "" &&
-										nonNullSamples != null ? (
-											<Flex direction="column" align="start">
-												<Text>Use all available non-null:</Text>
-												<Text color="green" weight="bold">
-													{/* Use the BE's clusters total ONLY when this is
+                        {renderAchievableMdeLine(targetMdePctNum != null ? targetMdePctNum / 100 : null, {
+                          note: '(matches your Target MDE)',
+                        })}
+                      </Flex>
+                    ) : (
+                      <Flex direction="column" align="start">
+                        <Text>{`Use minimum sample required: ${powerCheckTarget ?? 'N/A'}`}</Text>
+                        {renderAchievableMdeLine(targetMdePctNum != null ? targetMdePctNum / 100 : null, {
+                          note: '(matches your Target MDE)',
+                        })}
+                      </Flex>
+                    )}
+                  </RadioCards.Item>
+                  <RadioCards.Item
+                    value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
+                    disabled={nonNullSamples === undefined || nonNullSamples === 0}
+                  >
+                    {isClusterExperiment && data.clusterAvgSize !== '' && nonNullSamples != null ? (
+                      <Flex direction="column" align="start">
+                        <Text>Use all available non-null:</Text>
+                        <Text color="green" weight="bold">
+                          {/* Use the BE's clusters total ONLY when this is
 														the currently-selected option (otherwise
 														achievablePrimary is for a different N, e.g.
 														whatever the user typed in Custom). Otherwise
 														compute from nonNullSamples/avg_cluster_size. */}
-													{(selectedSampleOption ===
-														PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
-													achievablePrimary?.num_clusters_total != null
-														? achievablePrimary.num_clusters_total
-														: Math.floor(
-																nonNullSamples / Number(data.clusterAvgSize),
-															)
-													).toLocaleString()}{" "}
-													clusters
-												</Text>
-												<Text size="1" color="gray">
-													{nonNullSamples.toLocaleString()} participants
-												</Text>
-												{renderAchievableMdeLine(
-													selectedSampleOption ===
-														PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
-														? achievablePctChange
-														: null,
-													{
-														loading:
-															selectedSampleOption ===
-																PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
-															isRecomputingMde,
-													},
-												)}
-											</Flex>
-										) : (
-											<Flex direction="column" align="start">
-												<Text>{`Use all available non-null samples: ${nonNullSamples}`}</Text>
-												{renderAchievableMdeLine(
-													selectedSampleOption ===
-														PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
-														? achievablePctChange
-														: null,
-													{
-														loading:
-															selectedSampleOption ===
-																PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
-															isRecomputingMde,
-													},
-												)}
-											</Flex>
-										)}
-									</RadioCards.Item>
-									<RadioCards.Item
-										value={PowerCheckOption.ENTER_OWN}
-										disabled={allSamples === undefined || allSamples === 0}
-									>
-										<Flex
-											align="start"
-											direction={isClusterExperiment ? "column" : "row"}
-											gap="2"
-											wrap="wrap"
-										>
-											<span style={{ paddingTop: "4px" }}>
-												Use custom sample size:
-											</span>
-											{isClusterExperiment ? (
-												<div style={{ pointerEvents: "auto", width: "100%" }}>
-													<Flex direction="column" gap="2">
-														<Flex direction="column" gap="1">
-															<Text
-																size="1"
-																color="gray"
-																style={{ textTransform: "uppercase" }}
-															>
-																Clusters
-															</Text>
-															<TextField.Root
-																style={{ width: "180px" }}
-																size="2"
-																type="number"
-																min={0}
-																value={clustersInput}
-																placeholder={
-																	primaryPower?.num_clusters_total != null
-																		? `e.g. ${primaryPower.num_clusters_total}`
-																		: "# clusters"
-																}
-																onChange={(e) => {
-																	editingRef.current = "clusters";
-																	setClustersInput(e.target.value);
-																}}
-															/>
-														</Flex>
-														<Flex direction="column" gap="1">
-															<Text
-																size="1"
-																color="gray"
-																style={{ textTransform: "uppercase" }}
-															>
-																Participants
-															</Text>
-															<TextField.Root
-																style={{ width: "180px" }}
-																size="2"
-																type="number"
-																max={allSamples ?? undefined}
-																value={participantsInput}
-																placeholder={
-																	primaryPower?.target_n != null
-																		? `e.g. ${primaryPower.target_n.toLocaleString()}`
-																		: "# participants"
-																}
-																onChange={(e) => {
-																	editingRef.current = "participants";
-																	setParticipantsInput(e.target.value);
-																}}
-															/>
-														</Flex>
-														{renderAchievableMdeLine(
-															selectedSampleOption ===
-																PowerCheckOption.ENTER_OWN
-																? achievablePctChange
-																: null,
-															{
-																loading:
-																	selectedSampleOption ===
-																		PowerCheckOption.ENTER_OWN &&
-																	isRecomputingMde,
-															},
-														)}
-													</Flex>
-												</div>
-											) : (
-												<div style={{ pointerEvents: "auto" }}>
-													<TextField.Root
-														style={{ width: "250px" }}
-														size="2"
-														type="number"
-														max={allSamples ?? undefined}
-														onChange={(e) =>
-															dispatch({
-																type: "set-chosen-n",
-																value:
-																	e.target.value === ""
-																		? undefined
-																		: Number(e.target.value),
-															})
-														}
-														placeholder="Type your own desired #."
-													/>
-													{renderAchievableMdeLine(
-														selectedSampleOption ===
-															PowerCheckOption.ENTER_OWN
-															? achievablePctChange
-															: null,
-														{
-															loading:
-																selectedSampleOption ===
-																	PowerCheckOption.ENTER_OWN &&
-																isRecomputingMde,
-														},
-													)}
-												</div>
-											)}
-										</Flex>
-									</RadioCards.Item>
-								</Flex>
-							</RadioCards.Root>
-						</Flex>
-					</Flex>
-				</SectionCard>
-			)}
-		</Flex>
-	);
+                          {(selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
+                          achievablePrimary?.num_clusters_total != null
+                            ? achievablePrimary.num_clusters_total
+                            : Math.floor(nonNullSamples / Number(data.clusterAvgSize))
+                          ).toLocaleString()}{' '}
+                          clusters
+                        </Text>
+                        <Text size="1" color="gray">
+                          {nonNullSamples.toLocaleString()} participants
+                        </Text>
+                        {renderAchievableMdeLine(
+                          selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
+                            ? achievablePctChange
+                            : null,
+                          {
+                            loading:
+                              selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && isRecomputingMde,
+                          },
+                        )}
+                      </Flex>
+                    ) : (
+                      <Flex direction="column" align="start">
+                        <Text>{`Use all available non-null samples: ${nonNullSamples}`}</Text>
+                        {renderAchievableMdeLine(
+                          selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
+                            ? achievablePctChange
+                            : null,
+                          {
+                            loading:
+                              selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && isRecomputingMde,
+                          },
+                        )}
+                      </Flex>
+                    )}
+                  </RadioCards.Item>
+                  <RadioCards.Item
+                    value={PowerCheckOption.ENTER_OWN}
+                    disabled={allSamples === undefined || allSamples === 0}
+                  >
+                    <Flex align="start" direction={isClusterExperiment ? 'column' : 'row'} gap="2" wrap="wrap">
+                      <span style={{ paddingTop: '4px' }}>Use custom sample size:</span>
+                      {isClusterExperiment ? (
+                        <div style={{ pointerEvents: 'auto', width: '100%' }}>
+                          <Flex direction="column" gap="2">
+                            <Flex direction="column" gap="1">
+                              <Text size="1" color="gray" style={{ textTransform: 'uppercase' }}>
+                                Clusters
+                              </Text>
+                              <TextField.Root
+                                style={{ width: '180px' }}
+                                size="2"
+                                type="number"
+                                min={0}
+                                value={clustersInput}
+                                placeholder={
+                                  primaryPower?.num_clusters_total != null
+                                    ? `e.g. ${primaryPower.num_clusters_total}`
+                                    : '# clusters'
+                                }
+                                onChange={(e) => {
+                                  editingRef.current = 'clusters';
+                                  setClustersInput(e.target.value);
+                                }}
+                              />
+                            </Flex>
+                            <Flex direction="column" gap="1">
+                              <Text size="1" color="gray" style={{ textTransform: 'uppercase' }}>
+                                Participants
+                              </Text>
+                              <TextField.Root
+                                style={{ width: '180px' }}
+                                size="2"
+                                type="number"
+                                max={allSamples ?? undefined}
+                                value={participantsInput}
+                                placeholder={
+                                  primaryPower?.target_n != null
+                                    ? `e.g. ${primaryPower.target_n.toLocaleString()}`
+                                    : '# participants'
+                                }
+                                onChange={(e) => {
+                                  editingRef.current = 'participants';
+                                  setParticipantsInput(e.target.value);
+                                }}
+                              />
+                            </Flex>
+                            {renderAchievableMdeLine(
+                              selectedSampleOption === PowerCheckOption.ENTER_OWN ? achievablePctChange : null,
+                              {
+                                loading: selectedSampleOption === PowerCheckOption.ENTER_OWN && isRecomputingMde,
+                              },
+                            )}
+                          </Flex>
+                        </div>
+                      ) : (
+                        <div style={{ pointerEvents: 'auto' }}>
+                          <TextField.Root
+                            style={{ width: '250px' }}
+                            size="2"
+                            type="number"
+                            max={allSamples ?? undefined}
+                            onChange={(e) =>
+                              dispatch({
+                                type: 'set-chosen-n',
+                                value: e.target.value === '' ? undefined : Number(e.target.value),
+                              })
+                            }
+                            placeholder="Type your own desired #."
+                          />
+                          {renderAchievableMdeLine(
+                            selectedSampleOption === PowerCheckOption.ENTER_OWN ? achievablePctChange : null,
+                            {
+                              loading: selectedSampleOption === PowerCheckOption.ENTER_OWN && isRecomputingMde,
+                            },
+                          )}
+                        </div>
+                      )}
+                    </Flex>
+                  </RadioCards.Item>
+                </Flex>
+              </RadioCards.Root>
+            </Flex>
+          </Flex>
+        </SectionCard>
+      )}
+    </Flex>
+  );
 }

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -82,13 +82,47 @@ function RunPowerCheckButton({
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 	const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
 	const [validationError, setValidationError] = useState<ZodError | null>(null);
-	const [powerCheckTarget, setPowerCheckTarget] = useState<
-		number | undefined
-	>();
-	const [nonNullSamples, setNonNullSamples] = useState<number | undefined>();
-	const [allSamples, setAllSamples] = useState<number | undefined>();
+
+	// Derived from the saved power-check response. We deliberately do NOT
+	// hold these as useState — that's what caused the "0 participants /
+	// undefined samples" bug when navigating away to the Summary screen and
+	// hitting Back: the component remounts, useState resets to undefined,
+	// but data.powerCheckResponse (form state) persists, so the displays
+	// went out of sync with the underlying data. Computing them from the
+	// response makes them survive remounts for free.
+	const primaryFromSaved = data.powerCheckResponse?.analyses.find(
+		(a) =>
+			a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+	);
+	const powerCheckTarget: number | undefined =
+		primaryFromSaved?.target_n ?? undefined;
+	const nonNullSamples: number | undefined =
+		primaryFromSaved?.metric_spec.available_nonnull_n ?? undefined;
+	const allSamples: number | undefined =
+		primaryFromSaved?.metric_spec.available_n ?? undefined;
+
+	// selectedSampleOption is the radio's local UI state. We seed it lazily
+	// (once, on mount) from data.desiredN compared against the saved
+	// target/non-null sizes so the user's previous choice survives
+	// navigating away and back. After mount, it's driven by user clicks /
+	// handlePowerCheck like before — keeping it as state lets the user
+	// click "Custom" without immediately committing a desiredN.
 	const [selectedSampleOption, setSelectedSampleOption] =
-		useState<PowerCheckOption>(PowerCheckOption.USE_POWER_CHECK);
+		useState<PowerCheckOption>(() => {
+			if (!data.powerCheckResponse) return PowerCheckOption.USE_POWER_CHECK;
+			const primary = data.powerCheckResponse.analyses.find(
+				(a) =>
+					a.metric_spec.field_name ===
+					data.primaryMetric?.metric.field_name,
+			);
+			const target = primary?.target_n ?? undefined;
+			const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
+			if (data.desiredN === undefined) return PowerCheckOption.NONE;
+			if (data.desiredN === target) return PowerCheckOption.USE_POWER_CHECK;
+			if (data.desiredN === nonNull)
+				return PowerCheckOption.USE_ALL_NON_NULL_SAMPLES;
+			return PowerCheckOption.ENTER_OWN;
+		});
 
 	// Issue #217: cluster experiments show "clusters first, participants underneath".
 	const isClusterExperiment =
@@ -108,8 +142,36 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 	// derived sibling value (and the participants value to set-chosen-n) after
 	// they stop typing.
 	const avgClusterSize = Number(data.clusterAvgSize ?? "");
-	const [clustersInput, setClustersInput] = useState("");
-	const [participantsInput, setParticipantsInput] = useState("");
+
+	// Lazy-init the Custom inputs from data.desiredN so a previously-entered
+	// custom value survives navigating to Summary and clicking Back. Only
+	// seed when desiredN is set AND it doesn't match the recommended or
+	// max-available size (those are handled by the other two radio cards).
+	const initialCustomFromState = (() => {
+		if (data.desiredN === undefined) return { clusters: "", participants: "" };
+		const primary = data.powerCheckResponse?.analyses.find(
+			(a) =>
+				a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+		);
+		const target = primary?.target_n ?? undefined;
+		const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
+		if (data.desiredN === target || data.desiredN === nonNull) {
+			return { clusters: "", participants: "" };
+		}
+		const participants = String(data.desiredN);
+		const clusters =
+			Number.isFinite(avgClusterSize) && avgClusterSize > 0
+				? String(Math.ceil(data.desiredN / avgClusterSize))
+				: "";
+		return { clusters, participants };
+	})();
+
+	const [clustersInput, setClustersInput] = useState<string>(
+		initialCustomFromState.clusters,
+	);
+	const [participantsInput, setParticipantsInput] = useState<string>(
+		initialCustomFromState.participants,
+	);
 	// Which field the user is actively editing; used to avoid feedback loops
 	// when the debounce timer writes the derived value into the other field.
 	const editingRef = useRef<"clusters" | "participants" | null>(null);
@@ -152,6 +214,98 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 
 	const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
+	// Achievable MDE recompute: when the user picks Max-available or Custom, fire
+	// a fresh power-check call with desired_n included in the design spec. The BE
+	// switches to MDE mode and returns the achievable MDE plus the cluster split
+	// for the chosen N. The result is stored on form state so it can be (a) shown
+	// inline next to the radio option and (b) persisted as the experiment's
+	// power_analyses at save time. Custom typing is already debounced upstream
+	// (set-chosen-n only fires after 500ms), so this effect only sees the final
+	// committed value.
+	const [isRecomputingMde, setIsRecomputingMde] = useState(false);
+	useEffect(() => {
+		// Recompute only makes sense when the user has chosen a non-recommended
+		// sample size. For "Use minimum sample required" the original
+		// powerCheckResponse already carries the right answer (achievable MDE
+		// equals the user's target MDE by construction).
+		if (data.desiredN === undefined) return;
+		if (selectedSampleOption === PowerCheckOption.USE_POWER_CHECK) return;
+		if (selectedSampleOption === PowerCheckOption.NONE) return;
+		if (data.desiredN === powerCheckTarget) return;
+		if (!data.tableName || !data.primaryKey || !data.primaryMetric) return;
+
+		let cancelled = false;
+		setIsRecomputingMde(true);
+		// `void` here intentionally discards the promise — the IIFE manages its
+		// own lifecycle via the `cancelled` flag and the cleanup function below.
+		void (async () => {
+			try {
+				const design_spec = convertToFrequentistDesignSpec(data);
+				const response = await trigger({ design_spec });
+				if (cancelled) return;
+				dispatch({
+					type: "set-achievable-power-check-response",
+					response,
+				});
+			} catch {
+				// Swallow: if the recompute fails the inline display just doesn't
+				// show an achievable MDE. Validation issues are already surfaced
+				// by the manual Run-Power-Check flow on the same page.
+			} finally {
+				if (!cancelled) setIsRecomputingMde(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data.desiredN, selectedSampleOption, powerCheckTarget]);
+
+	// Read the achievable MDE for the primary metric (cluster-aware fields are
+	// populated by solve_for_mde_cluster on the BE; for non-cluster experiments
+	// pct_change_possible is still populated, so this works for both).
+	const achievablePrimary = data.achievablePowerCheckResponse?.analyses.find(
+		(a) =>
+			a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+	);
+	const achievablePctChange = achievablePrimary?.pct_change_possible ?? null;
+
+	// Target MDE the user requested (string from the form, expressed as a
+	// percent). Used as the "achievable MDE" for the recommended option, since
+	// by construction the recommended sample size hits the target exactly.
+	const targetMdeStr = data.primaryMetric?.mde;
+	const targetMdePctNum =
+		targetMdeStr !== undefined && targetMdeStr !== ""
+			? Number(targetMdeStr)
+			: null;
+
+	/** One-line "Achievable MDE: X%" annotation, sized to fit under a radio card.
+	 * Blue mirrors how Target MDE is shown on the saved-experiment Analysis bar
+	 * — same statistical concept, different perspective. Green stays reserved
+	 * for cluster counts (clusters/participants colorway) to keep that signal
+	 * unambiguous. Loading stays gray so users can tell "computing" from a real
+	 * value at a glance. */
+	const renderAchievableMdeLine = (
+		pctChange: number | null | undefined,
+		opts: { loading?: boolean; note?: string } = {},
+	) => {
+		if (opts.loading) {
+			return (
+				<Text size="1" color="gray">
+					Achievable MDE: computing…
+				</Text>
+			);
+		}
+		if (pctChange == null) return null;
+		const pct = (pctChange * 100).toFixed(2);
+		return (
+			<Text size="1" color="blue">
+				Achievable MDE: <strong>{pct}%</strong>
+				{opts.note ? ` ${opts.note}` : ""}
+			</Text>
+		);
+	};
+
 	const handlePowerCheck = async (
 		event: React.MouseEvent<HTMLButtonElement>,
 	) => {
@@ -176,9 +330,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 				response,
 				desiredN: undefined,
 			});
-			setPowerCheckTarget(primary?.target_n ?? undefined);
-			setNonNullSamples(primary?.metric_spec.available_nonnull_n ?? 0);
-			setAllSamples(primary?.metric_spec.available_n ?? 0);
+			// powerCheckTarget / nonNullSamples / allSamples are derived from
+			// data.powerCheckResponse now (see top of component), so the dispatch
+			// above is enough — no separate setters needed.
 			if (primary?.sufficient_n) {
 				setSelectedSampleOption(PowerCheckOption.USE_POWER_CHECK);
 				dispatch({
@@ -583,9 +737,23 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 													{(powerCheckTarget ?? 0).toLocaleString()}{" "}
 													participants
 												</Text>
+												{/* The recommended size is by definition the
+													minimum N that achieves the target MDE, so
+													achievable MDE = target MDE here. We render the
+													same line shape as Max/Custom for consistency. */}
+												{renderAchievableMdeLine(
+													targetMdePctNum != null ? targetMdePctNum / 100 : null,
+													{ note: "(matches your Target MDE)" },
+												)}
 											</Flex>
 										) : (
-											`Use minimum sample required: ${powerCheckTarget ?? "N/A"}`
+											<Flex direction="column" align="start">
+												<Text>{`Use minimum sample required: ${powerCheckTarget ?? "N/A"}`}</Text>
+												{renderAchievableMdeLine(
+													targetMdePctNum != null ? targetMdePctNum / 100 : null,
+													{ note: "(matches your Target MDE)" },
+												)}
+											</Flex>
 										)}
 									</RadioCards.Item>
 									<RadioCards.Item
@@ -600,17 +768,53 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 											<Flex direction="column" align="start">
 												<Text>Use all available non-null:</Text>
 												<Text color="green" weight="bold">
-													{Math.floor(
-														nonNullSamples / Number(data.clusterAvgSize),
+													{/* Use the BE's clusters total ONLY when this is
+														the currently-selected option (otherwise
+														achievablePrimary is for a different N, e.g.
+														whatever the user typed in Custom). Otherwise
+														compute from nonNullSamples/avg_cluster_size. */}
+													{(selectedSampleOption ===
+														PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
+													achievablePrimary?.num_clusters_total != null
+														? achievablePrimary.num_clusters_total
+														: Math.floor(
+																nonNullSamples / Number(data.clusterAvgSize),
+															)
 													).toLocaleString()}{" "}
 													clusters
 												</Text>
 												<Text size="1" color="gray">
 													{nonNullSamples.toLocaleString()} participants
 												</Text>
+												{renderAchievableMdeLine(
+													selectedSampleOption ===
+														PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
+														? achievablePctChange
+														: null,
+													{
+														loading:
+															selectedSampleOption ===
+																PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
+															isRecomputingMde,
+													},
+												)}
 											</Flex>
 										) : (
-											`Use all available non-null samples: ${nonNullSamples}`
+											<Flex direction="column" align="start">
+												<Text>{`Use all available non-null samples: ${nonNullSamples}`}</Text>
+												{renderAchievableMdeLine(
+													selectedSampleOption ===
+														PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
+														? achievablePctChange
+														: null,
+													{
+														loading:
+															selectedSampleOption ===
+																PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
+															isRecomputingMde,
+													},
+												)}
+											</Flex>
 										)}
 									</RadioCards.Item>
 									<RadioCards.Item
@@ -679,6 +883,18 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 																}}
 															/>
 														</Flex>
+														{renderAchievableMdeLine(
+															selectedSampleOption ===
+																PowerCheckOption.ENTER_OWN
+																? achievablePctChange
+																: null,
+															{
+																loading:
+																	selectedSampleOption ===
+																		PowerCheckOption.ENTER_OWN &&
+																	isRecomputingMde,
+															},
+														)}
 													</Flex>
 												</div>
 											) : (
@@ -699,6 +915,18 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 														}
 														placeholder="Type your own desired #."
 													/>
+													{renderAchievableMdeLine(
+														selectedSampleOption ===
+															PowerCheckOption.ENTER_OWN
+															? achievablePctChange
+															: null,
+														{
+															loading:
+																selectedSampleOption ===
+																	PowerCheckOption.ENTER_OWN &&
+																isRecomputingMde,
+														},
+													)}
 												</div>
 											)}
 										</Flex>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -1,378 +1,714 @@
-'use client';
+"use client";
 
+import { usePowerCheck } from "@/api/admin";
+import { SectionCard } from "@/components/ui/cards/section-card";
+import { GenericErrorCallout } from "@/components/ui/generic-error";
 import {
-  Badge,
-  Button,
-  Callout,
-  Card,
-  DataList,
-  Flex,
-  Grid,
-  Heading,
-  RadioCards,
-  Spinner,
-  Table,
-  Text,
-  TextField,
-} from '@radix-ui/themes';
-import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
-import { ExperimentFormData } from './experiment-form-def';
-import { ExperimentFreqStackScreenMessage } from './experiment-freq-stack-screen';
-import { usePowerCheck } from '@/api/admin';
-import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
-import { ZodError } from 'zod';
-import { useState } from 'react';
-import { SectionCard } from '@/components/ui/cards/section-card';
+	CheckCircledIcon,
+	CrossCircledIcon,
+	LightningBoltIcon,
+} from "@radix-ui/react-icons";
+import {
+	Badge,
+	Button,
+	Callout,
+	Card,
+	DataList,
+	Flex,
+	Grid,
+	Heading,
+	RadioCards,
+	Spinner,
+	Table,
+	Text,
+	TextField,
+} from "@radix-ui/themes";
+import { useEffect, useRef, useState } from "react";
+import { ZodError } from "zod";
+import { ExperimentFormData } from "./experiment-form-def";
+import { convertToFrequentistDesignSpec } from "./experiment-form-helpers";
+import { ExperimentFreqStackScreenMessage } from "./experiment-freq-stack-screen";
 
 enum PowerCheckOption {
-  USE_POWER_CHECK = 'use_power_check',
-  USE_ALL_NON_NULL_SAMPLES = 'use_all_non_null_samples',
-  ENTER_OWN = 'enter_own',
-  NONE = '',
+	USE_POWER_CHECK = "use_power_check",
+	USE_ALL_NON_NULL_SAMPLES = "use_all_non_null_samples",
+	ENTER_OWN = "enter_own",
+	NONE = "",
 }
 
 interface PowerCheckSectionProps {
-  data: ExperimentFormData;
-  dispatch: (msg: ExperimentFreqStackScreenMessage) => void;
+	data: ExperimentFormData;
+	dispatch: (msg: ExperimentFreqStackScreenMessage) => void;
 }
 
-const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData) => {
-  const reasons = [];
-  if (isMutating) {
-    reasons.push('Running power check');
-  }
-  if (data.primaryKey === undefined) {
-    reasons.push('Please select a unique ID field.');
-  }
-  if (data.primaryMetric === undefined) {
-    reasons.push('Please select a primary metric.');
-  }
-  return { enabled: !reasons.length, reason: reasons.join('\n') };
+const isPowerCheckButtonEnabled = (
+	isMutating: boolean,
+	data: ExperimentFormData,
+) => {
+	const reasons = [];
+	if (isMutating) {
+		reasons.push("Running power check");
+	}
+	if (data.primaryKey === undefined) {
+		reasons.push("Please select a unique ID field.");
+	}
+	if (data.primaryMetric === undefined) {
+		reasons.push("Please select a primary metric.");
+	}
+	return { enabled: !reasons.length, reason: reasons.join("\n") };
 };
 
 interface PowerCheckButtonProps {
-  enabled: boolean;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
-  loading: boolean;
+	enabled: boolean;
+	onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
+	loading: boolean;
 }
 
-function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProps) {
-  return (
-    <Button disabled={!enabled} onClick={onClick} style={{ minWidth: '25%' }}>
-      <Spinner loading={loading}>
-        <LightningBoltIcon />
-      </Spinner>
-      Run Power Check
-    </Button>
-  );
+function RunPowerCheckButton({
+	enabled,
+	onClick,
+	loading,
+}: PowerCheckButtonProps) {
+	return (
+		<Button disabled={!enabled} onClick={onClick} style={{ minWidth: "25%" }}>
+			<Spinner loading={loading}>
+				<LightningBoltIcon />
+			</Spinner>
+			Run Power Check
+		</Button>
+	);
 }
 
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
-  const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
-  const [validationError, setValidationError] = useState<ZodError | null>(null);
-  const [powerCheckTarget, setPowerCheckTarget] = useState<number | undefined>();
-  const [nonNullSamples, setNonNullSamples] = useState<number | undefined>();
-  const [allSamples, setAllSamples] = useState<number | undefined>();
-  const [selectedSampleOption, setSelectedSampleOption] = useState<PowerCheckOption>(PowerCheckOption.USE_POWER_CHECK);
+	const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
+	const [validationError, setValidationError] = useState<ZodError | null>(null);
+	const [powerCheckTarget, setPowerCheckTarget] = useState<
+		number | undefined
+	>();
+	const [nonNullSamples, setNonNullSamples] = useState<number | undefined>();
+	const [allSamples, setAllSamples] = useState<number | undefined>();
+	const [selectedSampleOption, setSelectedSampleOption] =
+		useState<PowerCheckOption>(PowerCheckOption.USE_POWER_CHECK);
 
-  const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
+	// Issue #217: cluster experiments show "clusters first, participants underneath".
+	const isClusterExperiment =
+		data.experimentType === "freq_cluster_preassigned";
+	// CV > 0.5 triggers a high-variability warning per the issue mockups.
+	const cvNum = Number(data.clusterCv ?? "");
+	const hasHighVariability =
+		isClusterExperiment &&
+		data.clusterCv !== undefined &&
+		data.clusterCv !== "" &&
+		!Number.isNaN(cvNum) &&
+		cvNum > 0.5;
 
-  const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    setValidationError(null);
+	// Issue #217: linked Clusters ↔ Participants inputs on the custom-N option,
+	// with a 0.5s debounce that auto-fills the other field. We track each input
+	// as a string so the user can type freely; the debounce timer commits the
+	// derived sibling value (and the participants value to set-chosen-n) after
+	// they stop typing.
+	const avgClusterSize = Number(data.clusterAvgSize ?? "");
+	const [clustersInput, setClustersInput] = useState("");
+	const [participantsInput, setParticipantsInput] = useState("");
+	// Which field the user is actively editing; used to avoid feedback loops
+	// when the debounce timer writes the derived value into the other field.
+	const editingRef = useRef<"clusters" | "participants" | null>(null);
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    if (!data.tableName || !data.primaryKey || !data.primaryMetric) {
-      return;
-    }
+	useEffect(() => {
+		if (!isClusterExperiment) return;
+		if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+		const which = editingRef.current;
+		if (which === null) return;
+		debounceRef.current = setTimeout(() => {
+			if (!Number.isFinite(avgClusterSize) || avgClusterSize <= 0) return;
+			if (which === "clusters") {
+				const n = Number(clustersInput);
+				if (!Number.isFinite(n) || n <= 0) {
+					setParticipantsInput("");
+					dispatch({ type: "set-chosen-n", value: undefined });
+					return;
+				}
+				const participants = Math.round(n * avgClusterSize);
+				setParticipantsInput(String(participants));
+				dispatch({ type: "set-chosen-n", value: participants });
+			} else {
+				const n = Number(participantsInput);
+				if (!Number.isFinite(n) || n <= 0) {
+					setClustersInput("");
+					dispatch({ type: "set-chosen-n", value: undefined });
+					return;
+				}
+				setClustersInput(String(Math.ceil(n / avgClusterSize)));
+				dispatch({ type: "set-chosen-n", value: n });
+			}
+			editingRef.current = null;
+		}, 500);
+		return () => {
+			if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [clustersInput, participantsInput, avgClusterSize, isClusterExperiment]);
 
-    // TODO: reimplement this to be simpler
-    try {
-      const design_spec = convertToFrequentistDesignSpec(data);
-      const response = await trigger({ design_spec });
-      const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
+	const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
-      dispatch({ type: 'set-power-check-response', response, desiredN: undefined });
-      setPowerCheckTarget(primary?.target_n ?? undefined);
-      setNonNullSamples(primary?.metric_spec.available_nonnull_n ?? 0);
-      setAllSamples(primary?.metric_spec.available_n ?? 0);
-      if (primary?.sufficient_n) {
-        setSelectedSampleOption(PowerCheckOption.USE_POWER_CHECK);
-        dispatch({ type: 'set-chosen-n', value: primary?.target_n ?? undefined });
-      } else {
-        setSelectedSampleOption(PowerCheckOption.NONE);
-      }
-    } catch (err) {
-      if (err instanceof ZodError) {
-        setValidationError(err);
-        return;
-      }
-      throw err;
-    }
-  };
+	const handlePowerCheck = async (
+		event: React.MouseEvent<HTMLButtonElement>,
+	) => {
+		event.preventDefault();
+		setValidationError(null);
 
-  const handleSampleOptionChange = (value: PowerCheckOption) => {
-    setSelectedSampleOption(value);
-    switch (value) {
-      case PowerCheckOption.USE_POWER_CHECK:
-        dispatch({ type: 'set-chosen-n', value: powerCheckTarget });
-        break;
-      case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
-        dispatch({ type: 'set-chosen-n', value: nonNullSamples });
-        break;
-      case PowerCheckOption.ENTER_OWN:
-      case PowerCheckOption.NONE:
-        dispatch({ type: 'set-chosen-n', value: undefined });
-        break;
-    }
-  };
+		if (!data.tableName || !data.primaryKey || !data.primaryMetric) {
+			return;
+		}
 
-  const primaryPower =
-    data.powerCheckResponse !== undefined && !validationError ? data.powerCheckResponse.analyses[0] : undefined;
-  const restPower =
-    data.powerCheckResponse !== undefined && !validationError && data.powerCheckResponse.analyses.length > 1
-      ? data.powerCheckResponse.analyses.slice(1)
-      : undefined;
+		// TODO: reimplement this to be simpler
+		try {
+			const design_spec = convertToFrequentistDesignSpec(data);
+			const response = await trigger({ design_spec });
+			const primary = response.analyses.find(
+				(a) =>
+					a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+			);
 
-  return (
-    <Flex direction="column" gap={'3'}>
-      <Flex direction="row" gap="4">
-        <Flex direction="column" gap="1" flexGrow="1">
-          <Text as="label" size="2" weight="medium">
-            Confidence (%)
-          </Text>
-          <TextField.Root
-            type="number"
-            min={50}
-            max={99}
-            value={data.confidence ?? '95'}
-            onChange={(e) => dispatch({ type: 'set-confidence', value: e.target.value })}
-            placeholder="95"
-          />
-        </Flex>
-        <Flex direction="column" gap="1" flexGrow="1">
-          <Text as="label" size="2" weight="medium">
-            Power (%)
-          </Text>
-          <TextField.Root
-            type="number"
-            min={50}
-            max={99}
-            value={data.power ?? '80'}
-            onChange={(e) => dispatch({ type: 'set-power', value: e.target.value })}
-            placeholder="80"
-          />
-        </Flex>
-      </Flex>
+			dispatch({
+				type: "set-power-check-response",
+				response,
+				desiredN: undefined,
+			});
+			setPowerCheckTarget(primary?.target_n ?? undefined);
+			setNonNullSamples(primary?.metric_spec.available_nonnull_n ?? 0);
+			setAllSamples(primary?.metric_spec.available_n ?? 0);
+			if (primary?.sufficient_n) {
+				setSelectedSampleOption(PowerCheckOption.USE_POWER_CHECK);
+				dispatch({
+					type: "set-chosen-n",
+					value: primary?.target_n ?? undefined,
+				});
+			} else {
+				setSelectedSampleOption(PowerCheckOption.NONE);
+			}
+		} catch (err) {
+			if (err instanceof ZodError) {
+				setValidationError(err);
+				return;
+			}
+			throw err;
+		}
+	};
 
-      <SectionCard title="Analysis">
-        <Flex direction="column" gap="3" align="center">
-          <RunPowerCheckButton enabled={enabled} onClick={handlePowerCheck} loading={isMutating} />
+	const handleSampleOptionChange = (value: PowerCheckOption) => {
+		setSelectedSampleOption(value);
+		switch (value) {
+			case PowerCheckOption.USE_POWER_CHECK:
+				dispatch({ type: "set-chosen-n", value: powerCheckTarget });
+				break;
+			case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
+				dispatch({ type: "set-chosen-n", value: nonNullSamples });
+				break;
+			case PowerCheckOption.ENTER_OWN:
+			case PowerCheckOption.NONE:
+				dispatch({ type: "set-chosen-n", value: undefined });
+				break;
+		}
+	};
 
-          {error && (
-            <Flex align="center" gap="2">
-              <GenericErrorCallout title={'Power check failed'} error={error} />
-            </Flex>
-          )}
+	const primaryPower =
+		data.powerCheckResponse !== undefined && !validationError
+			? data.powerCheckResponse.analyses[0]
+			: undefined;
+	const restPower =
+		data.powerCheckResponse !== undefined &&
+		!validationError &&
+		data.powerCheckResponse.analyses.length > 1
+			? data.powerCheckResponse.analyses.slice(1)
+			: undefined;
 
-          {validationError && (
-            <Flex align="center" gap="2">
-              <GenericErrorCallout
-                title={'Validation failed'}
-                message={validationError.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('\n')}
-              />
-            </Flex>
-          )}
+	return (
+		<Flex direction="column" gap={"3"}>
+			<Flex direction="row" gap="4">
+				<Flex direction="column" gap="1" flexGrow="1">
+					<Text as="label" size="2" weight="medium">
+						Confidence (%)
+					</Text>
+					<TextField.Root
+						type="number"
+						min={50}
+						max={99}
+						value={data.confidence ?? "95"}
+						onChange={(e) =>
+							dispatch({ type: "set-confidence", value: e.target.value })
+						}
+						placeholder="95"
+					/>
+				</Flex>
+				<Flex direction="column" gap="1" flexGrow="1">
+					<Text as="label" size="2" weight="medium">
+						Power (%)
+					</Text>
+					<TextField.Root
+						type="number"
+						min={50}
+						max={99}
+						value={data.power ?? "80"}
+						onChange={(e) =>
+							dispatch({ type: "set-power", value: e.target.value })
+						}
+						placeholder="80"
+					/>
+				</Flex>
+			</Flex>
 
-          {primaryPower && (
-            <Callout.Root color={primaryPower.sufficient_n ? 'green' : 'red'}>
-              <Callout.Icon>{primaryPower.sufficient_n ? <CheckCircledIcon /> : <CrossCircledIcon />}</Callout.Icon>
-              <Callout.Text>
-                {primaryPower.msg?.msg ||
-                  (primaryPower.sufficient_n
-                    ? `The experiment has sufficient power.`
-                    : `The experiment does not have sufficient power.`)}
-              </Callout.Text>
-            </Callout.Root>
-          )}
+			<SectionCard title="Analysis">
+				<Flex direction="column" gap="3" align="center">
+					<RunPowerCheckButton
+						enabled={enabled}
+						onClick={handlePowerCheck}
+						loading={isMutating}
+					/>
 
-          <Grid rows={'1'} columns={restPower ? '2' : '1'} gap={'3'}>
-            {primaryPower && (
-              <>
-                <Card>
-                  <Flex direction="column" gap={'3'}>
-                    <Heading size={'3'}>Primary Metric: {primaryPower.metric_spec.field_name}</Heading>
-                    <DataList.Root>
-                      <DataList.Item>
-                        <DataList.Label>Status</DataList.Label>
-                        <DataList.Value>
-                          {primaryPower.sufficient_n ? (
-                            <Badge color={'green'}>Pass</Badge>
-                          ) : (
-                            <Badge color={'red'}>Failed</Badge>
-                          )}
-                        </DataList.Value>
-                      </DataList.Item>
-                      <DataList.Item>
-                        <DataList.Label>Required</DataList.Label>
-                        <DataList.Value>{primaryPower.target_n || '?'}</DataList.Value>
-                      </DataList.Item>
-                      <DataList.Item>
-                        <DataList.Label>Available</DataList.Label>
-                        <DataList.Value>
-                          {' '}
-                          {primaryPower.metric_spec.available_n == null ? (
-                            '?'
-                          ) : primaryPower.metric_spec.available_n === 0 ||
-                            primaryPower.metric_spec.available_n < (primaryPower.target_n ?? 0) ? (
-                            <span color="crimson">{primaryPower.metric_spec.available_n}</span>
-                          ) : (
-                            primaryPower.metric_spec.available_n
-                          )}
-                        </DataList.Value>
-                      </DataList.Item>
-                      <DataList.Item>
-                        <DataList.Label>Available (non-null)</DataList.Label>
-                        <DataList.Value>
-                          {primaryPower.metric_spec.available_nonnull_n == null ? (
-                            '?'
-                          ) : primaryPower.metric_spec.available_nonnull_n === 0 ||
-                            primaryPower.metric_spec.available_nonnull_n < (primaryPower.target_n ?? 0) ||
-                            primaryPower.metric_spec.available_nonnull_n <
-                              (primaryPower.metric_spec.available_n ?? 0) ? (
-                            <Text color="orange">{primaryPower.metric_spec.available_nonnull_n}</Text>
-                          ) : (
-                            primaryPower.metric_spec.available_nonnull_n
-                          )}
-                        </DataList.Value>
-                      </DataList.Item>
-                      {primaryPower.pct_change_possible !== null && primaryPower.pct_change_possible !== undefined && (
-                        <DataList.Item>
-                          <DataList.Label>MME</DataList.Label>
-                          <DataList.Value>{(primaryPower.pct_change_possible * 100).toFixed(4)}%</DataList.Value>
-                        </DataList.Item>
-                      )}
-                    </DataList.Root>
-                  </Flex>
-                </Card>
-              </>
-            )}
-            {restPower ? (
-              <Card key={'secondary'}>
-                <Flex direction="column" gap={'3'}>
-                  <Heading size={'3'}>Secondary Metrics</Heading>
-                  <Table.Root>
-                    <Table.Header>
-                      <Table.Row>
-                        <Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Required</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Available</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Available (non-null)</Table.ColumnHeaderCell>
-                      </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                      {restPower.map((metricAnalysis, i) => (
-                        <Table.Row key={`rest${i}`}>
-                          <Table.Cell>{metricAnalysis.metric_spec.field_name}</Table.Cell>
-                          <Table.Cell>
-                            {metricAnalysis.sufficient_n ? (
-                              <Badge color={'green'}>Pass</Badge>
-                            ) : (
-                              <Badge color={'orange'}>Failed</Badge>
-                            )}
-                          </Table.Cell>
-                          <Table.Cell align={'right'}>{metricAnalysis.target_n ?? ''}</Table.Cell>
-                          <Table.Cell align={'right'}>
-                            {metricAnalysis.metric_spec.available_n == null ? (
-                              '?'
-                            ) : metricAnalysis.metric_spec.available_n === 0 ||
-                              metricAnalysis.metric_spec.available_n < (metricAnalysis.target_n ?? 0) ? (
-                              <Text color="crimson">{metricAnalysis.metric_spec.available_n}</Text>
-                            ) : (
-                              metricAnalysis.metric_spec.available_n
-                            )}
-                          </Table.Cell>
-                          <Table.Cell align={'right'}>
-                            {metricAnalysis.metric_spec.available_nonnull_n == null ? (
-                              '?'
-                            ) : metricAnalysis.metric_spec.available_nonnull_n === 0 ||
-                              metricAnalysis.metric_spec.available_nonnull_n < (metricAnalysis.target_n ?? 0) ? (
-                              <Text color="crimson">{metricAnalysis.metric_spec.available_nonnull_n}</Text>
-                            ) : (
-                              metricAnalysis.metric_spec.available_nonnull_n
-                            )}
-                          </Table.Cell>
-                        </Table.Row>
-                      ))}
-                    </Table.Body>
-                  </Table.Root>
-                </Flex>
-              </Card>
-            ) : null}
-          </Grid>
-        </Flex>
-      </SectionCard>
+					{error && (
+						<Flex align="center" gap="2">
+							<GenericErrorCallout title={"Power check failed"} error={error} />
+						</Flex>
+					)}
 
-      {data.powerCheckResponse !== undefined && !validationError && (
-        <SectionCard title="Select Target Sample Size">
-          <Flex direction="column" gap="3" align="start">
-            <Text>Select target sample size to distribute across all arms:</Text>
-            <Flex direction="column" gap="2" align="center">
-              {!data.powerCheckResponse.analyses.map((a) => a.sufficient_n).every((sufficient) => sufficient) && (
-                <Callout.Root color="orange">
-                  <Callout.Icon>
-                    <CrossCircledIcon />
-                  </Callout.Icon>
-                  <Callout.Text>
-                    You don&apos;t have sufficient samples for one or more metrics. You can still proceed with a custom
-                    sample size, but consider adjusting your experiment design.
-                  </Callout.Text>
-                </Callout.Root>
-              )}
-              <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleSampleOptionChange}>
-                <Flex direction={'row'} gap={'3'} justify={'between'}>
-                  <RadioCards.Item
-                    value={PowerCheckOption.USE_POWER_CHECK}
-                    disabled={powerCheckTarget === undefined || powerCheckTarget === 0}
-                  >
-                    Use minimum sample required: {powerCheckTarget ?? 'N/A'}
-                  </RadioCards.Item>
-                  <RadioCards.Item
-                    value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-                    disabled={nonNullSamples === undefined || nonNullSamples === 0}
-                  >
-                    Use all available non-null samples: {nonNullSamples}
-                  </RadioCards.Item>
-                  <RadioCards.Item
-                    value={PowerCheckOption.ENTER_OWN}
-                    disabled={allSamples === undefined || allSamples === 0}
-                  >
-                    <Flex align="center" direction={'row'} gap="2">
-                      <span>Use custom sample size:</span>
-                      <div style={{ pointerEvents: 'auto' }}>
-                        <TextField.Root
-                          style={{ width: '250px' }}
-                          size="2"
-                          type="number"
-                          max={allSamples ?? undefined}
-                          onChange={(e) =>
-                            dispatch({
-                              type: 'set-chosen-n',
-                              value: e.target.value === '' ? undefined : Number(e.target.value),
-                            })
-                          }
-                          placeholder="Type your own desired #."
-                        />
-                      </div>
-                    </Flex>
-                  </RadioCards.Item>
-                </Flex>
-              </RadioCards.Root>
-            </Flex>
-          </Flex>
-        </SectionCard>
-      )}
-    </Flex>
-  );
+					{validationError && (
+						<Flex align="center" gap="2">
+							<GenericErrorCallout
+								title={"Validation failed"}
+								message={validationError.issues
+									.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+									.join("\n")}
+							/>
+						</Flex>
+					)}
+
+					{primaryPower && (
+						<Callout.Root color={primaryPower.sufficient_n ? "green" : "red"}>
+							<Callout.Icon>
+								{primaryPower.sufficient_n ? (
+									<CheckCircledIcon />
+								) : (
+									<CrossCircledIcon />
+								)}
+							</Callout.Icon>
+							<Callout.Text>
+								{isClusterExperiment &&
+								primaryPower.num_clusters_total != null ? (
+									<>
+										There are{" "}
+										<strong>
+											{(
+												primaryPower.metric_spec.available_n ?? 0
+											).toLocaleString()}{" "}
+											participants
+										</strong>{" "}
+										available. A minimum of{" "}
+										<strong>
+											{primaryPower.num_clusters_total.toLocaleString()}{" "}
+											clusters
+										</strong>{" "}
+										(
+										{(primaryPower.target_n ?? 0).toLocaleString()}{" "}
+										participants) are needed to meet your design specs.{" "}
+										{primaryPower.sufficient_n
+											? "There are enough units available."
+											: "Insufficient units available."}
+									</>
+								) : (
+									primaryPower.msg?.msg ||
+									(primaryPower.sufficient_n
+										? "The experiment has sufficient power."
+										: "The experiment does not have sufficient power.")
+								)}
+							</Callout.Text>
+							{/* Issue #217: CV > 0.5 warning nested inside the success/result box. */}
+							{hasHighVariability && (
+								<Callout.Root color="amber" mt="2">
+									<Callout.Text>
+										⚠ CV = {data.clusterCv}: cluster size variability is high.
+										The cluster count estimate may be unreliable.
+									</Callout.Text>
+								</Callout.Root>
+							)}
+						</Callout.Root>
+					)}
+
+					<Grid rows={"1"} columns={restPower ? "2" : "1"} gap={"3"}>
+						{primaryPower && (
+							<>
+								<Card>
+									<Flex direction="column" gap={"3"}>
+										<Heading size={"3"}>
+											Primary Metric: {primaryPower.metric_spec.field_name}
+										</Heading>
+										<DataList.Root>
+											<DataList.Item>
+												<DataList.Label>Status</DataList.Label>
+												<DataList.Value>
+													{primaryPower.sufficient_n ? (
+														<Badge color={"green"}>Pass</Badge>
+													) : (
+														<Badge color={"red"}>Failed</Badge>
+													)}
+												</DataList.Value>
+											</DataList.Item>
+											<DataList.Item>
+												<DataList.Label>Required</DataList.Label>
+												<DataList.Value>
+													{isClusterExperiment &&
+													primaryPower.num_clusters_total != null ? (
+														<Flex direction="column" align="end">
+															<Text color="green" weight="bold">
+																{primaryPower.num_clusters_total.toLocaleString()}{" "}
+																clusters
+															</Text>
+															<Text size="1" color="gray">
+																{(
+																	primaryPower.target_n ?? 0
+																).toLocaleString()}{" "}
+																participants
+															</Text>
+														</Flex>
+													) : (
+														primaryPower.target_n || "?"
+													)}
+												</DataList.Value>
+											</DataList.Item>
+											<DataList.Item>
+												<DataList.Label>Available</DataList.Label>
+												<DataList.Value>
+													{isClusterExperiment &&
+													data.clusterAvgSize !== "" &&
+													primaryPower.metric_spec.available_n != null ? (
+														<Flex direction="column" align="end">
+															<Text color="green" weight="bold">
+																{Math.floor(
+																	primaryPower.metric_spec.available_n /
+																		Number(data.clusterAvgSize),
+																).toLocaleString()}{" "}
+																clusters
+															</Text>
+															<Text size="1" color="gray">
+																{primaryPower.metric_spec.available_n.toLocaleString()}{" "}
+																participants
+															</Text>
+														</Flex>
+													) : primaryPower.metric_spec.available_n == null ? (
+														"?"
+													) : primaryPower.metric_spec.available_n === 0 ||
+														primaryPower.metric_spec.available_n <
+															(primaryPower.target_n ?? 0) ? (
+														<Text color="crimson">
+															{primaryPower.metric_spec.available_n}
+														</Text>
+													) : (
+														primaryPower.metric_spec.available_n
+													)}
+												</DataList.Value>
+											</DataList.Item>
+											<DataList.Item>
+												<DataList.Label>Available (non-null)</DataList.Label>
+												<DataList.Value>
+													{isClusterExperiment &&
+													data.clusterAvgSize !== "" &&
+													primaryPower.metric_spec.available_nonnull_n !=
+														null ? (
+														<Flex direction="column" align="end">
+															<Text color="green" weight="bold">
+																{Math.floor(
+																	primaryPower.metric_spec
+																		.available_nonnull_n /
+																		Number(data.clusterAvgSize),
+																).toLocaleString()}{" "}
+																clusters
+															</Text>
+															<Text size="1" color="gray">
+																{primaryPower.metric_spec.available_nonnull_n.toLocaleString()}{" "}
+																participants
+															</Text>
+														</Flex>
+													) : primaryPower.metric_spec.available_nonnull_n ==
+													null ? (
+														"?"
+													) : primaryPower.metric_spec.available_nonnull_n ===
+															0 ||
+														primaryPower.metric_spec.available_nonnull_n <
+															(primaryPower.target_n ?? 0) ||
+														primaryPower.metric_spec.available_nonnull_n <
+															(primaryPower.metric_spec.available_n ?? 0) ? (
+														<Text color="orange">
+															{primaryPower.metric_spec.available_nonnull_n}
+														</Text>
+													) : (
+														primaryPower.metric_spec.available_nonnull_n
+													)}
+												</DataList.Value>
+											</DataList.Item>
+											{primaryPower.pct_change_possible !== null &&
+												primaryPower.pct_change_possible !== undefined && (
+													<DataList.Item>
+														<DataList.Label>Target MDE</DataList.Label>
+														<DataList.Value>
+															{(primaryPower.pct_change_possible * 100).toFixed(
+																4,
+															)}
+															%
+														</DataList.Value>
+													</DataList.Item>
+												)}
+										</DataList.Root>
+									</Flex>
+								</Card>
+							</>
+						)}
+						{restPower ? (
+							<Card key={"secondary"}>
+								<Flex direction="column" gap={"3"}>
+									<Heading size={"3"}>Secondary Metrics</Heading>
+									<Table.Root>
+										<Table.Header>
+											<Table.Row>
+												<Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
+												<Table.ColumnHeaderCell></Table.ColumnHeaderCell>
+												<Table.ColumnHeaderCell>
+													Required
+												</Table.ColumnHeaderCell>
+												<Table.ColumnHeaderCell>
+													Available
+												</Table.ColumnHeaderCell>
+												<Table.ColumnHeaderCell>
+													Available (non-null)
+												</Table.ColumnHeaderCell>
+											</Table.Row>
+										</Table.Header>
+										<Table.Body>
+											{restPower.map((metricAnalysis, i) => (
+												<Table.Row key={`rest${i}`}>
+													<Table.Cell>
+														{metricAnalysis.metric_spec.field_name}
+													</Table.Cell>
+													<Table.Cell>
+														{metricAnalysis.sufficient_n ? (
+															<Badge color={"green"}>Pass</Badge>
+														) : (
+															<Badge color={"orange"}>Failed</Badge>
+														)}
+													</Table.Cell>
+													<Table.Cell align={"right"}>
+														{metricAnalysis.target_n ?? ""}
+													</Table.Cell>
+													<Table.Cell align={"right"}>
+														{metricAnalysis.metric_spec.available_n == null ? (
+															"?"
+														) : metricAnalysis.metric_spec.available_n === 0 ||
+															metricAnalysis.metric_spec.available_n <
+																(metricAnalysis.target_n ?? 0) ? (
+															<Text color="crimson">
+																{metricAnalysis.metric_spec.available_n}
+															</Text>
+														) : (
+															metricAnalysis.metric_spec.available_n
+														)}
+													</Table.Cell>
+													<Table.Cell align={"right"}>
+														{metricAnalysis.metric_spec.available_nonnull_n ==
+														null ? (
+															"?"
+														) : metricAnalysis.metric_spec
+																.available_nonnull_n === 0 ||
+															metricAnalysis.metric_spec.available_nonnull_n <
+																(metricAnalysis.target_n ?? 0) ? (
+															<Text color="crimson">
+																{metricAnalysis.metric_spec.available_nonnull_n}
+															</Text>
+														) : (
+															metricAnalysis.metric_spec.available_nonnull_n
+														)}
+													</Table.Cell>
+												</Table.Row>
+											))}
+										</Table.Body>
+									</Table.Root>
+								</Flex>
+							</Card>
+						) : null}
+					</Grid>
+				</Flex>
+			</SectionCard>
+
+			{data.powerCheckResponse !== undefined && !validationError && (
+				<SectionCard title="Select Target Sample Size">
+					<Flex direction="column" gap="3" align="start">
+						<Text>
+							Select target sample size to distribute across all arms:
+						</Text>
+						<Flex direction="column" gap="2" align="center">
+							{!data.powerCheckResponse.analyses
+								.map((a) => a.sufficient_n)
+								.every((sufficient) => sufficient) && (
+								<Callout.Root color="orange">
+									<Callout.Icon>
+										<CrossCircledIcon />
+									</Callout.Icon>
+									<Callout.Text>
+										You don&apos;t have sufficient samples for one or more
+										metrics. You can still proceed with a custom sample size,
+										but consider adjusting your experiment design.
+									</Callout.Text>
+								</Callout.Root>
+							)}
+							<RadioCards.Root
+								columns="1"
+								value={selectedSampleOption}
+								onValueChange={handleSampleOptionChange}
+							>
+								<Flex direction={"row"} gap={"3"} justify={"between"}>
+									<RadioCards.Item
+										value={PowerCheckOption.USE_POWER_CHECK}
+										disabled={
+											powerCheckTarget === undefined || powerCheckTarget === 0
+										}
+									>
+										{isClusterExperiment &&
+										primaryPower?.num_clusters_total != null ? (
+											<Flex direction="column" align="start">
+												<Text>Use minimum sample required:</Text>
+												<Text color="green" weight="bold">
+													{primaryPower.num_clusters_total.toLocaleString()}{" "}
+													clusters
+												</Text>
+												<Text size="1" color="gray">
+													{(powerCheckTarget ?? 0).toLocaleString()}{" "}
+													participants
+												</Text>
+											</Flex>
+										) : (
+											`Use minimum sample required: ${powerCheckTarget ?? "N/A"}`
+										)}
+									</RadioCards.Item>
+									<RadioCards.Item
+										value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
+										disabled={
+											nonNullSamples === undefined || nonNullSamples === 0
+										}
+									>
+										{isClusterExperiment &&
+										data.clusterAvgSize !== "" &&
+										nonNullSamples != null ? (
+											<Flex direction="column" align="start">
+												<Text>Use all available non-null:</Text>
+												<Text color="green" weight="bold">
+													{Math.floor(
+														nonNullSamples / Number(data.clusterAvgSize),
+													).toLocaleString()}{" "}
+													clusters
+												</Text>
+												<Text size="1" color="gray">
+													{nonNullSamples.toLocaleString()} participants
+												</Text>
+											</Flex>
+										) : (
+											`Use all available non-null samples: ${nonNullSamples}`
+										)}
+									</RadioCards.Item>
+									<RadioCards.Item
+										value={PowerCheckOption.ENTER_OWN}
+										disabled={allSamples === undefined || allSamples === 0}
+									>
+										<Flex
+											align="start"
+											direction={isClusterExperiment ? "column" : "row"}
+											gap="2"
+											wrap="wrap"
+										>
+											<span style={{ paddingTop: "4px" }}>
+												Use custom sample size:
+											</span>
+											{isClusterExperiment ? (
+												<div style={{ pointerEvents: "auto", width: "100%" }}>
+													<Flex direction="column" gap="2">
+														<Flex direction="column" gap="1">
+															<Text
+																size="1"
+																color="gray"
+																style={{ textTransform: "uppercase" }}
+															>
+																Clusters
+															</Text>
+															<TextField.Root
+																style={{ width: "180px" }}
+																size="2"
+																type="number"
+																min={0}
+																value={clustersInput}
+																placeholder={
+																	primaryPower?.num_clusters_total != null
+																		? `e.g. ${primaryPower.num_clusters_total}`
+																		: "# clusters"
+																}
+																onChange={(e) => {
+																	editingRef.current = "clusters";
+																	setClustersInput(e.target.value);
+																}}
+															/>
+														</Flex>
+														<Flex direction="column" gap="1">
+															<Text
+																size="1"
+																color="gray"
+																style={{ textTransform: "uppercase" }}
+															>
+																Participants
+															</Text>
+															<TextField.Root
+																style={{ width: "180px" }}
+																size="2"
+																type="number"
+																max={allSamples ?? undefined}
+																value={participantsInput}
+																placeholder={
+																	primaryPower?.target_n != null
+																		? `e.g. ${primaryPower.target_n.toLocaleString()}`
+																		: "# participants"
+																}
+																onChange={(e) => {
+																	editingRef.current = "participants";
+																	setParticipantsInput(e.target.value);
+																}}
+															/>
+														</Flex>
+													</Flex>
+												</div>
+											) : (
+												<div style={{ pointerEvents: "auto" }}>
+													<TextField.Root
+														style={{ width: "250px" }}
+														size="2"
+														type="number"
+														max={allSamples ?? undefined}
+														onChange={(e) =>
+															dispatch({
+																type: "set-chosen-n",
+																value:
+																	e.target.value === ""
+																		? undefined
+																		: Number(e.target.value),
+															})
+														}
+														placeholder="Type your own desired #."
+													/>
+												</div>
+											)}
+										</Flex>
+									</RadioCards.Item>
+								</Flex>
+							</RadioCards.Root>
+						</Flex>
+					</Flex>
+				</SectionCard>
+			)}
+		</Flex>
+	);
 }

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { usePowerCheck } from '@/api/admin';
+import { PowerResponseOutput } from '@/api/methods.schemas';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
@@ -119,23 +120,30 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   // they stop typing.
   const avgClusterSize = Number(data.clusterAvgSize ?? '');
 
-  // Lazy-init the Custom inputs from data.desiredN so a previously-entered
-  // custom value survives navigating to Summary and clicking Back. Only
-  // seed when desiredN is set AND it doesn't match the recommended or
-  // max-available size (those are handled by the other two radio cards).
+  // Lazy-init the Custom inputs so a previously-typed value survives
+  // navigating away (Summary → Back). We prefer the cached
+  // achievableCustomDesiredN because it remembers the user's typed Custom
+  // value even after they switched to another radio (Use minimum / Max).
+  // If that's not set yet, fall back to data.desiredN — but only when it
+  // doesn't match the recommended or max-available value (those belong to
+  // the other radios).
   const initialCustomFromState = (() => {
-    if (data.desiredN === undefined) return { clusters: '', participants: '' };
-    const primary = data.powerCheckResponse?.analyses.find(
-      (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-    );
-    const target = primary?.target_n ?? undefined;
-    const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
-    if (data.desiredN === target || data.desiredN === nonNull) {
-      return { clusters: '', participants: '' };
+    let customN: number | undefined = data.achievableCustomDesiredN;
+    if (customN === undefined) {
+      if (data.desiredN === undefined) return { clusters: '', participants: '' };
+      const primary = data.powerCheckResponse?.analyses.find(
+        (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+      );
+      const target = primary?.target_n ?? undefined;
+      const nonNull = primary?.metric_spec.available_nonnull_n ?? undefined;
+      if (data.desiredN === target || data.desiredN === nonNull) {
+        return { clusters: '', participants: '' };
+      }
+      customN = data.desiredN;
     }
-    const participants = String(data.desiredN);
+    const participants = String(customN);
     const clusters =
-      Number.isFinite(avgClusterSize) && avgClusterSize > 0 ? String(Math.ceil(data.desiredN / avgClusterSize)) : '';
+      Number.isFinite(avgClusterSize) && avgClusterSize > 0 ? String(Math.ceil(customN / avgClusterSize)) : '';
     return { clusters, participants };
   })();
 
@@ -183,60 +191,99 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
-  // Achievable MDE recompute: when the user picks Max-available or Custom, fire
-  // a fresh power-check call with desired_n included in the design spec. The BE
-  // switches to MDE mode and returns the achievable MDE plus the cluster split
-  // for the chosen N. The result is stored on form state so it can be (a) shown
-  // inline next to the radio option and (b) persisted as the experiment's
-  // power_analyses at save time. Custom typing is already debounced upstream
-  // (set-chosen-n only fires after 500ms), so this effect only sees the final
-  // committed value.
-  const [isRecomputingMde, setIsRecomputingMde] = useState(false);
-  useEffect(() => {
-    // Recompute only makes sense when the user has chosen a non-recommended
-    // sample size. For "Use minimum sample required" the original
-    // powerCheckResponse already carries the right answer (achievable MDE
-    // equals the user's target MDE by construction).
-    if (data.desiredN === undefined) return;
-    if (selectedSampleOption === PowerCheckOption.USE_POWER_CHECK) return;
-    if (selectedSampleOption === PowerCheckOption.NONE) return;
-    if (data.desiredN === powerCheckTarget) return;
-    if (!data.tableName || !data.primaryKey || !data.primaryMetric) return;
+  // Two cached achievable-MDE recomputes — one for the Max-available radio and
+  // one for the value typed into Custom. Each is fetched independently and
+  // persists in form state so each card's MDE annotation stays visible even
+  // when the user is on a different radio. Use minimum sample required's
+  // achievable MDE equals the user's target MDE by construction (no call
+  // needed).
+  const [isRecomputingMax, setIsRecomputingMax] = useState(false);
+  const [isRecomputingCustom, setIsRecomputingCustom] = useState(false);
 
+  // Helper to fire a fresh power-check call with `desired_n` set to `n`,
+  // independent of any react state on the parent (so it's safe to call from
+  // two different effects with different desired_n values).
+  const fetchAchievableFor = async (n: number) => {
+    if (!data.tableName || !data.primaryKey || !data.primaryMetric) return undefined;
+    try {
+      const design_spec = convertToFrequentistDesignSpec({ ...data, desiredN: n });
+      return await trigger({ design_spec });
+    } catch {
+      return undefined;
+    }
+  };
+
+  // Max-available recompute: fires once nonNullSamples becomes known after
+  // the initial Power Check. Doesn't depend on which radio is selected.
+  useEffect(() => {
+    if (nonNullSamples === undefined || nonNullSamples <= 0) return;
+    if (data.achievableMaxPowerCheckResponse !== undefined) return;
+    if (!data.tableName || !data.primaryKey || !data.primaryMetric) return;
     let cancelled = false;
-    setIsRecomputingMde(true);
-    // `void` here intentionally discards the promise — the IIFE manages its
-    // own lifecycle via the `cancelled` flag and the cleanup function below.
+    setIsRecomputingMax(true);
     void (async () => {
-      try {
-        const design_spec = convertToFrequentistDesignSpec(data);
-        const response = await trigger({ design_spec });
-        if (cancelled) return;
-        dispatch({
-          type: 'set-achievable-power-check-response',
-          response,
-        });
-      } catch {
-        // Swallow: if the recompute fails the inline display just doesn't
-        // show an achievable MDE. Validation issues are already surfaced
-        // by the manual Run-Power-Check flow on the same page.
-      } finally {
-        if (!cancelled) setIsRecomputingMde(false);
-      }
+      const response = await fetchAchievableFor(nonNullSamples);
+      if (cancelled) return;
+      if (response) dispatch({ type: 'set-achievable-max-response', response });
+      setIsRecomputingMax(false);
     })();
     return () => {
       cancelled = true;
+      setIsRecomputingMax(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data.desiredN, selectedSampleOption, powerCheckTarget]);
+  }, [nonNullSamples, data.achievableMaxPowerCheckResponse]);
 
-  // Read the achievable MDE for the primary metric (cluster-aware fields are
-  // populated by solve_for_mde_cluster on the BE; for non-cluster experiments
-  // pct_change_possible is still populated, so this works for both).
-  const achievablePrimary = data.achievablePowerCheckResponse?.analyses.find(
-    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-  );
-  const achievablePctChange = achievablePrimary?.pct_change_possible ?? null;
+  // Custom recompute: fires when the user is on the Custom option and the
+  // typed desired_n differs from the cached one. desiredN itself is already
+  // debounced upstream (set-chosen-n only fires after 500ms typing pause).
+  useEffect(() => {
+    if (selectedSampleOption !== PowerCheckOption.ENTER_OWN) return;
+    if (data.desiredN === undefined) return;
+    if (data.desiredN === data.achievableCustomDesiredN) return;
+    if (data.desiredN === powerCheckTarget) return;
+    if (data.desiredN === nonNullSamples) return;
+    if (!data.tableName || !data.primaryKey || !data.primaryMetric) return;
+    let cancelled = false;
+    const targetN = data.desiredN;
+    setIsRecomputingCustom(true);
+    void (async () => {
+      const response = await fetchAchievableFor(targetN);
+      if (cancelled) return;
+      if (response) {
+        dispatch({ type: 'set-achievable-custom-response', response, desiredN: targetN });
+      }
+      setIsRecomputingCustom(false);
+    })();
+    return () => {
+      cancelled = true;
+      setIsRecomputingCustom(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    data.desiredN,
+    selectedSampleOption,
+    data.achievableCustomDesiredN,
+    powerCheckTarget,
+    nonNullSamples,
+  ]);
+
+  // Helper to pull pct_change for the primary metric from any power-check
+  // response. Reads pct_change_with_desired_n first (set by the BE when
+  // desired_n was sufficient) and falls back to pct_change_possible (set in
+  // the MDE-mode-fallback path when desired_n was insufficient).
+  const readAchievablePct = (response: PowerResponseOutput | undefined): number | null => {
+    const primary = response?.analyses.find(
+      (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+    );
+    if (!primary) return null;
+    const withDesired = (primary as { pct_change_with_desired_n?: number | null })
+      .pct_change_with_desired_n;
+    if (withDesired != null) return withDesired;
+    return primary.pct_change_possible ?? null;
+  };
+  const maxAchievablePct = readAchievablePct(data.achievableMaxPowerCheckResponse);
+  const customAchievablePct = readAchievablePct(data.achievableCustomPowerCheckResponse);
 
   // Target MDE the user requested (string from the form, expressed as a
   // percent). Used as the "achievable MDE" for the recommended option, since
@@ -321,6 +368,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
         dispatch({ type: 'set-chosen-n', value: nonNullSamples });
         break;
       case PowerCheckOption.ENTER_OWN:
+        // If the user had previously typed a value (cached as
+        // achievableCustomDesiredN), restore it so the inputs and desiredN
+        // stay in sync and Next is enabled. Otherwise leave desiredN
+        // undefined so the user can type fresh.
+        dispatch({ type: 'set-chosen-n', value: data.achievableCustomDesiredN });
+        break;
       case PowerCheckOption.NONE:
         dispatch({ type: 'set-chosen-n', value: undefined });
         break;
@@ -632,40 +685,21 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                           {/* Use the BE's clusters total ONLY when this is
 														the currently-selected option (otherwise
 														achievablePrimary is for a different N, e.g.
-														whatever the user typed in Custom). Otherwise
-														compute from nonNullSamples/avg_cluster_size. */}
-                          {(selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
-                          achievablePrimary?.num_clusters_total != null
-                            ? achievablePrimary.num_clusters_total
-                            : Math.floor(nonNullSamples / Number(data.clusterAvgSize))
-                          ).toLocaleString()}{' '}
-                          clusters
+														For Max-available the BE response's num_clusters_total
+														is the MINIMUM required (not the cluster count for
+														desired_n = nonNullSamples), so we always compute it
+														client-side from nonNullSamples/avg_cluster_size. */}
+                          {Math.floor(nonNullSamples / Number(data.clusterAvgSize)).toLocaleString()} clusters
                         </Text>
                         <Text size="1" color="gray">
                           {nonNullSamples.toLocaleString()} participants
                         </Text>
-                        {renderAchievableMdeLine(
-                          selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
-                            ? achievablePctChange
-                            : null,
-                          {
-                            loading:
-                              selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && isRecomputingMde,
-                          },
-                        )}
+                        {renderAchievableMdeLine(maxAchievablePct, { loading: isRecomputingMax })}
                       </Flex>
                     ) : (
                       <Flex direction="column" align="start">
                         <Text>{`Use all available non-null samples: ${nonNullSamples}`}</Text>
-                        {renderAchievableMdeLine(
-                          selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
-                            ? achievablePctChange
-                            : null,
-                          {
-                            loading:
-                              selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && isRecomputingMde,
-                          },
-                        )}
+                        {renderAchievableMdeLine(maxAchievablePct, { loading: isRecomputingMax })}
                       </Flex>
                     )}
                   </RadioCards.Item>
@@ -720,12 +754,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                                 }}
                               />
                             </Flex>
-                            {renderAchievableMdeLine(
-                              selectedSampleOption === PowerCheckOption.ENTER_OWN ? achievablePctChange : null,
-                              {
-                                loading: selectedSampleOption === PowerCheckOption.ENTER_OWN && isRecomputingMde,
-                              },
-                            )}
+                            {renderAchievableMdeLine(customAchievablePct, { loading: isRecomputingCustom })}
                           </Flex>
                         </div>
                       ) : (
@@ -743,12 +772,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             }
                             placeholder="Type your own desired #."
                           />
-                          {renderAchievableMdeLine(
-                            selectedSampleOption === PowerCheckOption.ENTER_OWN ? achievablePctChange : null,
-                            {
-                              loading: selectedSampleOption === PowerCheckOption.ENTER_OWN && isRecomputingMde,
-                            },
-                          )}
+                          {renderAchievableMdeLine(customAchievablePct, { loading: isRecomputingCustom })}
                         </div>
                       )}
                     </Flex>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,283 +1,214 @@
-"use client";
-import {
-	useListOrganizationDatasources,
-	useListOrganizationExperiments,
-} from "@/api/admin";
-import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
-import { CreateExperimentButton } from "@/components/features/experiments/create-experiment-button";
-import { ExperimentCard } from "@/components/features/experiments/experiment-card";
-import { ExperimentImpactFilter } from "@/components/features/experiments/experiment-impact-filter";
-import { ExperimentStatusFilter } from "@/components/features/experiments/experiment-status-filter";
-import { ExperimentsTable } from "@/components/features/experiments/experiments-table";
-import type {
-	ExperimentStatus,
-	ExperimentWithStatus,
-} from "@/components/features/experiments/types";
-import { EmptyStateCard } from "@/components/ui/cards/empty-state-card";
-import { GenericErrorCallout } from "@/components/ui/generic-error";
-import { XSpinner } from "@/components/ui/x-spinner";
-import { useCurrentOrganization } from "@/providers/organization-provider";
-import { useLocalStorage } from "@/providers/use-local-storage";
-import { NO_DWH_DRIVER, PRODUCT_NAME } from "@/services/constants";
-import { getExperimentStatus } from "@/services/experiment-utils";
-import {
-	DashboardIcon,
-	GearIcon,
-	ListBulletIcon,
-	MagnifyingGlassIcon,
-	ReloadIcon,
-} from "@radix-ui/react-icons";
-import {
-	Flex,
-	Grid,
-	Heading,
-	IconButton,
-	TextField,
-	Tooltip,
-} from "@radix-ui/themes";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+'use client';
+import { useListOrganizationDatasources, useListOrganizationExperiments } from '@/api/admin';
+import { isClusterDesign } from '@/components/features/experiments/cluster-detection';
+import { CreateExperimentButton } from '@/components/features/experiments/create-experiment-button';
+import { ExperimentCard } from '@/components/features/experiments/experiment-card';
+import { ExperimentImpactFilter } from '@/components/features/experiments/experiment-impact-filter';
+import { ExperimentStatusFilter } from '@/components/features/experiments/experiment-status-filter';
+import { ExperimentsTable } from '@/components/features/experiments/experiments-table';
+import type { ExperimentStatus, ExperimentWithStatus } from '@/components/features/experiments/types';
+import { EmptyStateCard } from '@/components/ui/cards/empty-state-card';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { useCurrentOrganization } from '@/providers/organization-provider';
+import { useLocalStorage } from '@/providers/use-local-storage';
+import { NO_DWH_DRIVER, PRODUCT_NAME } from '@/services/constants';
+import { getExperimentStatus } from '@/services/experiment-utils';
+import { DashboardIcon, GearIcon, ListBulletIcon, MagnifyingGlassIcon, ReloadIcon } from '@radix-ui/react-icons';
+import { Flex, Grid, Heading, IconButton, TextField, Tooltip } from '@radix-ui/themes';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 export default function Page() {
-	const router = useRouter();
-	const orgContext = useCurrentOrganization();
-	const currentOrgId = orgContext!.current.id;
-	const [selectedStatuses, setSelectedStatuses] = useState<ExperimentStatus[]>(
-		[],
-	);
-	const [selectedImpacts, setSelectedImpacts] = useState<string[]>([]);
-	const [searchQuery, setSearchQuery] = useState("");
-	const [viewMode, setViewMode] = useLocalStorage<"card" | "table">(
-		"exp-view-mode",
-	);
+  const router = useRouter();
+  const orgContext = useCurrentOrganization();
+  const currentOrgId = orgContext!.current.id;
+  const [selectedStatuses, setSelectedStatuses] = useState<ExperimentStatus[]>([]);
+  const [selectedImpacts, setSelectedImpacts] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [viewMode, setViewMode] = useLocalStorage<'card' | 'table'>('exp-view-mode');
 
-	const isCardView = viewMode === null || viewMode === "card";
+  const isCardView = viewMode === null || viewMode === 'card';
 
-	const { data: datasourcesData, error: datasourcesError } =
-		useListOrganizationDatasources(currentOrgId, {
-			swr: {
-				enabled: !!currentOrgId,
-			},
-		});
+  const { data: datasourcesData, error: datasourcesError } = useListOrganizationDatasources(currentOrgId, {
+    swr: {
+      enabled: !!currentOrgId,
+    },
+  });
 
-	const {
-		data: experimentsData,
-		isLoading: experimentsIsLoading,
-		error: experimentsError,
-	} = useListOrganizationExperiments(currentOrgId, {
-		swr: { enabled: !!currentOrgId },
-	});
+  const {
+    data: experimentsData,
+    isLoading: experimentsIsLoading,
+    error: experimentsError,
+  } = useListOrganizationExperiments(currentOrgId, {
+    swr: { enabled: !!currentOrgId },
+  });
 
-	const committedExperiments =
-		experimentsData?.items.filter(
-			(experiment) => experiment.state === "committed",
-		) || [];
+  const committedExperiments = experimentsData?.items.filter((experiment) => experiment.state === 'committed') || [];
 
-	const experimentsWithStatus = committedExperiments.map((experiment) => ({
-		...experiment,
-		status: getExperimentStatus(
-			experiment.design_spec.start_date,
-			experiment.design_spec.end_date,
-		),
-	}));
+  const experimentsWithStatus = committedExperiments.map((experiment) => ({
+    ...experiment,
+    status: getExperimentStatus(experiment.design_spec.start_date, experiment.design_spec.end_date),
+  }));
 
-	const matchesStatusFilter = (experiment: ExperimentWithStatus): boolean => {
-		if (selectedStatuses.length === 0) return true;
-		return selectedStatuses.includes(experiment.status);
-	};
+  const matchesStatusFilter = (experiment: ExperimentWithStatus): boolean => {
+    if (selectedStatuses.length === 0) return true;
+    return selectedStatuses.includes(experiment.status);
+  };
 
-	const matchesImpactFilter = (experiment: ExperimentWithStatus): boolean => {
-		if (selectedImpacts.length === 0) return true;
-		const normalizedImpact = experiment.impact ?? "";
-		return selectedImpacts.includes(normalizedImpact);
-	};
+  const matchesImpactFilter = (experiment: ExperimentWithStatus): boolean => {
+    if (selectedImpacts.length === 0) return true;
+    const normalizedImpact = experiment.impact ?? '';
+    return selectedImpacts.includes(normalizedImpact);
+  };
 
-	const matchesSearchQuery = (experiment: ExperimentWithStatus): boolean => {
-		if (searchQuery === "") return true;
-		const query = searchQuery.toLowerCase();
-		return (
-			experiment.design_spec.experiment_name.toLowerCase().includes(query) ||
-			experiment.design_spec.description.toLowerCase().includes(query)
-		);
-	};
+  const matchesSearchQuery = (experiment: ExperimentWithStatus): boolean => {
+    if (searchQuery === '') return true;
+    const query = searchQuery.toLowerCase();
+    return (
+      experiment.design_spec.experiment_name.toLowerCase().includes(query) ||
+      experiment.design_spec.description.toLowerCase().includes(query)
+    );
+  };
 
-	const resetFilters = () => {
-		setSelectedStatuses([]);
-		setSelectedImpacts([]);
-		setSearchQuery("");
-	};
+  const resetFilters = () => {
+    setSelectedStatuses([]);
+    setSelectedImpacts([]);
+    setSearchQuery('');
+  };
 
-	const filteredExperiments = experimentsWithStatus.filter(
-		(experiment) =>
-			matchesStatusFilter(experiment) &&
-			matchesImpactFilter(experiment) &&
-			matchesSearchQuery(experiment),
-	);
+  const filteredExperiments = experimentsWithStatus.filter(
+    (experiment) =>
+      matchesStatusFilter(experiment) && matchesImpactFilter(experiment) && matchesSearchQuery(experiment),
+  );
 
-	const filtersActive =
-		selectedStatuses.length > 0 ||
-		selectedImpacts.length > 0 ||
-		searchQuery !== "";
+  const filtersActive = selectedStatuses.length > 0 || selectedImpacts.length > 0 || searchQuery !== '';
 
-	if (datasourcesError) {
-		return (
-			<GenericErrorCallout
-				title={"Error with experiments list"}
-				error={datasourcesError}
-			/>
-		);
-	}
+  if (datasourcesError) {
+    return <GenericErrorCallout title={'Error with experiments list'} error={datasourcesError} />;
+  }
 
-	if (experimentsError) {
-		return (
-			<GenericErrorCallout
-				title={"Error with experiments list"}
-				error={experimentsError}
-			/>
-		);
-	}
+  if (experimentsError) {
+    return <GenericErrorCallout title={'Error with experiments list'} error={experimentsError} />;
+  }
 
-	return (
-		<Flex direction="column" gap="4">
-			<Flex justify="between" align="center">
-				<Heading size={"8"}>
-					Experiments
-					{orgContext && orgContext.available.length > 1 && (
-						<> for {orgContext.current.name}</>
-					)}
-				</Heading>
-				<CreateExperimentButton />
-			</Flex>
+  return (
+    <Flex direction="column" gap="4">
+      <Flex justify="between" align="center">
+        <Heading size={'8'}>
+          Experiments
+          {orgContext && orgContext.available.length > 1 && <> for {orgContext.current.name}</>}
+        </Heading>
+        <CreateExperimentButton />
+      </Flex>
 
-			{experimentsIsLoading && (
-				<Flex>
-					<XSpinner message={"Loading experiments list..."} />
-				</Flex>
-			)}
+      {experimentsIsLoading && (
+        <Flex>
+          <XSpinner message={'Loading experiments list...'} />
+        </Flex>
+      )}
 
-			{datasourcesData &&
-			(datasourcesData.items.length === 0 ||
-				(datasourcesData?.items.length === 1 &&
-					datasourcesData.items[0].driver === NO_DWH_DRIVER &&
-					committedExperiments.length === 0)) ? (
-				// If there are no non-api-only datasources and no experiments, show the ds setup message.
-				// One can still create api-only experiments from the create experiment button.
-				<EmptyStateCard
-					title={`Welcome to ${PRODUCT_NAME}`}
-					description="To get started with experiments you'll need to first add a datasource in settings."
-					buttonText="Go to Settings"
-					buttonIcon={<GearIcon />}
-					onClick={() => router.push(`/organizations/${currentOrgId}`)}
-				/>
-			) : committedExperiments.length === 0 ? (
-				<EmptyStateCard
-					title="Create your first experiment"
-					description="Get started by creating your first experiment."
-				>
-					<CreateExperimentButton />
-				</EmptyStateCard>
-			) : experimentsData ? (
-				<Flex direction="column" gap="4">
-					<Flex justify="between" align="center" gap="4">
-						<Flex align="center" gap="4">
-							<TextField.Root
-								placeholder="Search experiments..."
-								value={searchQuery}
-								onChange={(e) => setSearchQuery(e.target.value)}
-							>
-								<TextField.Slot>
-									<MagnifyingGlassIcon height="16" width="16" />
-								</TextField.Slot>
-							</TextField.Root>
+      {datasourcesData &&
+      (datasourcesData.items.length === 0 ||
+        (datasourcesData?.items.length === 1 &&
+          datasourcesData.items[0].driver === NO_DWH_DRIVER &&
+          committedExperiments.length === 0)) ? (
+        // If there are no non-api-only datasources and no experiments, show the ds setup message.
+        // One can still create api-only experiments from the create experiment button.
+        <EmptyStateCard
+          title={`Welcome to ${PRODUCT_NAME}`}
+          description="To get started with experiments you'll need to first add a datasource in settings."
+          buttonText="Go to Settings"
+          buttonIcon={<GearIcon />}
+          onClick={() => router.push(`/organizations/${currentOrgId}`)}
+        />
+      ) : committedExperiments.length === 0 ? (
+        <EmptyStateCard
+          title="Create your first experiment"
+          description="Get started by creating your first experiment."
+        >
+          <CreateExperimentButton />
+        </EmptyStateCard>
+      ) : experimentsData ? (
+        <Flex direction="column" gap="4">
+          <Flex justify="between" align="center" gap="4">
+            <Flex align="center" gap="4">
+              <TextField.Root
+                placeholder="Search experiments..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              >
+                <TextField.Slot>
+                  <MagnifyingGlassIcon height="16" width="16" />
+                </TextField.Slot>
+              </TextField.Root>
 
-							<ExperimentStatusFilter
-								value={selectedStatuses}
-								onChange={setSelectedStatuses}
-							/>
+              <ExperimentStatusFilter value={selectedStatuses} onChange={setSelectedStatuses} />
 
-							<ExperimentImpactFilter
-								value={selectedImpacts}
-								onChange={setSelectedImpacts}
-							/>
-							{filtersActive && (
-								<Tooltip content="Reset Filters">
-									<IconButton variant="soft" onClick={resetFilters}>
-										<ReloadIcon />
-									</IconButton>
-								</Tooltip>
-							)}
-						</Flex>
+              <ExperimentImpactFilter value={selectedImpacts} onChange={setSelectedImpacts} />
+              {filtersActive && (
+                <Tooltip content="Reset Filters">
+                  <IconButton variant="soft" onClick={resetFilters}>
+                    <ReloadIcon />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Flex>
 
-						<Flex gap="2">
-							<Tooltip content="Card View">
-								<IconButton
-									variant={isCardView ? "solid" : "soft"}
-									size="2"
-									onClick={() => setViewMode("card")}
-								>
-									<DashboardIcon />
-								</IconButton>
-							</Tooltip>
-							<Tooltip content="Table View">
-								<IconButton
-									variant={!isCardView ? "solid" : "soft"}
-									size="2"
-									onClick={() => setViewMode("table")}
-								>
-									<ListBulletIcon />
-								</IconButton>
-							</Tooltip>
-						</Flex>
-					</Flex>
+            <Flex gap="2">
+              <Tooltip content="Card View">
+                <IconButton variant={isCardView ? 'solid' : 'soft'} size="2" onClick={() => setViewMode('card')}>
+                  <DashboardIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip content="Table View">
+                <IconButton variant={!isCardView ? 'solid' : 'soft'} size="2" onClick={() => setViewMode('table')}>
+                  <ListBulletIcon />
+                </IconButton>
+              </Tooltip>
+            </Flex>
+          </Flex>
 
-					{filteredExperiments.length === 0 ? (
-						<EmptyStateCard
-							title={
-								searchQuery
-									? "No experiments found"
-									: "No experiments match your filters"
-							}
-							description={
-								searchQuery
-									? "Try adjusting your search terms or filters."
-									: "Try adjusting your filters to see more experiments."
-							}
-						/>
-					) : isCardView ? (
-						<Grid columns={{ initial: "1", md: "2", lg: "3" }} gap="3">
-							{filteredExperiments.map((experiment) => {
-								return (
-									<ExperimentCard
-										key={experiment.experiment_id}
-										title={experiment.design_spec.experiment_name}
-										hypothesis={experiment.design_spec.description}
-										type={experiment.design_spec.experiment_type}
-										isCluster={isClusterDesign(
-											experiment.design_spec,
-											(experiment as { power_analyses?: unknown })
-												.power_analyses,
-										)}
-										startDate={experiment.design_spec.start_date}
-										endDate={experiment.design_spec.end_date}
-										datasourceId={experiment.datasource_id}
-										designUrl={experiment.design_spec.design_url || ""}
-										experimentId={experiment.experiment_id}
-										organizationId={currentOrgId}
-										status={experiment.status}
-										impact={experiment.impact}
-										decision={experiment.decision}
-									/>
-								);
-							})}
-						</Grid>
-					) : (
-						<ExperimentsTable
-							experiments={filteredExperiments}
-							organizationId={currentOrgId}
-						/>
-					)}
-				</Flex>
-			) : null}
-		</Flex>
-	);
+          {filteredExperiments.length === 0 ? (
+            <EmptyStateCard
+              title={searchQuery ? 'No experiments found' : 'No experiments match your filters'}
+              description={
+                searchQuery
+                  ? 'Try adjusting your search terms or filters.'
+                  : 'Try adjusting your filters to see more experiments.'
+              }
+            />
+          ) : isCardView ? (
+            <Grid columns={{ initial: '1', md: '2', lg: '3' }} gap="3">
+              {filteredExperiments.map((experiment) => {
+                return (
+                  <ExperimentCard
+                    key={experiment.experiment_id}
+                    title={experiment.design_spec.experiment_name}
+                    hypothesis={experiment.design_spec.description}
+                    type={experiment.design_spec.experiment_type}
+                    isCluster={isClusterDesign(
+                      experiment.design_spec,
+                      (experiment as { power_analyses?: unknown }).power_analyses,
+                    )}
+                    startDate={experiment.design_spec.start_date}
+                    endDate={experiment.design_spec.end_date}
+                    datasourceId={experiment.datasource_id}
+                    designUrl={experiment.design_spec.design_url || ''}
+                    experimentId={experiment.experiment_id}
+                    organizationId={currentOrgId}
+                    status={experiment.status}
+                    impact={experiment.impact}
+                    decision={experiment.decision}
+                  />
+                );
+              })}
+            </Grid>
+          ) : (
+            <ExperimentsTable experiments={filteredExperiments} organizationId={currentOrgId} />
+          )}
+        </Flex>
+      ) : null}
+    </Flex>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,209 +1,283 @@
-'use client';
-import { useState } from 'react';
-import { useLocalStorage } from '@/providers/use-local-storage';
-import { Flex, Grid, Heading, IconButton, TextField, Tooltip } from '@radix-ui/themes';
-import { DashboardIcon, GearIcon, ListBulletIcon, MagnifyingGlassIcon, ReloadIcon } from '@radix-ui/react-icons';
-import { useListOrganizationDatasources, useListOrganizationExperiments } from '@/api/admin';
-import { XSpinner } from '@/components/ui/x-spinner';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
-import { useCurrentOrganization } from '@/providers/organization-provider';
-import { EmptyStateCard } from '@/components/ui/cards/empty-state-card';
-import { useRouter } from 'next/navigation';
-import { NO_DWH_DRIVER, PRODUCT_NAME } from '@/services/constants';
-import { CreateExperimentButton } from '@/components/features/experiments/create-experiment-button';
-import { ExperimentCard } from '@/components/features/experiments/experiment-card';
-import { ExperimentsTable } from '@/components/features/experiments/experiments-table';
-import { ExperimentStatusFilter } from '@/components/features/experiments/experiment-status-filter';
-import { ExperimentImpactFilter } from '@/components/features/experiments/experiment-impact-filter';
-import type { ExperimentStatus, ExperimentWithStatus } from '@/components/features/experiments/types';
-import { getExperimentStatus } from '@/services/experiment-utils';
+"use client";
+import {
+	useListOrganizationDatasources,
+	useListOrganizationExperiments,
+} from "@/api/admin";
+import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
+import { CreateExperimentButton } from "@/components/features/experiments/create-experiment-button";
+import { ExperimentCard } from "@/components/features/experiments/experiment-card";
+import { ExperimentImpactFilter } from "@/components/features/experiments/experiment-impact-filter";
+import { ExperimentStatusFilter } from "@/components/features/experiments/experiment-status-filter";
+import { ExperimentsTable } from "@/components/features/experiments/experiments-table";
+import type {
+	ExperimentStatus,
+	ExperimentWithStatus,
+} from "@/components/features/experiments/types";
+import { EmptyStateCard } from "@/components/ui/cards/empty-state-card";
+import { GenericErrorCallout } from "@/components/ui/generic-error";
+import { XSpinner } from "@/components/ui/x-spinner";
+import { useCurrentOrganization } from "@/providers/organization-provider";
+import { useLocalStorage } from "@/providers/use-local-storage";
+import { NO_DWH_DRIVER, PRODUCT_NAME } from "@/services/constants";
+import { getExperimentStatus } from "@/services/experiment-utils";
+import {
+	DashboardIcon,
+	GearIcon,
+	ListBulletIcon,
+	MagnifyingGlassIcon,
+	ReloadIcon,
+} from "@radix-ui/react-icons";
+import {
+	Flex,
+	Grid,
+	Heading,
+	IconButton,
+	TextField,
+	Tooltip,
+} from "@radix-ui/themes";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 export default function Page() {
-  const router = useRouter();
-  const orgContext = useCurrentOrganization();
-  const currentOrgId = orgContext!.current.id;
-  const [selectedStatuses, setSelectedStatuses] = useState<ExperimentStatus[]>([]);
-  const [selectedImpacts, setSelectedImpacts] = useState<string[]>([]);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [viewMode, setViewMode] = useLocalStorage<'card' | 'table'>('exp-view-mode');
+	const router = useRouter();
+	const orgContext = useCurrentOrganization();
+	const currentOrgId = orgContext!.current.id;
+	const [selectedStatuses, setSelectedStatuses] = useState<ExperimentStatus[]>(
+		[],
+	);
+	const [selectedImpacts, setSelectedImpacts] = useState<string[]>([]);
+	const [searchQuery, setSearchQuery] = useState("");
+	const [viewMode, setViewMode] = useLocalStorage<"card" | "table">(
+		"exp-view-mode",
+	);
 
-  const isCardView = viewMode === null || viewMode === 'card';
+	const isCardView = viewMode === null || viewMode === "card";
 
-  const { data: datasourcesData, error: datasourcesError } = useListOrganizationDatasources(currentOrgId, {
-    swr: {
-      enabled: !!currentOrgId,
-    },
-  });
+	const { data: datasourcesData, error: datasourcesError } =
+		useListOrganizationDatasources(currentOrgId, {
+			swr: {
+				enabled: !!currentOrgId,
+			},
+		});
 
-  const {
-    data: experimentsData,
-    isLoading: experimentsIsLoading,
-    error: experimentsError,
-  } = useListOrganizationExperiments(currentOrgId, {
-    swr: { enabled: !!currentOrgId },
-  });
+	const {
+		data: experimentsData,
+		isLoading: experimentsIsLoading,
+		error: experimentsError,
+	} = useListOrganizationExperiments(currentOrgId, {
+		swr: { enabled: !!currentOrgId },
+	});
 
-  const committedExperiments = experimentsData?.items.filter((experiment) => experiment.state === 'committed') || [];
+	const committedExperiments =
+		experimentsData?.items.filter(
+			(experiment) => experiment.state === "committed",
+		) || [];
 
-  const experimentsWithStatus = committedExperiments.map((experiment) => ({
-    ...experiment,
-    status: getExperimentStatus(experiment.design_spec.start_date, experiment.design_spec.end_date),
-  }));
+	const experimentsWithStatus = committedExperiments.map((experiment) => ({
+		...experiment,
+		status: getExperimentStatus(
+			experiment.design_spec.start_date,
+			experiment.design_spec.end_date,
+		),
+	}));
 
-  const matchesStatusFilter = (experiment: ExperimentWithStatus): boolean => {
-    if (selectedStatuses.length === 0) return true;
-    return selectedStatuses.includes(experiment.status);
-  };
+	const matchesStatusFilter = (experiment: ExperimentWithStatus): boolean => {
+		if (selectedStatuses.length === 0) return true;
+		return selectedStatuses.includes(experiment.status);
+	};
 
-  const matchesImpactFilter = (experiment: ExperimentWithStatus): boolean => {
-    if (selectedImpacts.length === 0) return true;
-    const normalizedImpact = experiment.impact ?? '';
-    return selectedImpacts.includes(normalizedImpact);
-  };
+	const matchesImpactFilter = (experiment: ExperimentWithStatus): boolean => {
+		if (selectedImpacts.length === 0) return true;
+		const normalizedImpact = experiment.impact ?? "";
+		return selectedImpacts.includes(normalizedImpact);
+	};
 
-  const matchesSearchQuery = (experiment: ExperimentWithStatus): boolean => {
-    if (searchQuery === '') return true;
-    const query = searchQuery.toLowerCase();
-    return (
-      experiment.design_spec.experiment_name.toLowerCase().includes(query) ||
-      experiment.design_spec.description.toLowerCase().includes(query)
-    );
-  };
+	const matchesSearchQuery = (experiment: ExperimentWithStatus): boolean => {
+		if (searchQuery === "") return true;
+		const query = searchQuery.toLowerCase();
+		return (
+			experiment.design_spec.experiment_name.toLowerCase().includes(query) ||
+			experiment.design_spec.description.toLowerCase().includes(query)
+		);
+	};
 
-  const resetFilters = () => {
-    setSelectedStatuses([]);
-    setSelectedImpacts([]);
-    setSearchQuery('');
-  };
+	const resetFilters = () => {
+		setSelectedStatuses([]);
+		setSelectedImpacts([]);
+		setSearchQuery("");
+	};
 
-  const filteredExperiments = experimentsWithStatus.filter(
-    (experiment) =>
-      matchesStatusFilter(experiment) && matchesImpactFilter(experiment) && matchesSearchQuery(experiment),
-  );
+	const filteredExperiments = experimentsWithStatus.filter(
+		(experiment) =>
+			matchesStatusFilter(experiment) &&
+			matchesImpactFilter(experiment) &&
+			matchesSearchQuery(experiment),
+	);
 
-  const filtersActive = selectedStatuses.length > 0 || selectedImpacts.length > 0 || searchQuery !== '';
+	const filtersActive =
+		selectedStatuses.length > 0 ||
+		selectedImpacts.length > 0 ||
+		searchQuery !== "";
 
-  if (datasourcesError) {
-    return <GenericErrorCallout title={'Error with experiments list'} error={datasourcesError} />;
-  }
+	if (datasourcesError) {
+		return (
+			<GenericErrorCallout
+				title={"Error with experiments list"}
+				error={datasourcesError}
+			/>
+		);
+	}
 
-  if (experimentsError) {
-    return <GenericErrorCallout title={'Error with experiments list'} error={experimentsError} />;
-  }
+	if (experimentsError) {
+		return (
+			<GenericErrorCallout
+				title={"Error with experiments list"}
+				error={experimentsError}
+			/>
+		);
+	}
 
-  return (
-    <Flex direction="column" gap="4">
-      <Flex justify="between" align="center">
-        <Heading size={'8'}>
-          Experiments
-          {orgContext && orgContext.available.length > 1 && <> for {orgContext.current.name}</>}
-        </Heading>
-        <CreateExperimentButton />
-      </Flex>
+	return (
+		<Flex direction="column" gap="4">
+			<Flex justify="between" align="center">
+				<Heading size={"8"}>
+					Experiments
+					{orgContext && orgContext.available.length > 1 && (
+						<> for {orgContext.current.name}</>
+					)}
+				</Heading>
+				<CreateExperimentButton />
+			</Flex>
 
-      {experimentsIsLoading && (
-        <Flex>
-          <XSpinner message={'Loading experiments list...'} />
-        </Flex>
-      )}
+			{experimentsIsLoading && (
+				<Flex>
+					<XSpinner message={"Loading experiments list..."} />
+				</Flex>
+			)}
 
-      {datasourcesData &&
-      (datasourcesData.items.length === 0 ||
-        (datasourcesData?.items.length === 1 &&
-          datasourcesData.items[0].driver === NO_DWH_DRIVER &&
-          committedExperiments.length === 0)) ? (
-        // If there are no non-api-only datasources and no experiments, show the ds setup message.
-        // One can still create api-only experiments from the create experiment button.
-        <EmptyStateCard
-          title={`Welcome to ${PRODUCT_NAME}`}
-          description="To get started with experiments you'll need to first add a datasource in settings."
-          buttonText="Go to Settings"
-          buttonIcon={<GearIcon />}
-          onClick={() => router.push(`/organizations/${currentOrgId}`)}
-        />
-      ) : committedExperiments.length === 0 ? (
-        <EmptyStateCard
-          title="Create your first experiment"
-          description="Get started by creating your first experiment."
-        >
-          <CreateExperimentButton />
-        </EmptyStateCard>
-      ) : experimentsData ? (
-        <Flex direction="column" gap="4">
-          <Flex justify="between" align="center" gap="4">
-            <Flex align="center" gap="4">
-              <TextField.Root
-                placeholder="Search experiments..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              >
-                <TextField.Slot>
-                  <MagnifyingGlassIcon height="16" width="16" />
-                </TextField.Slot>
-              </TextField.Root>
+			{datasourcesData &&
+			(datasourcesData.items.length === 0 ||
+				(datasourcesData?.items.length === 1 &&
+					datasourcesData.items[0].driver === NO_DWH_DRIVER &&
+					committedExperiments.length === 0)) ? (
+				// If there are no non-api-only datasources and no experiments, show the ds setup message.
+				// One can still create api-only experiments from the create experiment button.
+				<EmptyStateCard
+					title={`Welcome to ${PRODUCT_NAME}`}
+					description="To get started with experiments you'll need to first add a datasource in settings."
+					buttonText="Go to Settings"
+					buttonIcon={<GearIcon />}
+					onClick={() => router.push(`/organizations/${currentOrgId}`)}
+				/>
+			) : committedExperiments.length === 0 ? (
+				<EmptyStateCard
+					title="Create your first experiment"
+					description="Get started by creating your first experiment."
+				>
+					<CreateExperimentButton />
+				</EmptyStateCard>
+			) : experimentsData ? (
+				<Flex direction="column" gap="4">
+					<Flex justify="between" align="center" gap="4">
+						<Flex align="center" gap="4">
+							<TextField.Root
+								placeholder="Search experiments..."
+								value={searchQuery}
+								onChange={(e) => setSearchQuery(e.target.value)}
+							>
+								<TextField.Slot>
+									<MagnifyingGlassIcon height="16" width="16" />
+								</TextField.Slot>
+							</TextField.Root>
 
-              <ExperimentStatusFilter value={selectedStatuses} onChange={setSelectedStatuses} />
+							<ExperimentStatusFilter
+								value={selectedStatuses}
+								onChange={setSelectedStatuses}
+							/>
 
-              <ExperimentImpactFilter value={selectedImpacts} onChange={setSelectedImpacts} />
-              {filtersActive && (
-                <Tooltip content="Reset Filters">
-                  <IconButton variant="soft" onClick={resetFilters}>
-                    <ReloadIcon />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </Flex>
+							<ExperimentImpactFilter
+								value={selectedImpacts}
+								onChange={setSelectedImpacts}
+							/>
+							{filtersActive && (
+								<Tooltip content="Reset Filters">
+									<IconButton variant="soft" onClick={resetFilters}>
+										<ReloadIcon />
+									</IconButton>
+								</Tooltip>
+							)}
+						</Flex>
 
-            <Flex gap="2">
-              <Tooltip content="Card View">
-                <IconButton variant={isCardView ? 'solid' : 'soft'} size="2" onClick={() => setViewMode('card')}>
-                  <DashboardIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip content="Table View">
-                <IconButton variant={!isCardView ? 'solid' : 'soft'} size="2" onClick={() => setViewMode('table')}>
-                  <ListBulletIcon />
-                </IconButton>
-              </Tooltip>
-            </Flex>
-          </Flex>
+						<Flex gap="2">
+							<Tooltip content="Card View">
+								<IconButton
+									variant={isCardView ? "solid" : "soft"}
+									size="2"
+									onClick={() => setViewMode("card")}
+								>
+									<DashboardIcon />
+								</IconButton>
+							</Tooltip>
+							<Tooltip content="Table View">
+								<IconButton
+									variant={!isCardView ? "solid" : "soft"}
+									size="2"
+									onClick={() => setViewMode("table")}
+								>
+									<ListBulletIcon />
+								</IconButton>
+							</Tooltip>
+						</Flex>
+					</Flex>
 
-          {filteredExperiments.length === 0 ? (
-            <EmptyStateCard
-              title={searchQuery ? 'No experiments found' : 'No experiments match your filters'}
-              description={
-                searchQuery
-                  ? 'Try adjusting your search terms or filters.'
-                  : 'Try adjusting your filters to see more experiments.'
-              }
-            />
-          ) : isCardView ? (
-            <Grid columns={{ initial: '1', md: '2', lg: '3' }} gap="3">
-              {filteredExperiments.map((experiment) => {
-                return (
-                  <ExperimentCard
-                    key={experiment.experiment_id}
-                    title={experiment.design_spec.experiment_name}
-                    hypothesis={experiment.design_spec.description}
-                    type={experiment.design_spec.experiment_type}
-                    startDate={experiment.design_spec.start_date}
-                    endDate={experiment.design_spec.end_date}
-                    datasourceId={experiment.datasource_id}
-                    designUrl={experiment.design_spec.design_url || ''}
-                    experimentId={experiment.experiment_id}
-                    organizationId={currentOrgId}
-                    status={experiment.status}
-                    impact={experiment.impact}
-                    decision={experiment.decision}
-                  />
-                );
-              })}
-            </Grid>
-          ) : (
-            <ExperimentsTable experiments={filteredExperiments} organizationId={currentOrgId} />
-          )}
-        </Flex>
-      ) : null}
-    </Flex>
-  );
+					{filteredExperiments.length === 0 ? (
+						<EmptyStateCard
+							title={
+								searchQuery
+									? "No experiments found"
+									: "No experiments match your filters"
+							}
+							description={
+								searchQuery
+									? "Try adjusting your search terms or filters."
+									: "Try adjusting your filters to see more experiments."
+							}
+						/>
+					) : isCardView ? (
+						<Grid columns={{ initial: "1", md: "2", lg: "3" }} gap="3">
+							{filteredExperiments.map((experiment) => {
+								return (
+									<ExperimentCard
+										key={experiment.experiment_id}
+										title={experiment.design_spec.experiment_name}
+										hypothesis={experiment.design_spec.description}
+										type={experiment.design_spec.experiment_type}
+										isCluster={isClusterDesign(
+											experiment.design_spec,
+											(experiment as { power_analyses?: unknown })
+												.power_analyses,
+										)}
+										startDate={experiment.design_spec.start_date}
+										endDate={experiment.design_spec.end_date}
+										datasourceId={experiment.datasource_id}
+										designUrl={experiment.design_spec.design_url || ""}
+										experimentId={experiment.experiment_id}
+										organizationId={currentOrgId}
+										status={experiment.status}
+										impact={experiment.impact}
+										decision={experiment.decision}
+									/>
+								);
+							})}
+						</Grid>
+					) : (
+						<ExperimentsTable
+							experiments={filteredExperiments}
+							organizationId={currentOrgId}
+						/>
+					)}
+				</Flex>
+			) : null}
+		</Flex>
+	);
 }

--- a/src/components/features/experiments/arms-and-allocations-table-row.tsx
+++ b/src/components/features/experiments/arms-and-allocations-table-row.tsx
@@ -1,62 +1,88 @@
-import { Table, Heading, Badge, Text } from '@radix-ui/themes';
-import { PersonIcon } from '@radix-ui/react-icons';
-import { useUpdateArm, getGetExperimentForUiKey } from '@/api/admin';
-import { Arm } from '@/api/methods.schemas';
-import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
-import { EditableTextArea } from '@/components/ui/inputs/editable-text-area';
-import { mutate } from 'swr';
-import { ReadMoreText } from '@/components/ui/read-more-text';
+import { getGetExperimentForUiKey, useUpdateArm } from "@/api/admin";
+import { Arm } from "@/api/methods.schemas";
+import { EditableTextArea } from "@/components/ui/inputs/editable-text-area";
+import { EditableTextField } from "@/components/ui/inputs/editable-text-field";
+import { ReadMoreText } from "@/components/ui/read-more-text";
+import { PersonIcon } from "@radix-ui/react-icons";
+import { Badge, Heading, Table, Text } from "@radix-ui/themes";
+import { mutate } from "swr";
 
 interface ArmsAndAllocationsTableRowProps {
-  datasourceId: string;
-  experimentId: string;
-  arm: Arm;
-  armSize: number;
-  percentage: number;
+	datasourceId: string;
+	experimentId: string;
+	arm: Arm;
+	armSize: number;
+	percentage: number;
+	/** Cluster count for this arm (cluster-randomized experiments only). */
+	numClusters?: number;
+	/** Whether the parent table is showing the Clusters column. */
+	showClusters?: boolean;
 }
 
 export function ArmsAndAllocationsTableRow({
-  datasourceId,
-  experimentId,
-  arm,
-  armSize,
-  percentage,
+	datasourceId,
+	experimentId,
+	arm,
+	armSize,
+	percentage,
+	numClusters,
+	showClusters,
 }: ArmsAndAllocationsTableRowProps) {
-  const { trigger: updateArm } = useUpdateArm(datasourceId, experimentId, arm.arm_id!, {
-    swr: {
-      onSuccess: async () => {
-        await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
-      },
-    },
-  });
+	const { trigger: updateArm } = useUpdateArm(
+		datasourceId,
+		experimentId,
+		arm.arm_id!,
+		{
+			swr: {
+				onSuccess: async () => {
+					await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
+				},
+			},
+		},
+	);
 
-  return (
-    <Table.Row>
-      <Table.Cell width="20%">
-        <EditableTextField value={arm.arm_name} onSubmit={(value) => updateArm({ name: value })} size="1">
-          <Heading size="2">{arm.arm_name}</Heading>
-        </EditableTextField>
-      </Table.Cell>
-      <Table.Cell>
-        <Badge>
-          <PersonIcon />
-          <Text>{armSize.toLocaleString()}</Text>
-        </Badge>
-      </Table.Cell>
-      <Table.Cell>
-        <Badge>
-          <Text>{percentage.toFixed(2)}%</Text>
-        </Badge>
-      </Table.Cell>
-      <Table.Cell>
-        <EditableTextArea
-          value={arm.arm_description || 'No description'}
-          onSubmit={(value) => updateArm({ description: value })}
-          size="1"
-        >
-          <ReadMoreText text={arm.arm_description || 'No description'} />
-        </EditableTextArea>
-      </Table.Cell>
-    </Table.Row>
-  );
+	return (
+		<Table.Row>
+			<Table.Cell width="20%">
+				<EditableTextField
+					value={arm.arm_name}
+					onSubmit={(value) => updateArm({ name: value })}
+					size="1"
+				>
+					<Heading size="2">{arm.arm_name}</Heading>
+				</EditableTextField>
+			</Table.Cell>
+			<Table.Cell>
+				<Badge>
+					<PersonIcon />
+					<Text>{armSize.toLocaleString()}</Text>
+				</Badge>
+			</Table.Cell>
+			{showClusters && (
+				<Table.Cell>
+					{numClusters !== undefined ? (
+						<Badge color="green">
+							<Text>{numClusters.toLocaleString()}</Text>
+						</Badge>
+					) : (
+						<Text color="gray">—</Text>
+					)}
+				</Table.Cell>
+			)}
+			<Table.Cell>
+				<Badge>
+					<Text>{percentage.toFixed(2)}%</Text>
+				</Badge>
+			</Table.Cell>
+			<Table.Cell>
+				<EditableTextArea
+					value={arm.arm_description || "No description"}
+					onSubmit={(value) => updateArm({ description: value })}
+					size="1"
+				>
+					<ReadMoreText text={arm.arm_description || "No description"} />
+				</EditableTextArea>
+			</Table.Cell>
+		</Table.Row>
+	);
 }

--- a/src/components/features/experiments/arms-and-allocations-table-row.tsx
+++ b/src/components/features/experiments/arms-and-allocations-table-row.tsx
@@ -1,88 +1,79 @@
-import { getGetExperimentForUiKey, useUpdateArm } from "@/api/admin";
-import { Arm } from "@/api/methods.schemas";
-import { EditableTextArea } from "@/components/ui/inputs/editable-text-area";
-import { EditableTextField } from "@/components/ui/inputs/editable-text-field";
-import { ReadMoreText } from "@/components/ui/read-more-text";
-import { PersonIcon } from "@radix-ui/react-icons";
-import { Badge, Heading, Table, Text } from "@radix-ui/themes";
-import { mutate } from "swr";
+import { getGetExperimentForUiKey, useUpdateArm } from '@/api/admin';
+import { Arm } from '@/api/methods.schemas';
+import { EditableTextArea } from '@/components/ui/inputs/editable-text-area';
+import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
+import { ReadMoreText } from '@/components/ui/read-more-text';
+import { PersonIcon } from '@radix-ui/react-icons';
+import { Badge, Heading, Table, Text } from '@radix-ui/themes';
+import { mutate } from 'swr';
 
 interface ArmsAndAllocationsTableRowProps {
-	datasourceId: string;
-	experimentId: string;
-	arm: Arm;
-	armSize: number;
-	percentage: number;
-	/** Cluster count for this arm (cluster-randomized experiments only). */
-	numClusters?: number;
-	/** Whether the parent table is showing the Clusters column. */
-	showClusters?: boolean;
+  datasourceId: string;
+  experimentId: string;
+  arm: Arm;
+  armSize: number;
+  percentage: number;
+  /** Cluster count for this arm (cluster-randomized experiments only). */
+  numClusters?: number;
+  /** Whether the parent table is showing the Clusters column. */
+  showClusters?: boolean;
 }
 
 export function ArmsAndAllocationsTableRow({
-	datasourceId,
-	experimentId,
-	arm,
-	armSize,
-	percentage,
-	numClusters,
-	showClusters,
+  datasourceId,
+  experimentId,
+  arm,
+  armSize,
+  percentage,
+  numClusters,
+  showClusters,
 }: ArmsAndAllocationsTableRowProps) {
-	const { trigger: updateArm } = useUpdateArm(
-		datasourceId,
-		experimentId,
-		arm.arm_id!,
-		{
-			swr: {
-				onSuccess: async () => {
-					await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
-				},
-			},
-		},
-	);
+  const { trigger: updateArm } = useUpdateArm(datasourceId, experimentId, arm.arm_id!, {
+    swr: {
+      onSuccess: async () => {
+        await mutate(getGetExperimentForUiKey(datasourceId, experimentId));
+      },
+    },
+  });
 
-	return (
-		<Table.Row>
-			<Table.Cell width="20%">
-				<EditableTextField
-					value={arm.arm_name}
-					onSubmit={(value) => updateArm({ name: value })}
-					size="1"
-				>
-					<Heading size="2">{arm.arm_name}</Heading>
-				</EditableTextField>
-			</Table.Cell>
-			<Table.Cell>
-				<Badge>
-					<PersonIcon />
-					<Text>{armSize.toLocaleString()}</Text>
-				</Badge>
-			</Table.Cell>
-			{showClusters && (
-				<Table.Cell>
-					{numClusters !== undefined ? (
-						<Badge color="green">
-							<Text>{numClusters.toLocaleString()}</Text>
-						</Badge>
-					) : (
-						<Text color="gray">—</Text>
-					)}
-				</Table.Cell>
-			)}
-			<Table.Cell>
-				<Badge>
-					<Text>{percentage.toFixed(2)}%</Text>
-				</Badge>
-			</Table.Cell>
-			<Table.Cell>
-				<EditableTextArea
-					value={arm.arm_description || "No description"}
-					onSubmit={(value) => updateArm({ description: value })}
-					size="1"
-				>
-					<ReadMoreText text={arm.arm_description || "No description"} />
-				</EditableTextArea>
-			</Table.Cell>
-		</Table.Row>
-	);
+  return (
+    <Table.Row>
+      <Table.Cell width="20%">
+        <EditableTextField value={arm.arm_name} onSubmit={(value) => updateArm({ name: value })} size="1">
+          <Heading size="2">{arm.arm_name}</Heading>
+        </EditableTextField>
+      </Table.Cell>
+      <Table.Cell>
+        <Badge>
+          <PersonIcon />
+          <Text>{armSize.toLocaleString()}</Text>
+        </Badge>
+      </Table.Cell>
+      {showClusters && (
+        <Table.Cell>
+          {numClusters !== undefined ? (
+            <Badge color="green">
+              <Text>{numClusters.toLocaleString()}</Text>
+            </Badge>
+          ) : (
+            <Text color="gray">—</Text>
+          )}
+        </Table.Cell>
+      )}
+      <Table.Cell>
+        <Badge>
+          <Text>{percentage.toFixed(2)}%</Text>
+        </Badge>
+      </Table.Cell>
+      <Table.Cell>
+        <EditableTextArea
+          value={arm.arm_description || 'No description'}
+          onSubmit={(value) => updateArm({ description: value })}
+          size="1"
+        >
+          <ReadMoreText text={arm.arm_description || 'No description'} />
+        </EditableTextArea>
+      </Table.Cell>
+    </Table.Row>
+  );
 }

--- a/src/components/features/experiments/arms-and-allocations-table.tsx
+++ b/src/components/features/experiments/arms-and-allocations-table.tsx
@@ -1,69 +1,64 @@
-import { Arm, AssignSummaryArmSizes } from "@/api/methods.schemas";
-import { Table } from "@radix-ui/themes";
-import { ArmsAndAllocationsTableRow } from "./arms-and-allocations-table-row";
+import { Arm, AssignSummaryArmSizes } from '@/api/methods.schemas';
+import { Table } from '@radix-ui/themes';
+import { ArmsAndAllocationsTableRow } from './arms-and-allocations-table-row';
 
 interface ArmsAndAllocationsTableProps {
-	datasourceId: string;
-	experimentId: string;
-	arms: Arm[];
-	sampleSize: number;
-	armSizes?: AssignSummaryArmSizes;
-	/**
-	 * For cluster-randomized experiments, the number of clusters per arm
-	 * (keyed by arm_id). When provided, a Clusters column is shown in green.
-	 * Issue #217 mockup ClustersUI3A.
-	 */
-	clustersByArmId?: Record<string, number>;
+  datasourceId: string;
+  experimentId: string;
+  arms: Arm[];
+  sampleSize: number;
+  armSizes?: AssignSummaryArmSizes;
+  /**
+   * For cluster-randomized experiments, the number of clusters per arm
+   * (keyed by arm_id). When provided, a Clusters column is shown in green.
+   * Issue #217 mockup ClustersUI3A.
+   */
+  clustersByArmId?: Record<string, number>;
 }
 
 export function ArmsAndAllocationsTable({
-	datasourceId,
-	experimentId,
-	arms,
-	sampleSize,
-	armSizes,
-	clustersByArmId,
+  datasourceId,
+  experimentId,
+  arms,
+  sampleSize,
+  armSizes,
+  clustersByArmId,
 }: ArmsAndAllocationsTableProps) {
-	const sortedArms = [...arms].sort((a, b) => {
-		if (!a.arm_id || !b.arm_id) return 0;
-		return a.arm_id.localeCompare(b.arm_id);
-	});
-	const showClusters = clustersByArmId !== undefined;
-	return (
-		<Table.Root>
-			<Table.Header>
-				<Table.Row>
-					<Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-					<Table.ColumnHeaderCell>Participants</Table.ColumnHeaderCell>
-					{showClusters && (
-						<Table.ColumnHeaderCell>Clusters</Table.ColumnHeaderCell>
-					)}
-					<Table.ColumnHeaderCell>Split</Table.ColumnHeaderCell>
-					<Table.ColumnHeaderCell>Description</Table.ColumnHeaderCell>
-				</Table.Row>
-			</Table.Header>
-			<Table.Body>
-				{sortedArms.map((arm) => {
-					const armSize =
-						armSizes?.find((a) => a.arm.arm_id === arm.arm_id)?.size || 0;
-					const percentage = (armSize / sampleSize) * 100;
-					const numClusters = arm.arm_id
-						? clustersByArmId?.[arm.arm_id]
-						: undefined;
-					return (
-						<ArmsAndAllocationsTableRow
-							key={arm.arm_id}
-							datasourceId={datasourceId}
-							experimentId={experimentId}
-							arm={arm}
-							armSize={armSize}
-							percentage={percentage}
-							numClusters={numClusters}
-							showClusters={showClusters}
-						/>
-					);
-				})}
-			</Table.Body>
-		</Table.Root>
-	);
+  const sortedArms = [...arms].sort((a, b) => {
+    if (!a.arm_id || !b.arm_id) return 0;
+    return a.arm_id.localeCompare(b.arm_id);
+  });
+  const showClusters = clustersByArmId !== undefined;
+  return (
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Participants</Table.ColumnHeaderCell>
+          {showClusters && <Table.ColumnHeaderCell>Clusters</Table.ColumnHeaderCell>}
+          <Table.ColumnHeaderCell>Split</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Description</Table.ColumnHeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {sortedArms.map((arm) => {
+          const armSize = armSizes?.find((a) => a.arm.arm_id === arm.arm_id)?.size || 0;
+          const percentage = (armSize / sampleSize) * 100;
+          const numClusters = arm.arm_id ? clustersByArmId?.[arm.arm_id] : undefined;
+          return (
+            <ArmsAndAllocationsTableRow
+              key={arm.arm_id}
+              datasourceId={datasourceId}
+              experimentId={experimentId}
+              arm={arm}
+              armSize={armSize}
+              percentage={percentage}
+              numClusters={numClusters}
+              showClusters={showClusters}
+            />
+          );
+        })}
+      </Table.Body>
+    </Table.Root>
+  );
 }

--- a/src/components/features/experiments/arms-and-allocations-table.tsx
+++ b/src/components/features/experiments/arms-and-allocations-table.tsx
@@ -1,52 +1,69 @@
-import { Table } from '@radix-ui/themes';
-import { Arm, AssignSummaryArmSizes } from '@/api/methods.schemas';
-import { ArmsAndAllocationsTableRow } from './arms-and-allocations-table-row';
+import { Arm, AssignSummaryArmSizes } from "@/api/methods.schemas";
+import { Table } from "@radix-ui/themes";
+import { ArmsAndAllocationsTableRow } from "./arms-and-allocations-table-row";
 
 interface ArmsAndAllocationsTableProps {
-  datasourceId: string;
-  experimentId: string;
-  arms: Arm[];
-  sampleSize: number;
-  armSizes?: AssignSummaryArmSizes;
+	datasourceId: string;
+	experimentId: string;
+	arms: Arm[];
+	sampleSize: number;
+	armSizes?: AssignSummaryArmSizes;
+	/**
+	 * For cluster-randomized experiments, the number of clusters per arm
+	 * (keyed by arm_id). When provided, a Clusters column is shown in green.
+	 * Issue #217 mockup ClustersUI3A.
+	 */
+	clustersByArmId?: Record<string, number>;
 }
 
 export function ArmsAndAllocationsTable({
-  datasourceId,
-  experimentId,
-  arms,
-  sampleSize,
-  armSizes,
+	datasourceId,
+	experimentId,
+	arms,
+	sampleSize,
+	armSizes,
+	clustersByArmId,
 }: ArmsAndAllocationsTableProps) {
-  const sortedArms = [...arms].sort((a, b) => {
-    if (!a.arm_id || !b.arm_id) return 0;
-    return a.arm_id.localeCompare(b.arm_id);
-  });
-  return (
-    <Table.Root>
-      <Table.Header>
-        <Table.Row>
-          <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Participants</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Split</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Description</Table.ColumnHeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {sortedArms.map((arm) => {
-          const armSize = armSizes?.find((a) => a.arm.arm_id === arm.arm_id)?.size || 0;
-          const percentage = (armSize / sampleSize) * 100;
-          return (
-            <ArmsAndAllocationsTableRow
-              key={arm.arm_id}
-              datasourceId={datasourceId}
-              experimentId={experimentId}
-              arm={arm}
-              armSize={armSize}
-              percentage={percentage}
-            />
-          );
-        })}
-      </Table.Body>
-    </Table.Root>
-  );
+	const sortedArms = [...arms].sort((a, b) => {
+		if (!a.arm_id || !b.arm_id) return 0;
+		return a.arm_id.localeCompare(b.arm_id);
+	});
+	const showClusters = clustersByArmId !== undefined;
+	return (
+		<Table.Root>
+			<Table.Header>
+				<Table.Row>
+					<Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+					<Table.ColumnHeaderCell>Participants</Table.ColumnHeaderCell>
+					{showClusters && (
+						<Table.ColumnHeaderCell>Clusters</Table.ColumnHeaderCell>
+					)}
+					<Table.ColumnHeaderCell>Split</Table.ColumnHeaderCell>
+					<Table.ColumnHeaderCell>Description</Table.ColumnHeaderCell>
+				</Table.Row>
+			</Table.Header>
+			<Table.Body>
+				{sortedArms.map((arm) => {
+					const armSize =
+						armSizes?.find((a) => a.arm.arm_id === arm.arm_id)?.size || 0;
+					const percentage = (armSize / sampleSize) * 100;
+					const numClusters = arm.arm_id
+						? clustersByArmId?.[arm.arm_id]
+						: undefined;
+					return (
+						<ArmsAndAllocationsTableRow
+							key={arm.arm_id}
+							datasourceId={datasourceId}
+							experimentId={experimentId}
+							arm={arm}
+							armSize={armSize}
+							percentage={percentage}
+							numClusters={numClusters}
+							showClusters={showClusters}
+						/>
+					);
+				})}
+			</Table.Body>
+		</Table.Root>
+	);
 }

--- a/src/components/features/experiments/cluster-builder.tsx
+++ b/src/components/features/experiments/cluster-builder.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import type { FieldMetadata } from "@/api/methods.schemas";
+import { Combobox } from "@/components/ui/combobox";
+import { DataTypeBadge } from "@/components/ui/data-type-badge";
+import { Pencil1Icon, ReloadIcon } from "@radix-ui/react-icons";
+import {
+	Box,
+	Button,
+	Callout,
+	Flex,
+	Grid,
+	IconButton,
+	Spinner,
+	Text,
+	TextField,
+} from "@radix-ui/themes";
+import { useState } from "react";
+
+/**
+ * ClusterBuilder is the cluster-randomization counterpart to StrataBuilder.
+ *
+ * It collects:
+ *  - the cluster ID field (e.g. school_id, village_id)
+ *  - the per-experiment ICC, CV, and average cluster size as manual inputs
+ *
+ * These are sent to the backend (PR #163's API) as `cluster_column` on the
+ * design spec and `icc`/`cv`/`avg_cluster_size` on each metric. The backend
+ * can auto-calculate the latter three from the data when the user leaves
+ * them blank; this component intentionally keeps them as manual inputs for
+ * the first cut of the cluster UI.
+ *
+ * If CV > 0.5, a "high variability" warning is shown next to the CV input
+ * (per issue #217 mockups).
+ */
+
+interface ClusterBuilderProps {
+	/** Candidate cluster-ID fields. Caller should sort and exclude invalid fields. */
+	availableFields: FieldMetadata[];
+	clusterField?: FieldMetadata;
+	icc: string;
+	cv: string;
+	avgClusterSize: string;
+	onClusterFieldChange: (field: FieldMetadata | undefined) => void;
+	onIccChange: (value: string) => void;
+	onCvChange: (value: string) => void;
+	onAvgClusterSizeChange: (value: string) => void;
+	/**
+	 * Called when the user clicks "Calculate from datasource". The parent
+	 * runs a power-check with cluster_column set (and ICC/CV/avg unset) — the
+	 * BE auto-calculates the cluster stats and returns them — then dispatches
+	 * the values back into this builder via the on*Change callbacks.
+	 *
+	 * When undefined, the auto-fill button is not shown (e.g. when prerequisites
+	 * like a primary metric aren't ready yet).
+	 */
+	onAutoFill?: () => Promise<void> | void;
+	/** Whether an auto-fill request is currently in flight. */
+	autoFillLoading?: boolean;
+	/** Error message from the most recent auto-fill attempt, if any. */
+	autoFillError?: string | null;
+}
+
+const getDisplayText = (option: FieldMetadata) => option.field_name;
+
+interface ClusterComboboxRowProps {
+	field: FieldMetadata;
+}
+
+const ClusterComboboxRow = ({ field }: ClusterComboboxRowProps) => (
+	<Flex gap="2" align="center" justify="between" wrap="nowrap">
+		<Text size="2">{field.field_name}</Text>
+		<DataTypeBadge type={field.data_type} />
+	</Flex>
+);
+
+const HIGH_CV_THRESHOLD = 0.5;
+
+/**
+ * Read-mostly numeric stat with a small ghost pencil button (matches the
+ * Pencil1Icon UX used elsewhere on arm names). The value displays plain when
+ * idle; clicking the pencil flips to an editable input that commits on blur or
+ * Enter. The display chip has a soft green background (var(--green-2)) when a
+ * value is present, signalling "auto-filled from the datasource, click to
+ * override" per the issue #217 mockups.
+ */
+function ClusterStatField({
+	label,
+	value,
+	placeholder,
+	min,
+	max,
+	step,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	placeholder: string;
+	min?: number;
+	max?: number;
+	step?: string;
+	onChange: (next: string) => void;
+}) {
+	const [editing, setEditing] = useState(false);
+	const [draft, setDraft] = useState(value);
+
+	const startEditing = () => {
+		setDraft(value);
+		setEditing(true);
+	};
+	const commit = () => {
+		if (draft !== value) onChange(draft);
+		setEditing(false);
+	};
+
+	return (
+		<Flex direction="column" gap="1">
+			<Text as="label" size="2" weight="bold">
+				{label}
+			</Text>
+			{editing ? (
+				<TextField.Root
+					autoFocus
+					type="number"
+					inputMode="decimal"
+					min={min}
+					max={max}
+					step={step}
+					value={draft}
+					placeholder={placeholder}
+					onChange={(e) => setDraft(e.target.value)}
+					onBlur={commit}
+					onKeyDown={(e) => {
+						if (e.key === "Enter") commit();
+						else if (e.key === "Escape") setEditing(false);
+					}}
+				/>
+			) : (
+				<Flex
+					align="center"
+					gap="2"
+					px="2"
+					py="1"
+					style={{
+						backgroundColor: value !== "" ? "var(--green-2)" : undefined,
+						border: "1px solid var(--gray-a5)",
+						borderRadius: "var(--radius-2)",
+						minHeight: "32px",
+					}}
+				>
+					<Text style={{ flexGrow: 1 }}>
+						{value !== "" ? value : placeholder}
+					</Text>
+					<IconButton
+						variant="ghost"
+						size="1"
+						style={{ opacity: 0.6 }}
+						onClick={startEditing}
+						aria-label={`Edit ${label}`}
+					>
+						<Pencil1Icon />
+					</IconButton>
+				</Flex>
+			)}
+		</Flex>
+	);
+}
+
+export function ClusterBuilder({
+	availableFields,
+	clusterField,
+	icc,
+	cv,
+	avgClusterSize,
+	onClusterFieldChange,
+	onIccChange,
+	onCvChange,
+	onAvgClusterSizeChange,
+	onAutoFill,
+	autoFillLoading,
+	autoFillError,
+}: ClusterBuilderProps) {
+	const cvNum = Number(cv);
+	const cvIsHighVariability = cv !== "" && !Number.isNaN(cvNum) && cvNum > HIGH_CV_THRESHOLD;
+
+	if (availableFields.length === 0) {
+		return (
+			<Text color="gray" size="2">
+				No fields available to use as a cluster ID for this table.
+			</Text>
+		);
+	}
+
+	return (
+		<Flex direction="column" gap="3" overflowX="auto">
+			<Text size="2" color="gray">
+				ICC is calculated from the datasource for your primary metric.
+			</Text>
+
+			<Flex gap="2" align="center" wrap="wrap">
+				<Text as="label" size="2" weight="bold">
+					Cluster ID field
+				</Text>
+				<Combobox<FieldMetadata>
+					value={clusterField?.field_name ?? ""}
+					onChange={(_value, fieldName) => {
+						if (!fieldName) {
+							onClusterFieldChange(undefined);
+							return;
+						}
+						const match = availableFields.find(
+							(f) => f.field_name === fieldName,
+						);
+						if (match) onClusterFieldChange(match);
+					}}
+					options={availableFields}
+					getDisplayTextForOption={getDisplayText}
+					getKeyForOption={getDisplayText}
+					placeholder="Search fields..."
+					noMatchText="No matching fields"
+					dropdownRow={({ option }) => <ClusterComboboxRow field={option} />}
+				/>
+				{onAutoFill && (
+					<Button
+						variant="soft"
+						disabled={!clusterField || autoFillLoading}
+						onClick={async (e) => {
+							e.preventDefault();
+							await onAutoFill();
+						}}
+					>
+						<Spinner loading={!!autoFillLoading}>
+							<ReloadIcon />
+						</Spinner>
+						Calculate from datasource
+					</Button>
+				)}
+			</Flex>
+			{autoFillError && (
+				<Callout.Root color="red" size="1">
+					<Callout.Text>{autoFillError}</Callout.Text>
+				</Callout.Root>
+			)}
+
+			{clusterField && (
+				<Box>
+					<Grid columns={{ initial: "1", sm: "3" }} gap="3">
+						<ClusterStatField
+							label="ICC"
+							value={icc}
+							placeholder="—"
+							min={0}
+							max={1}
+							step="0.001"
+							onChange={onIccChange}
+						/>
+
+						<Flex direction="column" gap="1">
+							<ClusterStatField
+								label="CV"
+								value={cv}
+								placeholder="—"
+								min={0}
+								step="0.01"
+								onChange={onCvChange}
+							/>
+							{cvIsHighVariability && (
+								<Text size="1" color="amber">
+									⚠ high variability
+								</Text>
+							)}
+						</Flex>
+
+						<ClusterStatField
+							label="Avg cluster size"
+							value={avgClusterSize}
+							placeholder="—"
+							min={1}
+							step="1"
+							onChange={onAvgClusterSizeChange}
+						/>
+					</Grid>
+				</Box>
+			)}
+			{!clusterField && (
+				<Text size="1" color="gray">
+					Select a cluster ID field to calculate cluster statistics.
+				</Text>
+			)}
+		</Flex>
+	);
+}

--- a/src/components/features/experiments/cluster-builder.tsx
+++ b/src/components/features/experiments/cluster-builder.tsx
@@ -1,21 +1,11 @@
-"use client";
+'use client';
 
-import type { FieldMetadata } from "@/api/methods.schemas";
-import { Combobox } from "@/components/ui/combobox";
-import { DataTypeBadge } from "@/components/ui/data-type-badge";
-import { Pencil1Icon, ReloadIcon } from "@radix-ui/react-icons";
-import {
-	Box,
-	Button,
-	Callout,
-	Flex,
-	Grid,
-	IconButton,
-	Spinner,
-	Text,
-	TextField,
-} from "@radix-ui/themes";
-import { useState } from "react";
+import type { FieldMetadata } from '@/api/methods.schemas';
+import { Combobox } from '@/components/ui/combobox';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import { Pencil1Icon, ReloadIcon } from '@radix-ui/react-icons';
+import { Box, Button, Callout, Flex, Grid, IconButton, Spinner, Text, TextField } from '@radix-ui/themes';
+import { useState } from 'react';
 
 /**
  * ClusterBuilder is the cluster-randomization counterpart to StrataBuilder.
@@ -35,43 +25,43 @@ import { useState } from "react";
  */
 
 interface ClusterBuilderProps {
-	/** Candidate cluster-ID fields. Caller should sort and exclude invalid fields. */
-	availableFields: FieldMetadata[];
-	clusterField?: FieldMetadata;
-	icc: string;
-	cv: string;
-	avgClusterSize: string;
-	onClusterFieldChange: (field: FieldMetadata | undefined) => void;
-	onIccChange: (value: string) => void;
-	onCvChange: (value: string) => void;
-	onAvgClusterSizeChange: (value: string) => void;
-	/**
-	 * Called when the user clicks "Calculate from datasource". The parent
-	 * runs a power-check with cluster_column set (and ICC/CV/avg unset) — the
-	 * BE auto-calculates the cluster stats and returns them — then dispatches
-	 * the values back into this builder via the on*Change callbacks.
-	 *
-	 * When undefined, the auto-fill button is not shown (e.g. when prerequisites
-	 * like a primary metric aren't ready yet).
-	 */
-	onAutoFill?: () => Promise<void> | void;
-	/** Whether an auto-fill request is currently in flight. */
-	autoFillLoading?: boolean;
-	/** Error message from the most recent auto-fill attempt, if any. */
-	autoFillError?: string | null;
+  /** Candidate cluster-ID fields. Caller should sort and exclude invalid fields. */
+  availableFields: FieldMetadata[];
+  clusterField?: FieldMetadata;
+  icc: string;
+  cv: string;
+  avgClusterSize: string;
+  onClusterFieldChange: (field: FieldMetadata | undefined) => void;
+  onIccChange: (value: string) => void;
+  onCvChange: (value: string) => void;
+  onAvgClusterSizeChange: (value: string) => void;
+  /**
+   * Called when the user clicks "Calculate from datasource". The parent
+   * runs a power-check with cluster_column set (and ICC/CV/avg unset) — the
+   * BE auto-calculates the cluster stats and returns them — then dispatches
+   * the values back into this builder via the on*Change callbacks.
+   *
+   * When undefined, the auto-fill button is not shown (e.g. when prerequisites
+   * like a primary metric aren't ready yet).
+   */
+  onAutoFill?: () => Promise<void> | void;
+  /** Whether an auto-fill request is currently in flight. */
+  autoFillLoading?: boolean;
+  /** Error message from the most recent auto-fill attempt, if any. */
+  autoFillError?: string | null;
 }
 
 const getDisplayText = (option: FieldMetadata) => option.field_name;
 
 interface ClusterComboboxRowProps {
-	field: FieldMetadata;
+  field: FieldMetadata;
 }
 
 const ClusterComboboxRow = ({ field }: ClusterComboboxRowProps) => (
-	<Flex gap="2" align="center" justify="between" wrap="nowrap">
-		<Text size="2">{field.field_name}</Text>
-		<DataTypeBadge type={field.data_type} />
-	</Flex>
+  <Flex gap="2" align="center" justify="between" wrap="nowrap">
+    <Text size="2">{field.field_name}</Text>
+    <DataTypeBadge type={field.data_type} />
+  </Flex>
 );
 
 const HIGH_CV_THRESHOLD = 0.5;
@@ -85,208 +75,197 @@ const HIGH_CV_THRESHOLD = 0.5;
  * override" per the issue #217 mockups.
  */
 function ClusterStatField({
-	label,
-	value,
-	placeholder,
-	min,
-	max,
-	step,
-	onChange,
+  label,
+  value,
+  placeholder,
+  min,
+  max,
+  step,
+  onChange,
 }: {
-	label: string;
-	value: string;
-	placeholder: string;
-	min?: number;
-	max?: number;
-	step?: string;
-	onChange: (next: string) => void;
+  label: string;
+  value: string;
+  placeholder: string;
+  min?: number;
+  max?: number;
+  step?: string;
+  onChange: (next: string) => void;
 }) {
-	const [editing, setEditing] = useState(false);
-	const [draft, setDraft] = useState(value);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
 
-	const startEditing = () => {
-		setDraft(value);
-		setEditing(true);
-	};
-	const commit = () => {
-		if (draft !== value) onChange(draft);
-		setEditing(false);
-	};
+  const startEditing = () => {
+    setDraft(value);
+    setEditing(true);
+  };
+  const commit = () => {
+    if (draft !== value) onChange(draft);
+    setEditing(false);
+  };
 
-	return (
-		<Flex direction="column" gap="1">
-			<Text as="label" size="2" weight="bold">
-				{label}
-			</Text>
-			{editing ? (
-				<TextField.Root
-					autoFocus
-					type="number"
-					inputMode="decimal"
-					min={min}
-					max={max}
-					step={step}
-					value={draft}
-					placeholder={placeholder}
-					onChange={(e) => setDraft(e.target.value)}
-					onBlur={commit}
-					onKeyDown={(e) => {
-						if (e.key === "Enter") commit();
-						else if (e.key === "Escape") setEditing(false);
-					}}
-				/>
-			) : (
-				<Flex
-					align="center"
-					gap="2"
-					px="2"
-					py="1"
-					style={{
-						backgroundColor: value !== "" ? "var(--green-2)" : undefined,
-						border: "1px solid var(--gray-a5)",
-						borderRadius: "var(--radius-2)",
-						minHeight: "32px",
-					}}
-				>
-					<Text style={{ flexGrow: 1 }}>
-						{value !== "" ? value : placeholder}
-					</Text>
-					<IconButton
-						variant="ghost"
-						size="1"
-						style={{ opacity: 0.6 }}
-						onClick={startEditing}
-						aria-label={`Edit ${label}`}
-					>
-						<Pencil1Icon />
-					</IconButton>
-				</Flex>
-			)}
-		</Flex>
-	);
+  return (
+    <Flex direction="column" gap="1">
+      <Text as="label" size="2" weight="bold">
+        {label}
+      </Text>
+      {editing ? (
+        <TextField.Root
+          autoFocus
+          type="number"
+          inputMode="decimal"
+          min={min}
+          max={max}
+          step={step}
+          value={draft}
+          placeholder={placeholder}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit();
+            else if (e.key === 'Escape') setEditing(false);
+          }}
+        />
+      ) : (
+        <Flex
+          align="center"
+          gap="2"
+          px="2"
+          py="1"
+          style={{
+            backgroundColor: value !== '' ? 'var(--green-2)' : undefined,
+            border: '1px solid var(--gray-a5)',
+            borderRadius: 'var(--radius-2)',
+            minHeight: '32px',
+          }}
+        >
+          <Text style={{ flexGrow: 1 }}>{value !== '' ? value : placeholder}</Text>
+          <IconButton
+            variant="ghost"
+            size="1"
+            style={{ opacity: 0.6 }}
+            onClick={startEditing}
+            aria-label={`Edit ${label}`}
+          >
+            <Pencil1Icon />
+          </IconButton>
+        </Flex>
+      )}
+    </Flex>
+  );
 }
 
 export function ClusterBuilder({
-	availableFields,
-	clusterField,
-	icc,
-	cv,
-	avgClusterSize,
-	onClusterFieldChange,
-	onIccChange,
-	onCvChange,
-	onAvgClusterSizeChange,
-	onAutoFill,
-	autoFillLoading,
-	autoFillError,
+  availableFields,
+  clusterField,
+  icc,
+  cv,
+  avgClusterSize,
+  onClusterFieldChange,
+  onIccChange,
+  onCvChange,
+  onAvgClusterSizeChange,
+  onAutoFill,
+  autoFillLoading,
+  autoFillError,
 }: ClusterBuilderProps) {
-	const cvNum = Number(cv);
-	const cvIsHighVariability = cv !== "" && !Number.isNaN(cvNum) && cvNum > HIGH_CV_THRESHOLD;
+  const cvNum = Number(cv);
+  const cvIsHighVariability = cv !== '' && !Number.isNaN(cvNum) && cvNum > HIGH_CV_THRESHOLD;
 
-	if (availableFields.length === 0) {
-		return (
-			<Text color="gray" size="2">
-				No fields available to use as a cluster ID for this table.
-			</Text>
-		);
-	}
+  if (availableFields.length === 0) {
+    return (
+      <Text color="gray" size="2">
+        No fields available to use as a cluster ID for this table.
+      </Text>
+    );
+  }
 
-	return (
-		<Flex direction="column" gap="3" overflowX="auto">
-			<Text size="2" color="gray">
-				ICC is calculated from the datasource for your primary metric.
-			</Text>
+  return (
+    <Flex direction="column" gap="3" overflowX="auto">
+      <Text size="2" color="gray">
+        ICC is calculated from the datasource for your primary metric.
+      </Text>
 
-			<Flex gap="2" align="center" wrap="wrap">
-				<Text as="label" size="2" weight="bold">
-					Cluster ID field
-				</Text>
-				<Combobox<FieldMetadata>
-					value={clusterField?.field_name ?? ""}
-					onChange={(_value, fieldName) => {
-						if (!fieldName) {
-							onClusterFieldChange(undefined);
-							return;
-						}
-						const match = availableFields.find(
-							(f) => f.field_name === fieldName,
-						);
-						if (match) onClusterFieldChange(match);
-					}}
-					options={availableFields}
-					getDisplayTextForOption={getDisplayText}
-					getKeyForOption={getDisplayText}
-					placeholder="Search fields..."
-					noMatchText="No matching fields"
-					dropdownRow={({ option }) => <ClusterComboboxRow field={option} />}
-				/>
-				{onAutoFill && (
-					<Button
-						variant="soft"
-						disabled={!clusterField || autoFillLoading}
-						onClick={async (e) => {
-							e.preventDefault();
-							await onAutoFill();
-						}}
-					>
-						<Spinner loading={!!autoFillLoading}>
-							<ReloadIcon />
-						</Spinner>
-						Calculate from datasource
-					</Button>
-				)}
-			</Flex>
-			{autoFillError && (
-				<Callout.Root color="red" size="1">
-					<Callout.Text>{autoFillError}</Callout.Text>
-				</Callout.Root>
-			)}
+      <Flex gap="2" align="center" wrap="wrap">
+        <Text as="label" size="2" weight="bold">
+          Cluster ID field
+        </Text>
+        <Combobox<FieldMetadata>
+          value={clusterField?.field_name ?? ''}
+          onChange={(_value, fieldName) => {
+            if (!fieldName) {
+              onClusterFieldChange(undefined);
+              return;
+            }
+            const match = availableFields.find((f) => f.field_name === fieldName);
+            if (match) onClusterFieldChange(match);
+          }}
+          options={availableFields}
+          getDisplayTextForOption={getDisplayText}
+          getKeyForOption={getDisplayText}
+          placeholder="Search fields..."
+          noMatchText="No matching fields"
+          dropdownRow={({ option }) => <ClusterComboboxRow field={option} />}
+        />
+        {onAutoFill && (
+          <Button
+            variant="soft"
+            disabled={!clusterField || autoFillLoading}
+            onClick={async (e) => {
+              e.preventDefault();
+              await onAutoFill();
+            }}
+          >
+            <Spinner loading={!!autoFillLoading}>
+              <ReloadIcon />
+            </Spinner>
+            Calculate from datasource
+          </Button>
+        )}
+      </Flex>
+      {autoFillError && (
+        <Callout.Root color="red" size="1">
+          <Callout.Text>{autoFillError}</Callout.Text>
+        </Callout.Root>
+      )}
 
-			{clusterField && (
-				<Box>
-					<Grid columns={{ initial: "1", sm: "3" }} gap="3">
-						<ClusterStatField
-							label="ICC"
-							value={icc}
-							placeholder="—"
-							min={0}
-							max={1}
-							step="0.001"
-							onChange={onIccChange}
-						/>
+      {clusterField && (
+        <Box>
+          <Grid columns={{ initial: '1', sm: '3' }} gap="3">
+            <ClusterStatField
+              label="ICC"
+              value={icc}
+              placeholder="—"
+              min={0}
+              max={1}
+              step="0.001"
+              onChange={onIccChange}
+            />
 
-						<Flex direction="column" gap="1">
-							<ClusterStatField
-								label="CV"
-								value={cv}
-								placeholder="—"
-								min={0}
-								step="0.01"
-								onChange={onCvChange}
-							/>
-							{cvIsHighVariability && (
-								<Text size="1" color="amber">
-									⚠ high variability
-								</Text>
-							)}
-						</Flex>
+            <Flex direction="column" gap="1">
+              <ClusterStatField label="CV" value={cv} placeholder="—" min={0} step="0.01" onChange={onCvChange} />
+              {cvIsHighVariability && (
+                <Text size="1" color="amber">
+                  ⚠ high variability
+                </Text>
+              )}
+            </Flex>
 
-						<ClusterStatField
-							label="Avg cluster size"
-							value={avgClusterSize}
-							placeholder="—"
-							min={1}
-							step="1"
-							onChange={onAvgClusterSizeChange}
-						/>
-					</Grid>
-				</Box>
-			)}
-			{!clusterField && (
-				<Text size="1" color="gray">
-					Select a cluster ID field to calculate cluster statistics.
-				</Text>
-			)}
-		</Flex>
-	);
+            <ClusterStatField
+              label="Avg cluster size"
+              value={avgClusterSize}
+              placeholder="—"
+              min={1}
+              step="1"
+              onChange={onAvgClusterSizeChange}
+            />
+          </Grid>
+        </Box>
+      )}
+      {!clusterField && (
+        <Text size="1" color="gray">
+          Select a cluster ID field to calculate cluster statistics.
+        </Text>
+      )}
+    </Flex>
+  );
 }

--- a/src/components/features/experiments/cluster-detection.ts
+++ b/src/components/features/experiments/cluster-detection.ts
@@ -1,16 +1,16 @@
 /**
  * Cluster-experiment detection helpers.
  *
- * Background (issue #217): the BE on PR #163 accepts `cluster_column` and the
+ * Background (issue #217): the BE on PR #163 accepts `cluster_key` and the
  * per-metric `icc`/`cv`/`avg_cluster_size` on create-experiment requests, but
  * the storage layer (`storage_format_converters.py`) does not persist
- * `cluster_column` onto `tables.Experiment`, nor does it persist the per-
+ * `cluster_key` onto `tables.Experiment`, nor does it persist the per-
  * metric cluster stats onto `experiment_fields`. Those fields ARE preserved
  * inside the stored `power_analyses` JSON blob, because the BE writes the
  * raw PowerResponse via `_set_power_response_json`.
  *
  * The practical consequence is that when the FE re-fetches a saved cluster
- * experiment, `design_spec.cluster_column` and `design_spec.metrics[i].icc`
+ * experiment, `design_spec.cluster_key` and `design_spec.metrics[i].icc`
  * are missing — but `power_analyses.analyses[0].num_clusters_total`,
  * `clusters_per_arm`, `design_effect`, and the per-metric cluster stats on
  * `metric_spec` are all present.
@@ -18,7 +18,7 @@
  * This module centralises "is this a cluster experiment?" detection and
  * "what are the cluster stats?" extraction so every surface (badge, targeting
  * modal, arms & allocations, header, summary) reads from a single source of
- * truth. Once the BE properly persists cluster_column/icc/cv/avg, these
+ * truth. Once the BE properly persists cluster_key/icc/cv/avg, these
  * helpers fall back to the design_spec path naturally — nothing else needs
  * to change in the call sites.
  */
@@ -28,7 +28,7 @@
 // variant from methods.schemas.ts can be passed without TS griping about
 // missing fields on bandit types.
 type LooseDesignSpec = {
-  cluster_column?: string | null;
+  cluster_key?: string | null;
   metrics?: Array<{
     icc?: number | null;
     cv?: number | null;
@@ -53,7 +53,7 @@ type LoosePowerAnalyses = {
 export function isClusterDesign(designSpec: unknown, powerAnalyses: unknown): boolean {
   const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
   const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
-  if (ds?.cluster_column) return true;
+  if (ds?.cluster_key) return true;
   const firstAnalysis = pa?.analyses?.[0];
   if (firstAnalysis?.num_clusters_total != null) return true;
   if (firstAnalysis?.metric_spec?.icc != null) return true;
@@ -66,7 +66,7 @@ export function isClusterDesign(designSpec: unknown, powerAnalyses: unknown): bo
 /** Returns the cluster column field name from design spec or null when not persisted. */
 export function getClusterColumn(designSpec: unknown): string | null {
   const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
-  return ds?.cluster_column ?? null;
+  return ds?.cluster_key ?? null;
 }
 
 /**

--- a/src/components/features/experiments/cluster-detection.ts
+++ b/src/components/features/experiments/cluster-detection.ts
@@ -28,48 +28,45 @@
 // variant from methods.schemas.ts can be passed without TS griping about
 // missing fields on bandit types.
 type LooseDesignSpec = {
-	cluster_column?: string | null;
-	metrics?: Array<{
-		icc?: number | null;
-		cv?: number | null;
-		avg_cluster_size?: number | null;
-	} | null> | null;
+  cluster_column?: string | null;
+  metrics?: Array<{
+    icc?: number | null;
+    cv?: number | null;
+    avg_cluster_size?: number | null;
+  } | null> | null;
 };
 
 type LoosePowerAnalyses = {
-	analyses?: Array<{
-		metric_spec?: {
-			icc?: number | null;
-			cv?: number | null;
-			avg_cluster_size?: number | null;
-		} | null;
-		num_clusters_total?: number | null;
-		clusters_per_arm?: number[] | null;
-		design_effect?: number | null;
-	} | null> | null;
+  analyses?: Array<{
+    metric_spec?: {
+      icc?: number | null;
+      cv?: number | null;
+      avg_cluster_size?: number | null;
+    } | null;
+    num_clusters_total?: number | null;
+    clusters_per_arm?: number[] | null;
+    design_effect?: number | null;
+  } | null> | null;
 };
 
 /** Returns true if the experiment has any cluster signal on the design spec or stored power analyses. */
-export function isClusterDesign(
-	designSpec: unknown,
-	powerAnalyses: unknown,
-): boolean {
-	const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
-	const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
-	if (ds?.cluster_column) return true;
-	const firstAnalysis = pa?.analyses?.[0];
-	if (firstAnalysis?.num_clusters_total != null) return true;
-	if (firstAnalysis?.metric_spec?.icc != null) return true;
-	if (firstAnalysis?.design_effect != null) return true;
-	const firstMetric = ds?.metrics?.[0];
-	if (firstMetric?.icc != null) return true;
-	return false;
+export function isClusterDesign(designSpec: unknown, powerAnalyses: unknown): boolean {
+  const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
+  const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
+  if (ds?.cluster_column) return true;
+  const firstAnalysis = pa?.analyses?.[0];
+  if (firstAnalysis?.num_clusters_total != null) return true;
+  if (firstAnalysis?.metric_spec?.icc != null) return true;
+  if (firstAnalysis?.design_effect != null) return true;
+  const firstMetric = ds?.metrics?.[0];
+  if (firstMetric?.icc != null) return true;
+  return false;
 }
 
 /** Returns the cluster column field name from design spec or null when not persisted. */
 export function getClusterColumn(designSpec: unknown): string | null {
-	const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
-	return ds?.cluster_column ?? null;
+  const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
+  return ds?.cluster_column ?? null;
 }
 
 /**
@@ -77,23 +74,20 @@ export function getClusterColumn(designSpec: unknown): string | null {
  * Returns null if no cluster stats are available anywhere.
  */
 export function getPrimaryMetricClusterStats(
-	designSpec: unknown,
-	powerAnalyses: unknown,
+  designSpec: unknown,
+  powerAnalyses: unknown,
 ): {
-	icc: number | null;
-	cv: number | null;
-	avg_cluster_size: number | null;
+  icc: number | null;
+  cv: number | null;
+  avg_cluster_size: number | null;
 } | null {
-	const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
-	const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
-	const firstMetric = ds?.metrics?.[0];
-	const firstAnalysisMetric = pa?.analyses?.[0]?.metric_spec;
-	const icc = firstMetric?.icc ?? firstAnalysisMetric?.icc ?? null;
-	const cv = firstMetric?.cv ?? firstAnalysisMetric?.cv ?? null;
-	const avg =
-		firstMetric?.avg_cluster_size ??
-		firstAnalysisMetric?.avg_cluster_size ??
-		null;
-	if (icc == null && cv == null && avg == null) return null;
-	return { icc, cv, avg_cluster_size: avg };
+  const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
+  const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
+  const firstMetric = ds?.metrics?.[0];
+  const firstAnalysisMetric = pa?.analyses?.[0]?.metric_spec;
+  const icc = firstMetric?.icc ?? firstAnalysisMetric?.icc ?? null;
+  const cv = firstMetric?.cv ?? firstAnalysisMetric?.cv ?? null;
+  const avg = firstMetric?.avg_cluster_size ?? firstAnalysisMetric?.avg_cluster_size ?? null;
+  if (icc == null && cv == null && avg == null) return null;
+  return { icc, cv, avg_cluster_size: avg };
 }

--- a/src/components/features/experiments/cluster-detection.ts
+++ b/src/components/features/experiments/cluster-detection.ts
@@ -1,0 +1,99 @@
+/**
+ * Cluster-experiment detection helpers.
+ *
+ * Background (issue #217): the BE on PR #163 accepts `cluster_column` and the
+ * per-metric `icc`/`cv`/`avg_cluster_size` on create-experiment requests, but
+ * the storage layer (`storage_format_converters.py`) does not persist
+ * `cluster_column` onto `tables.Experiment`, nor does it persist the per-
+ * metric cluster stats onto `experiment_fields`. Those fields ARE preserved
+ * inside the stored `power_analyses` JSON blob, because the BE writes the
+ * raw PowerResponse via `_set_power_response_json`.
+ *
+ * The practical consequence is that when the FE re-fetches a saved cluster
+ * experiment, `design_spec.cluster_column` and `design_spec.metrics[i].icc`
+ * are missing — but `power_analyses.analyses[0].num_clusters_total`,
+ * `clusters_per_arm`, `design_effect`, and the per-metric cluster stats on
+ * `metric_spec` are all present.
+ *
+ * This module centralises "is this a cluster experiment?" detection and
+ * "what are the cluster stats?" extraction so every surface (badge, targeting
+ * modal, arms & allocations, header, summary) reads from a single source of
+ * truth. Once the BE properly persists cluster_column/icc/cv/avg, these
+ * helpers fall back to the design_spec path naturally — nothing else needs
+ * to change in the call sites.
+ */
+
+// Internal shape that lets us safely read the fields we care about. We accept
+// `unknown` at the API boundary and cast here, so any DesignSpec / PowerResponse
+// variant from methods.schemas.ts can be passed without TS griping about
+// missing fields on bandit types.
+type LooseDesignSpec = {
+	cluster_column?: string | null;
+	metrics?: Array<{
+		icc?: number | null;
+		cv?: number | null;
+		avg_cluster_size?: number | null;
+	} | null> | null;
+};
+
+type LoosePowerAnalyses = {
+	analyses?: Array<{
+		metric_spec?: {
+			icc?: number | null;
+			cv?: number | null;
+			avg_cluster_size?: number | null;
+		} | null;
+		num_clusters_total?: number | null;
+		clusters_per_arm?: number[] | null;
+		design_effect?: number | null;
+	} | null> | null;
+};
+
+/** Returns true if the experiment has any cluster signal on the design spec or stored power analyses. */
+export function isClusterDesign(
+	designSpec: unknown,
+	powerAnalyses: unknown,
+): boolean {
+	const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
+	const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
+	if (ds?.cluster_column) return true;
+	const firstAnalysis = pa?.analyses?.[0];
+	if (firstAnalysis?.num_clusters_total != null) return true;
+	if (firstAnalysis?.metric_spec?.icc != null) return true;
+	if (firstAnalysis?.design_effect != null) return true;
+	const firstMetric = ds?.metrics?.[0];
+	if (firstMetric?.icc != null) return true;
+	return false;
+}
+
+/** Returns the cluster column field name from design spec or null when not persisted. */
+export function getClusterColumn(designSpec: unknown): string | null {
+	const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
+	return ds?.cluster_column ?? null;
+}
+
+/**
+ * Reads the primary metric's cluster stats with fallback from power_analyses.
+ * Returns null if no cluster stats are available anywhere.
+ */
+export function getPrimaryMetricClusterStats(
+	designSpec: unknown,
+	powerAnalyses: unknown,
+): {
+	icc: number | null;
+	cv: number | null;
+	avg_cluster_size: number | null;
+} | null {
+	const ds = (designSpec ?? undefined) as LooseDesignSpec | undefined;
+	const pa = (powerAnalyses ?? undefined) as LoosePowerAnalyses | undefined;
+	const firstMetric = ds?.metrics?.[0];
+	const firstAnalysisMetric = pa?.analyses?.[0]?.metric_spec;
+	const icc = firstMetric?.icc ?? firstAnalysisMetric?.icc ?? null;
+	const cv = firstMetric?.cv ?? firstAnalysisMetric?.cv ?? null;
+	const avg =
+		firstMetric?.avg_cluster_size ??
+		firstAnalysisMetric?.avg_cluster_size ??
+		null;
+	if (icc == null && cv == null && avg == null) return null;
+	return { icc, cv, avg_cluster_size: avg };
+}

--- a/src/components/features/experiments/experiment-card.tsx
+++ b/src/components/features/experiments/experiment-card.tsx
@@ -1,130 +1,160 @@
-'use client';
-import { Card, Flex, Heading, IconButton, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { CalendarIcon, EyeOpenIcon, FileTextIcon, LightningBoltIcon } from '@radix-ui/react-icons';
-import { ExperimentActionsMenu } from '@/components/features/experiments/experiment-actions-menu';
-import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
-import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
-import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
-import { ExperimentImpactBadge } from '@/components/features/experiments/experiment-impact-badge';
-import type { ExperimentStatus } from '@/components/features/experiments/types';
-import { formatIsoDateLocal } from '@/services/date-utils';
-import Link from 'next/link';
-import { Impact } from '@/api/methods.schemas';
+"use client";
+import { Impact } from "@/api/methods.schemas";
+import { DownloadAssignmentsCsvButton } from "@/components/features/experiments/download-assignments-csv-button";
+import { ExperimentActionsMenu } from "@/components/features/experiments/experiment-actions-menu";
+import { ExperimentImpactBadge } from "@/components/features/experiments/experiment-impact-badge";
+import { ExperimentStatusBadge } from "@/components/features/experiments/experiment-status-badge";
+import { ExperimentTypeBadge } from "@/components/features/experiments/experiment-type-badge";
+import type { ExperimentStatus } from "@/components/features/experiments/types";
+import { formatIsoDateLocal } from "@/services/date-utils";
+import {
+	CalendarIcon,
+	EyeOpenIcon,
+	FileTextIcon,
+	LightningBoltIcon,
+} from "@radix-ui/react-icons";
+import {
+	Card,
+	Flex,
+	Heading,
+	IconButton,
+	Separator,
+	Text,
+	Tooltip,
+} from "@radix-ui/themes";
+import Link from "next/link";
 
 interface ExperimentCardProps {
-  title: string;
-  hypothesis: string;
-  type: string;
-  startDate: string;
-  endDate: string;
-  status: ExperimentStatus;
-  impact?: Impact;
-  decision?: string;
-  datasourceId: string;
-  designUrl?: string;
-  experimentId: string;
-  organizationId: string;
+	title: string;
+	hypothesis: string;
+	type: string;
+	/** Whether the experiment is cluster-randomized (issue #217). */
+	isCluster?: boolean;
+	startDate: string;
+	endDate: string;
+	status: ExperimentStatus;
+	impact?: Impact;
+	decision?: string;
+	datasourceId: string;
+	designUrl?: string;
+	experimentId: string;
+	organizationId: string;
 }
 
 export function ExperimentCard({
-  title,
-  hypothesis,
-  type,
-  startDate,
-  endDate,
-  status,
-  impact,
-  decision,
-  datasourceId,
-  designUrl,
-  experimentId,
-  organizationId,
+	title,
+	hypothesis,
+	type,
+	isCluster,
+	startDate,
+	endDate,
+	status,
+	impact,
+	decision,
+	datasourceId,
+	designUrl,
+	experimentId,
+	organizationId,
 }: ExperimentCardProps) {
-  return (
-    <Card size="3">
-      <Flex height={'100%'} direction="column">
-        <Flex direction="column" gap="4">
-          <Flex justify="between" align="center">
-            <Flex minWidth={'0'} align="center" gap="2">
-              <LightningBoltIcon width="16" height="16" color="var(--blue-9)" style={{ flexShrink: 0 }} />
-              <Tooltip content={title}>
-                <Heading as="h3" size="4" weight="medium" truncate asChild>
-                  <Link
-                    href={`/datasources/${datasourceId}/experiments/${experimentId}`}
-                    style={{ textDecoration: 'none', color: 'inherit' }}
-                  >
-                    {title}
-                  </Link>
-                </Heading>
-              </Tooltip>
-            </Flex>
+	return (
+		<Card size="3">
+			<Flex height={"100%"} direction="column">
+				<Flex direction="column" gap="4">
+					<Flex justify="between" align="center">
+						<Flex minWidth={"0"} align="center" gap="2">
+							<LightningBoltIcon
+								width="16"
+								height="16"
+								color="var(--blue-9)"
+								style={{ flexShrink: 0 }}
+							/>
+							<Tooltip content={title}>
+								<Heading as="h3" size="4" weight="medium" truncate asChild>
+									<Link
+										href={`/datasources/${datasourceId}/experiments/${experimentId}`}
+										style={{ textDecoration: "none", color: "inherit" }}
+									>
+										{title}
+									</Link>
+								</Heading>
+							</Tooltip>
+						</Flex>
 
-            <Flex align="center" gap="3" flexShrink={'0'}>
-              <ExperimentStatusBadge status={status} />
-              <ExperimentActionsMenu
-                organizationId={organizationId}
-                datasourceId={datasourceId}
-                experimentId={experimentId}
-              />
-            </Flex>
-          </Flex>
+						<Flex align="center" gap="3" flexShrink={"0"}>
+							<ExperimentStatusBadge status={status} />
+							<ExperimentActionsMenu
+								organizationId={organizationId}
+								datasourceId={datasourceId}
+								experimentId={experimentId}
+							/>
+						</Flex>
+					</Flex>
 
-          <Flex align="center" gap="2">
-            <CalendarIcon width="14" height="14" color="var(--gray-9)" />
-            <Text size="2" color="gray">
-              {formatIsoDateLocal(startDate)} - {formatIsoDateLocal(endDate)}
-            </Text>
-          </Flex>
+					<Flex align="center" gap="2">
+						<CalendarIcon width="14" height="14" color="var(--gray-9)" />
+						<Text size="2" color="gray">
+							{formatIsoDateLocal(startDate)} - {formatIsoDateLocal(endDate)}
+						</Text>
+					</Flex>
 
-          <Flex align="center" gap="2">
-            <ExperimentTypeBadge type={type} />
-            <Separator orientation="vertical" />
-            <ExperimentImpactBadge impact={impact} />
-          </Flex>
+					<Flex align="center" gap="2">
+						<ExperimentTypeBadge type={type} isCluster={isCluster} />
+						<Separator orientation="vertical" />
+						<ExperimentImpactBadge impact={impact} />
+					</Flex>
 
-          <Separator size="4" />
+					<Separator size="4" />
 
-          <Flex direction="column" gap="3">
-            <Flex direction="column" gap="1">
-              <Text size="2" weight="bold">
-                Hypothesis
-              </Text>
-              <Text size="2" truncate>
-                {hypothesis}
-              </Text>
-            </Flex>
-            <Flex direction="column" gap="1">
-              <Text size="2" weight="bold">
-                Decision
-              </Text>
-              <Text size="2" truncate color={decision ? undefined : 'gray'}>
-                {decision || 'Undecided'}
-              </Text>
-            </Flex>
-          </Flex>
-        </Flex>
+					<Flex direction="column" gap="3">
+						<Flex direction="column" gap="1">
+							<Text size="2" weight="bold">
+								Hypothesis
+							</Text>
+							<Text size="2" truncate>
+								{hypothesis}
+							</Text>
+						</Flex>
+						<Flex direction="column" gap="1">
+							<Text size="2" weight="bold">
+								Decision
+							</Text>
+							<Text size="2" truncate color={decision ? undefined : "gray"}>
+								{decision || "Undecided"}
+							</Text>
+						</Flex>
+					</Flex>
+				</Flex>
 
-        <Flex justify="end" gap="2" pt="4">
-          {designUrl && (
-            <Tooltip content="View design document">
-              <IconButton variant="soft" color="blue" size="2" asChild>
-                <Link href={designUrl} target="_blank" rel="noopener noreferrer">
-                  <FileTextIcon width="16" height="16" />
-                </Link>
-              </IconButton>
-            </Tooltip>
-          )}
+				<Flex justify="end" gap="2" pt="4">
+					{designUrl && (
+						<Tooltip content="View design document">
+							<IconButton variant="soft" color="blue" size="2" asChild>
+								<Link
+									href={designUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									<FileTextIcon width="16" height="16" />
+								</Link>
+							</IconButton>
+						</Tooltip>
+					)}
 
-          <Tooltip content="View experiment">
-            <IconButton variant="soft" color="blue" size="2" asChild>
-              <Link href={`/datasources/${datasourceId}/experiments/${experimentId}`}>
-                <EyeOpenIcon width="16" height="16" />
-              </Link>
-            </IconButton>
-          </Tooltip>
-          <DownloadAssignmentsCsvButton datasourceId={datasourceId} experimentId={experimentId} />
-        </Flex>
-      </Flex>
-    </Card>
-  );
+					<Tooltip content="View experiment">
+						<IconButton variant="soft" color="blue" size="2" asChild>
+							<Link
+								href={`/datasources/${datasourceId}/experiments/${experimentId}`}
+							>
+								<EyeOpenIcon width="16" height="16" />
+							</Link>
+						</IconButton>
+					</Tooltip>
+					<DownloadAssignmentsCsvButton
+						datasourceId={datasourceId}
+						experimentId={experimentId}
+					/>
+				</Flex>
+			</Flex>
+		</Card>
+	);
 }

--- a/src/components/features/experiments/experiment-card.tsx
+++ b/src/components/features/experiments/experiment-card.tsx
@@ -1,160 +1,133 @@
-"use client";
-import { Impact } from "@/api/methods.schemas";
-import { DownloadAssignmentsCsvButton } from "@/components/features/experiments/download-assignments-csv-button";
-import { ExperimentActionsMenu } from "@/components/features/experiments/experiment-actions-menu";
-import { ExperimentImpactBadge } from "@/components/features/experiments/experiment-impact-badge";
-import { ExperimentStatusBadge } from "@/components/features/experiments/experiment-status-badge";
-import { ExperimentTypeBadge } from "@/components/features/experiments/experiment-type-badge";
-import type { ExperimentStatus } from "@/components/features/experiments/types";
-import { formatIsoDateLocal } from "@/services/date-utils";
-import {
-	CalendarIcon,
-	EyeOpenIcon,
-	FileTextIcon,
-	LightningBoltIcon,
-} from "@radix-ui/react-icons";
-import {
-	Card,
-	Flex,
-	Heading,
-	IconButton,
-	Separator,
-	Text,
-	Tooltip,
-} from "@radix-ui/themes";
-import Link from "next/link";
+'use client';
+import { Impact } from '@/api/methods.schemas';
+import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
+import { ExperimentActionsMenu } from '@/components/features/experiments/experiment-actions-menu';
+import { ExperimentImpactBadge } from '@/components/features/experiments/experiment-impact-badge';
+import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
+import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
+import type { ExperimentStatus } from '@/components/features/experiments/types';
+import { formatIsoDateLocal } from '@/services/date-utils';
+import { CalendarIcon, EyeOpenIcon, FileTextIcon, LightningBoltIcon } from '@radix-ui/react-icons';
+import { Card, Flex, Heading, IconButton, Separator, Text, Tooltip } from '@radix-ui/themes';
+import Link from 'next/link';
 
 interface ExperimentCardProps {
-	title: string;
-	hypothesis: string;
-	type: string;
-	/** Whether the experiment is cluster-randomized (issue #217). */
-	isCluster?: boolean;
-	startDate: string;
-	endDate: string;
-	status: ExperimentStatus;
-	impact?: Impact;
-	decision?: string;
-	datasourceId: string;
-	designUrl?: string;
-	experimentId: string;
-	organizationId: string;
+  title: string;
+  hypothesis: string;
+  type: string;
+  /** Whether the experiment is cluster-randomized (issue #217). */
+  isCluster?: boolean;
+  startDate: string;
+  endDate: string;
+  status: ExperimentStatus;
+  impact?: Impact;
+  decision?: string;
+  datasourceId: string;
+  designUrl?: string;
+  experimentId: string;
+  organizationId: string;
 }
 
 export function ExperimentCard({
-	title,
-	hypothesis,
-	type,
-	isCluster,
-	startDate,
-	endDate,
-	status,
-	impact,
-	decision,
-	datasourceId,
-	designUrl,
-	experimentId,
-	organizationId,
+  title,
+  hypothesis,
+  type,
+  isCluster,
+  startDate,
+  endDate,
+  status,
+  impact,
+  decision,
+  datasourceId,
+  designUrl,
+  experimentId,
+  organizationId,
 }: ExperimentCardProps) {
-	return (
-		<Card size="3">
-			<Flex height={"100%"} direction="column">
-				<Flex direction="column" gap="4">
-					<Flex justify="between" align="center">
-						<Flex minWidth={"0"} align="center" gap="2">
-							<LightningBoltIcon
-								width="16"
-								height="16"
-								color="var(--blue-9)"
-								style={{ flexShrink: 0 }}
-							/>
-							<Tooltip content={title}>
-								<Heading as="h3" size="4" weight="medium" truncate asChild>
-									<Link
-										href={`/datasources/${datasourceId}/experiments/${experimentId}`}
-										style={{ textDecoration: "none", color: "inherit" }}
-									>
-										{title}
-									</Link>
-								</Heading>
-							</Tooltip>
-						</Flex>
+  return (
+    <Card size="3">
+      <Flex height={'100%'} direction="column">
+        <Flex direction="column" gap="4">
+          <Flex justify="between" align="center">
+            <Flex minWidth={'0'} align="center" gap="2">
+              <LightningBoltIcon width="16" height="16" color="var(--blue-9)" style={{ flexShrink: 0 }} />
+              <Tooltip content={title}>
+                <Heading as="h3" size="4" weight="medium" truncate asChild>
+                  <Link
+                    href={`/datasources/${datasourceId}/experiments/${experimentId}`}
+                    style={{ textDecoration: 'none', color: 'inherit' }}
+                  >
+                    {title}
+                  </Link>
+                </Heading>
+              </Tooltip>
+            </Flex>
 
-						<Flex align="center" gap="3" flexShrink={"0"}>
-							<ExperimentStatusBadge status={status} />
-							<ExperimentActionsMenu
-								organizationId={organizationId}
-								datasourceId={datasourceId}
-								experimentId={experimentId}
-							/>
-						</Flex>
-					</Flex>
+            <Flex align="center" gap="3" flexShrink={'0'}>
+              <ExperimentStatusBadge status={status} />
+              <ExperimentActionsMenu
+                organizationId={organizationId}
+                datasourceId={datasourceId}
+                experimentId={experimentId}
+              />
+            </Flex>
+          </Flex>
 
-					<Flex align="center" gap="2">
-						<CalendarIcon width="14" height="14" color="var(--gray-9)" />
-						<Text size="2" color="gray">
-							{formatIsoDateLocal(startDate)} - {formatIsoDateLocal(endDate)}
-						</Text>
-					</Flex>
+          <Flex align="center" gap="2">
+            <CalendarIcon width="14" height="14" color="var(--gray-9)" />
+            <Text size="2" color="gray">
+              {formatIsoDateLocal(startDate)} - {formatIsoDateLocal(endDate)}
+            </Text>
+          </Flex>
 
-					<Flex align="center" gap="2">
-						<ExperimentTypeBadge type={type} isCluster={isCluster} />
-						<Separator orientation="vertical" />
-						<ExperimentImpactBadge impact={impact} />
-					</Flex>
+          <Flex align="center" gap="2">
+            <ExperimentTypeBadge type={type} isCluster={isCluster} />
+            <Separator orientation="vertical" />
+            <ExperimentImpactBadge impact={impact} />
+          </Flex>
 
-					<Separator size="4" />
+          <Separator size="4" />
 
-					<Flex direction="column" gap="3">
-						<Flex direction="column" gap="1">
-							<Text size="2" weight="bold">
-								Hypothesis
-							</Text>
-							<Text size="2" truncate>
-								{hypothesis}
-							</Text>
-						</Flex>
-						<Flex direction="column" gap="1">
-							<Text size="2" weight="bold">
-								Decision
-							</Text>
-							<Text size="2" truncate color={decision ? undefined : "gray"}>
-								{decision || "Undecided"}
-							</Text>
-						</Flex>
-					</Flex>
-				</Flex>
+          <Flex direction="column" gap="3">
+            <Flex direction="column" gap="1">
+              <Text size="2" weight="bold">
+                Hypothesis
+              </Text>
+              <Text size="2" truncate>
+                {hypothesis}
+              </Text>
+            </Flex>
+            <Flex direction="column" gap="1">
+              <Text size="2" weight="bold">
+                Decision
+              </Text>
+              <Text size="2" truncate color={decision ? undefined : 'gray'}>
+                {decision || 'Undecided'}
+              </Text>
+            </Flex>
+          </Flex>
+        </Flex>
 
-				<Flex justify="end" gap="2" pt="4">
-					{designUrl && (
-						<Tooltip content="View design document">
-							<IconButton variant="soft" color="blue" size="2" asChild>
-								<Link
-									href={designUrl}
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									<FileTextIcon width="16" height="16" />
-								</Link>
-							</IconButton>
-						</Tooltip>
-					)}
+        <Flex justify="end" gap="2" pt="4">
+          {designUrl && (
+            <Tooltip content="View design document">
+              <IconButton variant="soft" color="blue" size="2" asChild>
+                <Link href={designUrl} target="_blank" rel="noopener noreferrer">
+                  <FileTextIcon width="16" height="16" />
+                </Link>
+              </IconButton>
+            </Tooltip>
+          )}
 
-					<Tooltip content="View experiment">
-						<IconButton variant="soft" color="blue" size="2" asChild>
-							<Link
-								href={`/datasources/${datasourceId}/experiments/${experimentId}`}
-							>
-								<EyeOpenIcon width="16" height="16" />
-							</Link>
-						</IconButton>
-					</Tooltip>
-					<DownloadAssignmentsCsvButton
-						datasourceId={datasourceId}
-						experimentId={experimentId}
-					/>
-				</Flex>
-			</Flex>
-		</Card>
-	);
+          <Tooltip content="View experiment">
+            <IconButton variant="soft" color="blue" size="2" asChild>
+              <Link href={`/datasources/${datasourceId}/experiments/${experimentId}`}>
+                <EyeOpenIcon width="16" height="16" />
+              </Link>
+            </IconButton>
+          </Tooltip>
+          <DownloadAssignmentsCsvButton datasourceId={datasourceId} experimentId={experimentId} />
+        </Flex>
+      </Flex>
+    </Card>
+  );
 }

--- a/src/components/features/experiments/experiment-confirmation-display.tsx
+++ b/src/components/features/experiments/experiment-confirmation-display.tsx
@@ -1,192 +1,158 @@
-"use client";
+'use client';
 
 import {
-	CMABExperimentSpecOutput,
-	CreateExperimentResponse,
-	FilterOutput,
-	MABExperimentSpecOutput,
-	OnlineFrequentistExperimentSpecOutput,
-	PreassignedFrequentistExperimentSpecOutput,
-} from "@/api/methods.schemas";
-import { ContextsSection } from "@/components/features/experiments/sections/contexts-section";
-import { DatasourceTargetingSection } from "@/components/features/experiments/sections/datasource-targeting-section";
-import { ExperimentDescriptionSection } from "@/components/features/experiments/sections/experiment-description-section";
-import {
-	MetricDisplay,
-	MetricsSection,
-} from "@/components/features/experiments/sections/metrics-section";
-import { OutcomesPriorSection } from "@/components/features/experiments/sections/outcomes-prior-section";
-import { PowerBalanceSection } from "@/components/features/experiments/sections/power-balance-section";
-import { TreatmentArmsSection } from "@/components/features/experiments/sections/treatment-arms-section";
-import { Flex, Grid } from "@radix-ui/themes";
+  CMABExperimentSpecOutput,
+  CreateExperimentResponse,
+  FilterOutput,
+  MABExperimentSpecOutput,
+  OnlineFrequentistExperimentSpecOutput,
+  PreassignedFrequentistExperimentSpecOutput,
+} from '@/api/methods.schemas';
+import { ContextsSection } from '@/components/features/experiments/sections/contexts-section';
+import { DatasourceTargetingSection } from '@/components/features/experiments/sections/datasource-targeting-section';
+import { ExperimentDescriptionSection } from '@/components/features/experiments/sections/experiment-description-section';
+import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
+import { OutcomesPriorSection } from '@/components/features/experiments/sections/outcomes-prior-section';
+import { PowerBalanceSection } from '@/components/features/experiments/sections/power-balance-section';
+import { TreatmentArmsSection } from '@/components/features/experiments/sections/treatment-arms-section';
+import { Flex, Grid } from '@radix-ui/themes';
 
 // Type guard to check if design spec is frequentist (has alpha, power, filters, strata)
 function isFrequentistSpec(
-	spec: CreateExperimentResponse["design_spec"],
-): spec is
-	| OnlineFrequentistExperimentSpecOutput
-	| PreassignedFrequentistExperimentSpecOutput {
-	return (
-		spec.experiment_type === "freq_online" ||
-		spec.experiment_type === "freq_preassigned"
-	);
+  spec: CreateExperimentResponse['design_spec'],
+): spec is OnlineFrequentistExperimentSpecOutput | PreassignedFrequentistExperimentSpecOutput {
+  return spec.experiment_type === 'freq_online' || spec.experiment_type === 'freq_preassigned';
 }
 
 // Type guard for MAB experiments
-function isMABSpec(
-	spec: CreateExperimentResponse["design_spec"],
-): spec is MABExperimentSpecOutput {
-	return spec.experiment_type === "mab_online";
+function isMABSpec(spec: CreateExperimentResponse['design_spec']): spec is MABExperimentSpecOutput {
+  return spec.experiment_type === 'mab_online';
 }
 
 // Type guard for CMAB experiments
-function isCMABSpec(
-	spec: CreateExperimentResponse["design_spec"],
-): spec is CMABExperimentSpecOutput {
-	return spec.experiment_type === "cmab_online";
+function isCMABSpec(spec: CreateExperimentResponse['design_spec']): spec is CMABExperimentSpecOutput {
+  return spec.experiment_type === 'cmab_online';
 }
 
 // Type guard for any bandit experiment
 function isBanditSpec(
-	spec: CreateExperimentResponse["design_spec"],
+  spec: CreateExperimentResponse['design_spec'],
 ): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput {
-	return isMABSpec(spec) || isCMABSpec(spec);
+  return isMABSpec(spec) || isCMABSpec(spec);
 }
 
 export interface ExperimentConfirmationDisplayProps {
-	response: CreateExperimentResponse;
+  response: CreateExperimentResponse;
 
-	tableName?: string;
-	primaryKey?: string;
-	// Data not available in response (frequentist-specific)
-	metrics?: {
-		primary?: MetricDisplay;
-		secondary?: MetricDisplay[];
-	};
-	desiredN?: number;
-	/**
-	 * Cluster randomization parameters for the new "Cluster Preassigned A/B
-	 * Testing" type (issue #217). Set only when the experiment is cluster-
-	 * randomized; rendered under the Metrics section.
-	 */
-	cluster?: {
-		field_name: string;
-		icc: string | number;
-		cv: string | number;
-		avg_cluster_size: string | number;
-	};
-	onEditMetadata?: () => void;
-	onEditTreatmentArms?: () => void;
-	onEditDatasource?: () => void;
-	onEditFilters?: () => void;
-	onEditOutcomesPrior?: () => void;
-	onEditContexts?: () => void;
-	onEditMetrics?: () => void;
-	onEditPowerBalance?: () => void;
-	// Optional footer for actions (commit/abandon in old flow, nothing in new flow)
-	footer?: React.ReactNode;
+  tableName?: string;
+  primaryKey?: string;
+  // Data not available in response (frequentist-specific)
+  metrics?: {
+    primary?: MetricDisplay;
+    secondary?: MetricDisplay[];
+  };
+  desiredN?: number;
+  /**
+   * Cluster randomization parameters for the new "Cluster Preassigned A/B
+   * Testing" type (issue #217). Set only when the experiment is cluster-
+   * randomized; rendered under the Metrics section.
+   */
+  cluster?: {
+    field_name: string;
+    icc: string | number;
+    cv: string | number;
+    avg_cluster_size: string | number;
+  };
+  onEditMetadata?: () => void;
+  onEditTreatmentArms?: () => void;
+  onEditDatasource?: () => void;
+  onEditFilters?: () => void;
+  onEditOutcomesPrior?: () => void;
+  onEditContexts?: () => void;
+  onEditMetrics?: () => void;
+  onEditPowerBalance?: () => void;
+  // Optional footer for actions (commit/abandon in old flow, nothing in new flow)
+  footer?: React.ReactNode;
 }
 
 export function ExperimentConfirmationDisplay({
-	response,
-	tableName,
-	primaryKey,
-	metrics,
-	desiredN,
-	cluster,
-	onEditMetadata,
-	onEditTreatmentArms,
-	onEditDatasource,
-	onEditFilters,
-	onEditOutcomesPrior,
-	onEditContexts,
-	onEditMetrics,
-	onEditPowerBalance,
-	footer,
+  response,
+  tableName,
+  primaryKey,
+  metrics,
+  desiredN,
+  cluster,
+  onEditMetadata,
+  onEditTreatmentArms,
+  onEditDatasource,
+  onEditFilters,
+  onEditOutcomesPrior,
+  onEditContexts,
+  onEditMetrics,
+  onEditPowerBalance,
+  footer,
 }: ExperimentConfirmationDisplayProps) {
-	const designSpec = response.design_spec;
-	const isFreq = isFrequentistSpec(designSpec);
-	const isFreqPreassigned = designSpec.experiment_type === "freq_preassigned";
-	const isBandit = isBanditSpec(designSpec);
-	const isCmab = isCMABSpec(designSpec);
+  const designSpec = response.design_spec;
+  const isFreq = isFrequentistSpec(designSpec);
+  const isFreqPreassigned = designSpec.experiment_type === 'freq_preassigned';
+  const isBandit = isBanditSpec(designSpec);
+  const isCmab = isCMABSpec(designSpec);
 
-	// Extract frequentist-specific properties (confidence/power/filters/strata)
-	// For non-frequentist experiments, these will be undefined
-	let confidence = 95;
-	let power = 80;
-	let filters: FilterOutput[] = [];
-	let strata: string[] | undefined;
+  // Extract frequentist-specific properties (confidence/power/filters/strata)
+  // For non-frequentist experiments, these will be undefined
+  let confidence = 95;
+  let power = 80;
+  let filters: FilterOutput[] = [];
+  let strata: string[] | undefined;
 
-	if (isFreq) {
-		const alpha = designSpec.alpha ?? 0.05;
-		confidence = Math.round((1 - alpha) * 100);
-		power = Math.round((designSpec.power ?? 0.8) * 100);
-		filters = designSpec.filters;
-		strata = designSpec.strata?.map((s) => s.field_name);
-	}
+  if (isFreq) {
+    const alpha = designSpec.alpha ?? 0.05;
+    confidence = Math.round((1 - alpha) * 100);
+    power = Math.round((designSpec.power ?? 0.8) * 100);
+    filters = designSpec.filters;
+    strata = designSpec.strata?.map((s) => s.field_name);
+  }
 
-	// Extract webhook IDs from response (webhooks is string[] directly)
-	// Extract bandit-specific properties
-	const priorType = isBandit ? designSpec.prior_type : undefined;
-	const rewardType = isBandit ? designSpec.reward_type : undefined;
-	const contexts = isCmab ? (designSpec.contexts ?? []) : [];
+  // Extract webhook IDs from response (webhooks is string[] directly)
+  // Extract bandit-specific properties
+  const priorType = isBandit ? designSpec.prior_type : undefined;
+  const rewardType = isBandit ? designSpec.reward_type : undefined;
+  const contexts = isCmab ? (designSpec.contexts ?? []) : [];
 
-	return (
-		<Flex direction="column" gap="4">
-			<Grid columns={"2"} gap={"3"}>
-				<ExperimentDescriptionSection
-					response={response}
-					onEdit={onEditMetadata}
-				/>
-				<TreatmentArmsSection
-					response={response}
-					onEdit={onEditTreatmentArms}
-				/>
-				{isFreq && (
-					<>
-						<DatasourceTargetingSection
-							tableName={tableName}
-							primaryKey={primaryKey}
-							filters={filters}
-							onEditDatasource={onEditDatasource}
-							onEditFilters={onEditFilters}
-						/>
-						<MetricsSection
-							metrics={metrics}
-							strata={strata}
-							onEdit={onEditMetrics}
-							cluster={cluster}
-						/>
-						{isFreqPreassigned && (
-							<PowerBalanceSection
-								confidence={confidence}
-								power={power}
-								desiredN={desiredN}
-								assignSummary={response.assign_summary}
-								onEdit={onEditPowerBalance}
-								designEffect={
-									response.power_analyses?.analyses?.[0]?.design_effect ?? null
-								}
-								numClustersTotal={
-									response.power_analyses?.analyses?.[0]?.num_clusters_total ??
-									null
-								}
-							/>
-						)}
-					</>
-				)}
-				{isBandit && (
-					<OutcomesPriorSection
-						priorType={priorType}
-						rewardType={rewardType}
-						onEdit={onEditOutcomesPrior}
-					/>
-				)}
-				{isCmab && contexts.length > 0 && (
-					<ContextsSection contexts={contexts} onEdit={onEditContexts} />
-				)}
-				{footer}
-			</Grid>
-		</Flex>
-	);
+  return (
+    <Flex direction="column" gap="4">
+      <Grid columns={'2'} gap={'3'}>
+        <ExperimentDescriptionSection response={response} onEdit={onEditMetadata} />
+        <TreatmentArmsSection response={response} onEdit={onEditTreatmentArms} />
+        {isFreq && (
+          <>
+            <DatasourceTargetingSection
+              tableName={tableName}
+              primaryKey={primaryKey}
+              filters={filters}
+              onEditDatasource={onEditDatasource}
+              onEditFilters={onEditFilters}
+            />
+            <MetricsSection metrics={metrics} strata={strata} onEdit={onEditMetrics} cluster={cluster} />
+            {isFreqPreassigned && (
+              <PowerBalanceSection
+                confidence={confidence}
+                power={power}
+                desiredN={desiredN}
+                assignSummary={response.assign_summary}
+                onEdit={onEditPowerBalance}
+                designEffect={response.power_analyses?.analyses?.[0]?.design_effect ?? null}
+                numClustersTotal={response.power_analyses?.analyses?.[0]?.num_clusters_total ?? null}
+              />
+            )}
+          </>
+        )}
+        {isBandit && (
+          <OutcomesPriorSection priorType={priorType} rewardType={rewardType} onEdit={onEditOutcomesPrior} />
+        )}
+        {isCmab && contexts.length > 0 && <ContextsSection contexts={contexts} onEdit={onEditContexts} />}
+        {footer}
+      </Grid>
+    </Flex>
+  );
 }

--- a/src/components/features/experiments/experiment-confirmation-display.tsx
+++ b/src/components/features/experiments/experiment-confirmation-display.tsx
@@ -1,144 +1,192 @@
-'use client';
+"use client";
 
-import { Flex, Grid } from '@radix-ui/themes';
 import {
-  CMABExperimentSpecOutput,
-  CreateExperimentResponse,
-  FilterOutput,
-  MABExperimentSpecOutput,
-  OnlineFrequentistExperimentSpecOutput,
-  PreassignedFrequentistExperimentSpecOutput,
-} from '@/api/methods.schemas';
-import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
-import { ExperimentDescriptionSection } from '@/components/features/experiments/sections/experiment-description-section';
-import { TreatmentArmsSection } from '@/components/features/experiments/sections/treatment-arms-section';
-import { ContextsSection } from '@/components/features/experiments/sections/contexts-section';
-import { DatasourceTargetingSection } from '@/components/features/experiments/sections/datasource-targeting-section';
-import { PowerBalanceSection } from '@/components/features/experiments/sections/power-balance-section';
-import { OutcomesPriorSection } from '@/components/features/experiments/sections/outcomes-prior-section';
+	CMABExperimentSpecOutput,
+	CreateExperimentResponse,
+	FilterOutput,
+	MABExperimentSpecOutput,
+	OnlineFrequentistExperimentSpecOutput,
+	PreassignedFrequentistExperimentSpecOutput,
+} from "@/api/methods.schemas";
+import { ContextsSection } from "@/components/features/experiments/sections/contexts-section";
+import { DatasourceTargetingSection } from "@/components/features/experiments/sections/datasource-targeting-section";
+import { ExperimentDescriptionSection } from "@/components/features/experiments/sections/experiment-description-section";
+import {
+	MetricDisplay,
+	MetricsSection,
+} from "@/components/features/experiments/sections/metrics-section";
+import { OutcomesPriorSection } from "@/components/features/experiments/sections/outcomes-prior-section";
+import { PowerBalanceSection } from "@/components/features/experiments/sections/power-balance-section";
+import { TreatmentArmsSection } from "@/components/features/experiments/sections/treatment-arms-section";
+import { Flex, Grid } from "@radix-ui/themes";
 
 // Type guard to check if design spec is frequentist (has alpha, power, filters, strata)
 function isFrequentistSpec(
-  spec: CreateExperimentResponse['design_spec'],
-): spec is OnlineFrequentistExperimentSpecOutput | PreassignedFrequentistExperimentSpecOutput {
-  return spec.experiment_type === 'freq_online' || spec.experiment_type === 'freq_preassigned';
+	spec: CreateExperimentResponse["design_spec"],
+): spec is
+	| OnlineFrequentistExperimentSpecOutput
+	| PreassignedFrequentistExperimentSpecOutput {
+	return (
+		spec.experiment_type === "freq_online" ||
+		spec.experiment_type === "freq_preassigned"
+	);
 }
 
 // Type guard for MAB experiments
-function isMABSpec(spec: CreateExperimentResponse['design_spec']): spec is MABExperimentSpecOutput {
-  return spec.experiment_type === 'mab_online';
+function isMABSpec(
+	spec: CreateExperimentResponse["design_spec"],
+): spec is MABExperimentSpecOutput {
+	return spec.experiment_type === "mab_online";
 }
 
 // Type guard for CMAB experiments
-function isCMABSpec(spec: CreateExperimentResponse['design_spec']): spec is CMABExperimentSpecOutput {
-  return spec.experiment_type === 'cmab_online';
+function isCMABSpec(
+	spec: CreateExperimentResponse["design_spec"],
+): spec is CMABExperimentSpecOutput {
+	return spec.experiment_type === "cmab_online";
 }
 
 // Type guard for any bandit experiment
 function isBanditSpec(
-  spec: CreateExperimentResponse['design_spec'],
+	spec: CreateExperimentResponse["design_spec"],
 ): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput {
-  return isMABSpec(spec) || isCMABSpec(spec);
+	return isMABSpec(spec) || isCMABSpec(spec);
 }
 
 export interface ExperimentConfirmationDisplayProps {
-  response: CreateExperimentResponse;
+	response: CreateExperimentResponse;
 
-  tableName?: string;
-  primaryKey?: string;
-  // Data not available in response (frequentist-specific)
-  metrics?: {
-    primary?: MetricDisplay;
-    secondary?: MetricDisplay[];
-  };
-  desiredN?: number;
-  onEditMetadata?: () => void;
-  onEditTreatmentArms?: () => void;
-  onEditDatasource?: () => void;
-  onEditFilters?: () => void;
-  onEditOutcomesPrior?: () => void;
-  onEditContexts?: () => void;
-  onEditMetrics?: () => void;
-  onEditPowerBalance?: () => void;
-  // Optional footer for actions (commit/abandon in old flow, nothing in new flow)
-  footer?: React.ReactNode;
+	tableName?: string;
+	primaryKey?: string;
+	// Data not available in response (frequentist-specific)
+	metrics?: {
+		primary?: MetricDisplay;
+		secondary?: MetricDisplay[];
+	};
+	desiredN?: number;
+	/**
+	 * Cluster randomization parameters for the new "Cluster Preassigned A/B
+	 * Testing" type (issue #217). Set only when the experiment is cluster-
+	 * randomized; rendered under the Metrics section.
+	 */
+	cluster?: {
+		field_name: string;
+		icc: string | number;
+		cv: string | number;
+		avg_cluster_size: string | number;
+	};
+	onEditMetadata?: () => void;
+	onEditTreatmentArms?: () => void;
+	onEditDatasource?: () => void;
+	onEditFilters?: () => void;
+	onEditOutcomesPrior?: () => void;
+	onEditContexts?: () => void;
+	onEditMetrics?: () => void;
+	onEditPowerBalance?: () => void;
+	// Optional footer for actions (commit/abandon in old flow, nothing in new flow)
+	footer?: React.ReactNode;
 }
 
 export function ExperimentConfirmationDisplay({
-  response,
-  tableName,
-  primaryKey,
-  metrics,
-  desiredN,
-  onEditMetadata,
-  onEditTreatmentArms,
-  onEditDatasource,
-  onEditFilters,
-  onEditOutcomesPrior,
-  onEditContexts,
-  onEditMetrics,
-  onEditPowerBalance,
-  footer,
+	response,
+	tableName,
+	primaryKey,
+	metrics,
+	desiredN,
+	cluster,
+	onEditMetadata,
+	onEditTreatmentArms,
+	onEditDatasource,
+	onEditFilters,
+	onEditOutcomesPrior,
+	onEditContexts,
+	onEditMetrics,
+	onEditPowerBalance,
+	footer,
 }: ExperimentConfirmationDisplayProps) {
-  const designSpec = response.design_spec;
-  const isFreq = isFrequentistSpec(designSpec);
-  const isFreqPreassigned = designSpec.experiment_type === 'freq_preassigned';
-  const isBandit = isBanditSpec(designSpec);
-  const isCmab = isCMABSpec(designSpec);
+	const designSpec = response.design_spec;
+	const isFreq = isFrequentistSpec(designSpec);
+	const isFreqPreassigned = designSpec.experiment_type === "freq_preassigned";
+	const isBandit = isBanditSpec(designSpec);
+	const isCmab = isCMABSpec(designSpec);
 
-  // Extract frequentist-specific properties (confidence/power/filters/strata)
-  // For non-frequentist experiments, these will be undefined
-  let confidence = 95;
-  let power = 80;
-  let filters: FilterOutput[] = [];
-  let strata: string[] | undefined;
+	// Extract frequentist-specific properties (confidence/power/filters/strata)
+	// For non-frequentist experiments, these will be undefined
+	let confidence = 95;
+	let power = 80;
+	let filters: FilterOutput[] = [];
+	let strata: string[] | undefined;
 
-  if (isFreq) {
-    const alpha = designSpec.alpha ?? 0.05;
-    confidence = Math.round((1 - alpha) * 100);
-    power = Math.round((designSpec.power ?? 0.8) * 100);
-    filters = designSpec.filters;
-    strata = designSpec.strata?.map((s) => s.field_name);
-  }
+	if (isFreq) {
+		const alpha = designSpec.alpha ?? 0.05;
+		confidence = Math.round((1 - alpha) * 100);
+		power = Math.round((designSpec.power ?? 0.8) * 100);
+		filters = designSpec.filters;
+		strata = designSpec.strata?.map((s) => s.field_name);
+	}
 
-  // Extract webhook IDs from response (webhooks is string[] directly)
-  // Extract bandit-specific properties
-  const priorType = isBandit ? designSpec.prior_type : undefined;
-  const rewardType = isBandit ? designSpec.reward_type : undefined;
-  const contexts = isCmab ? (designSpec.contexts ?? []) : [];
+	// Extract webhook IDs from response (webhooks is string[] directly)
+	// Extract bandit-specific properties
+	const priorType = isBandit ? designSpec.prior_type : undefined;
+	const rewardType = isBandit ? designSpec.reward_type : undefined;
+	const contexts = isCmab ? (designSpec.contexts ?? []) : [];
 
-  return (
-    <Flex direction="column" gap="4">
-      <Grid columns={'2'} gap={'3'}>
-        <ExperimentDescriptionSection response={response} onEdit={onEditMetadata} />
-        <TreatmentArmsSection response={response} onEdit={onEditTreatmentArms} />
-        {isFreq && (
-          <>
-            <DatasourceTargetingSection
-              tableName={tableName}
-              primaryKey={primaryKey}
-              filters={filters}
-              onEditDatasource={onEditDatasource}
-              onEditFilters={onEditFilters}
-            />
-            <MetricsSection metrics={metrics} strata={strata} onEdit={onEditMetrics} />
-            {isFreqPreassigned && (
-              <PowerBalanceSection
-                confidence={confidence}
-                power={power}
-                desiredN={desiredN}
-                assignSummary={response.assign_summary}
-                onEdit={onEditPowerBalance}
-              />
-            )}
-          </>
-        )}
-        {isBandit && (
-          <OutcomesPriorSection priorType={priorType} rewardType={rewardType} onEdit={onEditOutcomesPrior} />
-        )}
-        {isCmab && contexts.length > 0 && <ContextsSection contexts={contexts} onEdit={onEditContexts} />}
-        {footer}
-      </Grid>
-    </Flex>
-  );
+	return (
+		<Flex direction="column" gap="4">
+			<Grid columns={"2"} gap={"3"}>
+				<ExperimentDescriptionSection
+					response={response}
+					onEdit={onEditMetadata}
+				/>
+				<TreatmentArmsSection
+					response={response}
+					onEdit={onEditTreatmentArms}
+				/>
+				{isFreq && (
+					<>
+						<DatasourceTargetingSection
+							tableName={tableName}
+							primaryKey={primaryKey}
+							filters={filters}
+							onEditDatasource={onEditDatasource}
+							onEditFilters={onEditFilters}
+						/>
+						<MetricsSection
+							metrics={metrics}
+							strata={strata}
+							onEdit={onEditMetrics}
+							cluster={cluster}
+						/>
+						{isFreqPreassigned && (
+							<PowerBalanceSection
+								confidence={confidence}
+								power={power}
+								desiredN={desiredN}
+								assignSummary={response.assign_summary}
+								onEdit={onEditPowerBalance}
+								designEffect={
+									response.power_analyses?.analyses?.[0]?.design_effect ?? null
+								}
+								numClustersTotal={
+									response.power_analyses?.analyses?.[0]?.num_clusters_total ??
+									null
+								}
+							/>
+						)}
+					</>
+				)}
+				{isBandit && (
+					<OutcomesPriorSection
+						priorType={priorType}
+						rewardType={rewardType}
+						onEdit={onEditOutcomesPrior}
+					/>
+				)}
+				{isCmab && contexts.length > 0 && (
+					<ContextsSection contexts={contexts} onEdit={onEditContexts} />
+				)}
+				{footer}
+			</Grid>
+		</Flex>
+	);
 }

--- a/src/components/features/experiments/experiment-type-badge.tsx
+++ b/src/components/features/experiments/experiment-type-badge.tsx
@@ -1,30 +1,84 @@
-'use client';
+"use client";
 
-import { Badge, Tooltip } from '@radix-ui/themes';
+import { Badge, Tooltip } from "@radix-ui/themes";
 
-export const ExperimentTypeBadge = ({ type }: { type: string }) => {
-  const typeMap: Record<
-    string,
-    { name: string; tooltipName: string; color: 'green' | 'blue' | 'red' | 'purple'; variant?: 'soft' | 'outline' }
-  > = {
-    freq_preassigned: { name: 'A/B PreAs', tooltipName: 'A/B Preassigned', color: 'blue', variant: 'soft' },
-    freq_online: { name: 'A/B Online', tooltipName: 'A/B Online', color: 'blue', variant: 'soft' },
-    mab_online: { name: 'MAB', tooltipName: 'Multi-Armed Bandit', color: 'green', variant: 'soft' },
-    cmab_online: { name: 'CMAB', tooltipName: 'Contextual Multi-Armed Bandit', color: 'purple', variant: 'soft' },
-  };
+/**
+ * Renders the small badge that labels each experiment by type on the list/card
+ * views and the experiment details header.
+ *
+ * `isCluster` (issue #217) is an FE-only override: the backend stores cluster-
+ * randomized experiments as `freq_preassigned` (with `cluster_column` set on
+ * the design spec), so we can't distinguish them from regular preassigned
+ * experiments by `type` alone. Callers should pass `isCluster` when the
+ * underlying experiment's design spec has `cluster_column` populated.
+ */
+export const ExperimentTypeBadge = ({
+	type,
+	isCluster,
+}: {
+	type: string;
+	isCluster?: boolean;
+}) => {
+	const typeMap: Record<
+		string,
+		{
+			name: string;
+			tooltipName: string;
+			color: "green" | "blue" | "red" | "purple" | "orange";
+			variant?: "soft" | "outline";
+		}
+	> = {
+		freq_preassigned: {
+			name: "A/B PreAs",
+			tooltipName: "A/B Preassigned",
+			color: "blue",
+			variant: "soft",
+		},
+		freq_online: {
+			name: "A/B Online",
+			tooltipName: "A/B Online",
+			color: "blue",
+			variant: "soft",
+		},
+		mab_online: {
+			name: "MAB",
+			tooltipName: "Multi-Armed Bandit",
+			color: "green",
+			variant: "soft",
+		},
+		cmab_online: {
+			name: "CMAB",
+			tooltipName: "Contextual Multi-Armed Bandit",
+			color: "purple",
+			variant: "soft",
+		},
+	};
 
-  const { name, tooltipName, color, variant } = typeMap[type] || {
-    name: type,
-    tooltipName: type,
-    color: 'red' as const,
-    variant: 'outline' as const,
-  };
+	const baseEntry = typeMap[type] || {
+		name: type,
+		tooltipName: type,
+		color: "red" as const,
+		variant: "outline" as const,
+	};
 
-  return (
-    <Tooltip content={tooltipName}>
-      <Badge color={color} variant={variant} style={{ cursor: 'default' }}>
-        {name}
-      </Badge>
-    </Tooltip>
-  );
+	// Issue #217: cluster-randomized preassigned experiments get a distinct
+	// label but stay in the same blue family as regular A/B PreAs for visual
+	// consistency.
+	const { name, tooltipName, color, variant } =
+		isCluster && type === "freq_preassigned"
+			? {
+					name: "Cluster",
+					tooltipName: "Cluster Preassigned A/B Testing",
+					color: "blue" as const,
+					variant: "soft" as const,
+				}
+			: baseEntry;
+
+	return (
+		<Tooltip content={tooltipName}>
+			<Badge color={color} variant={variant} style={{ cursor: "default" }}>
+				{name}
+			</Badge>
+		</Tooltip>
+	);
 };

--- a/src/components/features/experiments/experiment-type-badge.tsx
+++ b/src/components/features/experiments/experiment-type-badge.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import { Badge, Tooltip } from "@radix-ui/themes";
+import { Badge, Tooltip } from '@radix-ui/themes';
 
 /**
  * Renders the small badge that labels each experiment by type on the list/card
@@ -12,73 +12,67 @@ import { Badge, Tooltip } from "@radix-ui/themes";
  * experiments by `type` alone. Callers should pass `isCluster` when the
  * underlying experiment's design spec has `cluster_column` populated.
  */
-export const ExperimentTypeBadge = ({
-	type,
-	isCluster,
-}: {
-	type: string;
-	isCluster?: boolean;
-}) => {
-	const typeMap: Record<
-		string,
-		{
-			name: string;
-			tooltipName: string;
-			color: "green" | "blue" | "red" | "purple" | "orange";
-			variant?: "soft" | "outline";
-		}
-	> = {
-		freq_preassigned: {
-			name: "A/B PreAs",
-			tooltipName: "A/B Preassigned",
-			color: "blue",
-			variant: "soft",
-		},
-		freq_online: {
-			name: "A/B Online",
-			tooltipName: "A/B Online",
-			color: "blue",
-			variant: "soft",
-		},
-		mab_online: {
-			name: "MAB",
-			tooltipName: "Multi-Armed Bandit",
-			color: "green",
-			variant: "soft",
-		},
-		cmab_online: {
-			name: "CMAB",
-			tooltipName: "Contextual Multi-Armed Bandit",
-			color: "purple",
-			variant: "soft",
-		},
-	};
+export const ExperimentTypeBadge = ({ type, isCluster }: { type: string; isCluster?: boolean }) => {
+  const typeMap: Record<
+    string,
+    {
+      name: string;
+      tooltipName: string;
+      color: 'green' | 'blue' | 'red' | 'purple' | 'orange';
+      variant?: 'soft' | 'outline';
+    }
+  > = {
+    freq_preassigned: {
+      name: 'A/B PreAs',
+      tooltipName: 'A/B Preassigned',
+      color: 'blue',
+      variant: 'soft',
+    },
+    freq_online: {
+      name: 'A/B Online',
+      tooltipName: 'A/B Online',
+      color: 'blue',
+      variant: 'soft',
+    },
+    mab_online: {
+      name: 'MAB',
+      tooltipName: 'Multi-Armed Bandit',
+      color: 'green',
+      variant: 'soft',
+    },
+    cmab_online: {
+      name: 'CMAB',
+      tooltipName: 'Contextual Multi-Armed Bandit',
+      color: 'purple',
+      variant: 'soft',
+    },
+  };
 
-	const baseEntry = typeMap[type] || {
-		name: type,
-		tooltipName: type,
-		color: "red" as const,
-		variant: "outline" as const,
-	};
+  const baseEntry = typeMap[type] || {
+    name: type,
+    tooltipName: type,
+    color: 'red' as const,
+    variant: 'outline' as const,
+  };
 
-	// Issue #217: cluster-randomized preassigned experiments get a distinct
-	// label but stay in the same blue family as regular A/B PreAs for visual
-	// consistency.
-	const { name, tooltipName, color, variant } =
-		isCluster && type === "freq_preassigned"
-			? {
-					name: "Cluster",
-					tooltipName: "Cluster Preassigned A/B Testing",
-					color: "blue" as const,
-					variant: "soft" as const,
-				}
-			: baseEntry;
+  // Issue #217: cluster-randomized preassigned experiments get a distinct
+  // label but stay in the same blue family as regular A/B PreAs for visual
+  // consistency.
+  const { name, tooltipName, color, variant } =
+    isCluster && type === 'freq_preassigned'
+      ? {
+          name: 'Cluster',
+          tooltipName: 'Cluster Preassigned A/B Testing',
+          color: 'blue' as const,
+          variant: 'soft' as const,
+        }
+      : baseEntry;
 
-	return (
-		<Tooltip content={tooltipName}>
-			<Badge color={color} variant={variant} style={{ cursor: "default" }}>
-				{name}
-			</Badge>
-		</Tooltip>
-	);
+  return (
+    <Tooltip content={tooltipName}>
+      <Badge color={color} variant={variant} style={{ cursor: 'default' }}>
+        {name}
+      </Badge>
+    </Tooltip>
+  );
 };

--- a/src/components/features/experiments/experiments-table-row.tsx
+++ b/src/components/features/experiments/experiments-table-row.tsx
@@ -1,68 +1,91 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
-import { Flex, IconButton, Table, Text, Tooltip } from '@radix-ui/themes';
-import { FileTextIcon } from '@radix-ui/react-icons';
-import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
-import { ExperimentImpactBadge } from '@/components/features/experiments/experiment-impact-badge';
-import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
-import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
-import { formatIsoDateLocal } from '@/services/date-utils';
-import { ExperimentWithStatus } from '@/components/features/experiments/types';
+import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
+import { DownloadAssignmentsCsvButton } from "@/components/features/experiments/download-assignments-csv-button";
+import { ExperimentImpactBadge } from "@/components/features/experiments/experiment-impact-badge";
+import { ExperimentStatusBadge } from "@/components/features/experiments/experiment-status-badge";
+import { ExperimentTypeBadge } from "@/components/features/experiments/experiment-type-badge";
+import { ExperimentWithStatus } from "@/components/features/experiments/types";
+import { formatIsoDateLocal } from "@/services/date-utils";
+import { FileTextIcon } from "@radix-ui/react-icons";
+import { Flex, IconButton, Table, Text, Tooltip } from "@radix-ui/themes";
+import Link from "next/link";
 
 interface ExperimentTableRowProps {
-  experiment: ExperimentWithStatus;
+	experiment: ExperimentWithStatus;
 }
 
 export function ExperimentsTableRow({ experiment }: ExperimentTableRowProps) {
-  const { experiment_id: experimentId, datasource_id: datasourceId, design_spec } = experiment;
-  return (
-    <>
-      <Table.Row>
-        <Table.Cell>
-          <Flex width="200px">
-            <Tooltip content={design_spec.experiment_name}>
-              <Text truncate asChild>
-                <Link href={`/datasources/${datasourceId}/experiments/${experimentId}`}>
-                  {design_spec.experiment_name}
-                </Link>
-              </Text>
-            </Tooltip>
-          </Flex>
-        </Table.Cell>
-        <Table.Cell>
-          <ExperimentStatusBadge status={experiment.status} />
-        </Table.Cell>
-        <Table.Cell>{formatIsoDateLocal(design_spec.start_date)}</Table.Cell>
-        <Table.Cell>{formatIsoDateLocal(design_spec.end_date)}</Table.Cell>
-        <Table.Cell>
-          <ExperimentImpactBadge impact={experiment.impact} useShortLabel={true} />
-        </Table.Cell>
-        <Table.Cell>
-          <Flex width="150px">
-            <Text truncate color={experiment.decision ? undefined : 'gray'}>
-              {experiment.decision || 'Undecided'}
-            </Text>
-          </Flex>
-        </Table.Cell>
-        <Table.Cell>
-          <ExperimentTypeBadge type={design_spec.experiment_type} />
-        </Table.Cell>
-        <Table.Cell>
-          <Flex gap="2">
-            <DownloadAssignmentsCsvButton datasourceId={datasourceId} experimentId={experimentId} />
-            {design_spec.design_url && (
-              <Tooltip content="View design document">
-                <IconButton variant="soft" color="blue" size="2" asChild>
-                  <Link href={design_spec.design_url} target="_blank" rel="noopener noreferrer">
-                    <FileTextIcon width="16" height="16" />
-                  </Link>
-                </IconButton>
-              </Tooltip>
-            )}
-          </Flex>
-        </Table.Cell>
-      </Table.Row>
-    </>
-  );
+	const {
+		experiment_id: experimentId,
+		datasource_id: datasourceId,
+		design_spec,
+	} = experiment;
+	return (
+		<>
+			<Table.Row>
+				<Table.Cell>
+					<Flex width="200px">
+						<Tooltip content={design_spec.experiment_name}>
+							<Text truncate asChild>
+								<Link
+									href={`/datasources/${datasourceId}/experiments/${experimentId}`}
+								>
+									{design_spec.experiment_name}
+								</Link>
+							</Text>
+						</Tooltip>
+					</Flex>
+				</Table.Cell>
+				<Table.Cell>
+					<ExperimentStatusBadge status={experiment.status} />
+				</Table.Cell>
+				<Table.Cell>{formatIsoDateLocal(design_spec.start_date)}</Table.Cell>
+				<Table.Cell>{formatIsoDateLocal(design_spec.end_date)}</Table.Cell>
+				<Table.Cell>
+					<ExperimentImpactBadge
+						impact={experiment.impact}
+						useShortLabel={true}
+					/>
+				</Table.Cell>
+				<Table.Cell>
+					<Flex width="150px">
+						<Text truncate color={experiment.decision ? undefined : "gray"}>
+							{experiment.decision || "Undecided"}
+						</Text>
+					</Flex>
+				</Table.Cell>
+				<Table.Cell>
+					<ExperimentTypeBadge
+						type={design_spec.experiment_type}
+						isCluster={isClusterDesign(
+							design_spec,
+							(experiment as { power_analyses?: unknown }).power_analyses,
+						)}
+					/>
+				</Table.Cell>
+				<Table.Cell>
+					<Flex gap="2">
+						<DownloadAssignmentsCsvButton
+							datasourceId={datasourceId}
+							experimentId={experimentId}
+						/>
+						{design_spec.design_url && (
+							<Tooltip content="View design document">
+								<IconButton variant="soft" color="blue" size="2" asChild>
+									<Link
+										href={design_spec.design_url}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										<FileTextIcon width="16" height="16" />
+									</Link>
+								</IconButton>
+							</Tooltip>
+						)}
+					</Flex>
+				</Table.Cell>
+			</Table.Row>
+		</>
+	);
 }

--- a/src/components/features/experiments/experiments-table-row.tsx
+++ b/src/components/features/experiments/experiments-table-row.tsx
@@ -1,91 +1,72 @@
-"use client";
+'use client';
 
-import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
-import { DownloadAssignmentsCsvButton } from "@/components/features/experiments/download-assignments-csv-button";
-import { ExperimentImpactBadge } from "@/components/features/experiments/experiment-impact-badge";
-import { ExperimentStatusBadge } from "@/components/features/experiments/experiment-status-badge";
-import { ExperimentTypeBadge } from "@/components/features/experiments/experiment-type-badge";
-import { ExperimentWithStatus } from "@/components/features/experiments/types";
-import { formatIsoDateLocal } from "@/services/date-utils";
-import { FileTextIcon } from "@radix-ui/react-icons";
-import { Flex, IconButton, Table, Text, Tooltip } from "@radix-ui/themes";
-import Link from "next/link";
+import { isClusterDesign } from '@/components/features/experiments/cluster-detection';
+import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
+import { ExperimentImpactBadge } from '@/components/features/experiments/experiment-impact-badge';
+import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
+import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
+import { ExperimentWithStatus } from '@/components/features/experiments/types';
+import { formatIsoDateLocal } from '@/services/date-utils';
+import { FileTextIcon } from '@radix-ui/react-icons';
+import { Flex, IconButton, Table, Text, Tooltip } from '@radix-ui/themes';
+import Link from 'next/link';
 
 interface ExperimentTableRowProps {
-	experiment: ExperimentWithStatus;
+  experiment: ExperimentWithStatus;
 }
 
 export function ExperimentsTableRow({ experiment }: ExperimentTableRowProps) {
-	const {
-		experiment_id: experimentId,
-		datasource_id: datasourceId,
-		design_spec,
-	} = experiment;
-	return (
-		<>
-			<Table.Row>
-				<Table.Cell>
-					<Flex width="200px">
-						<Tooltip content={design_spec.experiment_name}>
-							<Text truncate asChild>
-								<Link
-									href={`/datasources/${datasourceId}/experiments/${experimentId}`}
-								>
-									{design_spec.experiment_name}
-								</Link>
-							</Text>
-						</Tooltip>
-					</Flex>
-				</Table.Cell>
-				<Table.Cell>
-					<ExperimentStatusBadge status={experiment.status} />
-				</Table.Cell>
-				<Table.Cell>{formatIsoDateLocal(design_spec.start_date)}</Table.Cell>
-				<Table.Cell>{formatIsoDateLocal(design_spec.end_date)}</Table.Cell>
-				<Table.Cell>
-					<ExperimentImpactBadge
-						impact={experiment.impact}
-						useShortLabel={true}
-					/>
-				</Table.Cell>
-				<Table.Cell>
-					<Flex width="150px">
-						<Text truncate color={experiment.decision ? undefined : "gray"}>
-							{experiment.decision || "Undecided"}
-						</Text>
-					</Flex>
-				</Table.Cell>
-				<Table.Cell>
-					<ExperimentTypeBadge
-						type={design_spec.experiment_type}
-						isCluster={isClusterDesign(
-							design_spec,
-							(experiment as { power_analyses?: unknown }).power_analyses,
-						)}
-					/>
-				</Table.Cell>
-				<Table.Cell>
-					<Flex gap="2">
-						<DownloadAssignmentsCsvButton
-							datasourceId={datasourceId}
-							experimentId={experimentId}
-						/>
-						{design_spec.design_url && (
-							<Tooltip content="View design document">
-								<IconButton variant="soft" color="blue" size="2" asChild>
-									<Link
-										href={design_spec.design_url}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										<FileTextIcon width="16" height="16" />
-									</Link>
-								</IconButton>
-							</Tooltip>
-						)}
-					</Flex>
-				</Table.Cell>
-			</Table.Row>
-		</>
-	);
+  const { experiment_id: experimentId, datasource_id: datasourceId, design_spec } = experiment;
+  return (
+    <>
+      <Table.Row>
+        <Table.Cell>
+          <Flex width="200px">
+            <Tooltip content={design_spec.experiment_name}>
+              <Text truncate asChild>
+                <Link href={`/datasources/${datasourceId}/experiments/${experimentId}`}>
+                  {design_spec.experiment_name}
+                </Link>
+              </Text>
+            </Tooltip>
+          </Flex>
+        </Table.Cell>
+        <Table.Cell>
+          <ExperimentStatusBadge status={experiment.status} />
+        </Table.Cell>
+        <Table.Cell>{formatIsoDateLocal(design_spec.start_date)}</Table.Cell>
+        <Table.Cell>{formatIsoDateLocal(design_spec.end_date)}</Table.Cell>
+        <Table.Cell>
+          <ExperimentImpactBadge impact={experiment.impact} useShortLabel={true} />
+        </Table.Cell>
+        <Table.Cell>
+          <Flex width="150px">
+            <Text truncate color={experiment.decision ? undefined : 'gray'}>
+              {experiment.decision || 'Undecided'}
+            </Text>
+          </Flex>
+        </Table.Cell>
+        <Table.Cell>
+          <ExperimentTypeBadge
+            type={design_spec.experiment_type}
+            isCluster={isClusterDesign(design_spec, (experiment as { power_analyses?: unknown }).power_analyses)}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Flex gap="2">
+            <DownloadAssignmentsCsvButton datasourceId={datasourceId} experimentId={experimentId} />
+            {design_spec.design_url && (
+              <Tooltip content="View design document">
+                <IconButton variant="soft" color="blue" size="2" asChild>
+                  <Link href={design_spec.design_url} target="_blank" rel="noopener noreferrer">
+                    <FileTextIcon width="16" height="16" />
+                  </Link>
+                </IconButton>
+              </Tooltip>
+            )}
+          </Flex>
+        </Table.Cell>
+      </Table.Row>
+    </>
+  );
 }

--- a/src/components/features/experiments/icc-badge.tsx
+++ b/src/components/features/experiments/icc-badge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * IccBadge displays the Intraclass Correlation Coefficient (ICC) for a
+ * cluster-randomized experiment alongside Target MDE in the analysis bar.
+ * Issue #217 mockup ClustersUI6A/6B.
+ */
+
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import {
+	Badge,
+	Flex,
+	Heading,
+	Tooltip as RadixTooltip,
+	Text,
+} from "@radix-ui/themes";
+
+type IccBadgeProps = {
+	value?: number | null;
+	size?: "1" | "2" | "3";
+};
+
+const ICC_TOOLTIP =
+	"Intraclass Correlation Coefficient: measures how similar participants within the same cluster are. Higher values reduce statistical power.";
+
+export function IccBadge({ value, size = "2" }: IccBadgeProps) {
+	if (value === null || value === undefined) return null;
+	const display = typeof value === "number" ? value.toFixed(3) : String(value);
+	return (
+		<Badge size={size}>
+			<Flex gap="4" align="center">
+				<Heading size={size}>ICC:</Heading>
+				<Flex gap="2" align="center">
+					<Text>{display}</Text>
+					<RadixTooltip content={ICC_TOOLTIP}>
+						<InfoCircledIcon />
+					</RadixTooltip>
+				</Flex>
+			</Flex>
+		</Badge>
+	);
+}
+
+export default IccBadge;

--- a/src/components/features/experiments/icc-badge.tsx
+++ b/src/components/features/experiments/icc-badge.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 /**
  * IccBadge displays the Intraclass Correlation Coefficient (ICC) for a
@@ -6,39 +6,33 @@
  * Issue #217 mockup ClustersUI6A/6B.
  */
 
-import { InfoCircledIcon } from "@radix-ui/react-icons";
-import {
-	Badge,
-	Flex,
-	Heading,
-	Tooltip as RadixTooltip,
-	Text,
-} from "@radix-ui/themes";
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Badge, Flex, Heading, Tooltip as RadixTooltip, Text } from '@radix-ui/themes';
 
 type IccBadgeProps = {
-	value?: number | null;
-	size?: "1" | "2" | "3";
+  value?: number | null;
+  size?: '1' | '2' | '3';
 };
 
 const ICC_TOOLTIP =
-	"Intraclass Correlation Coefficient: measures how similar participants within the same cluster are. Higher values reduce statistical power.";
+  'Intraclass Correlation Coefficient: measures how similar participants within the same cluster are. Higher values reduce statistical power.';
 
-export function IccBadge({ value, size = "2" }: IccBadgeProps) {
-	if (value === null || value === undefined) return null;
-	const display = typeof value === "number" ? value.toFixed(3) : String(value);
-	return (
-		<Badge size={size}>
-			<Flex gap="4" align="center">
-				<Heading size={size}>ICC:</Heading>
-				<Flex gap="2" align="center">
-					<Text>{display}</Text>
-					<RadixTooltip content={ICC_TOOLTIP}>
-						<InfoCircledIcon />
-					</RadixTooltip>
-				</Flex>
-			</Flex>
-		</Badge>
-	);
+export function IccBadge({ value, size = '2' }: IccBadgeProps) {
+  if (value === null || value === undefined) return null;
+  const display = typeof value === 'number' ? value.toFixed(3) : String(value);
+  return (
+    <Badge size={size}>
+      <Flex gap="4" align="center">
+        <Heading size={size}>ICC:</Heading>
+        <Flex gap="2" align="center">
+          <Text>{display}</Text>
+          <RadixTooltip content={ICC_TOOLTIP}>
+            <InfoCircledIcon />
+          </RadixTooltip>
+        </Flex>
+      </Flex>
+    </Badge>
+  );
 }
 
 export default IccBadge;

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -1,84 +1,75 @@
-"use client";
+'use client';
 
-import { InfoCircledIcon } from "@radix-ui/react-icons";
-import {
-	Badge,
-	Flex,
-	Heading,
-	Tooltip as RadixTooltip,
-	Text,
-} from "@radix-ui/themes";
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Badge, Flex, Heading, Tooltip as RadixTooltip, Text } from '@radix-ui/themes';
 
 type MdeBadgeProps = {
-	value?: string | number | null;
-	/**
-	 * Achievable MDE for the experiment's committed sample size, as a
-	 * percent string or number (e.g. "7.8" or 7.8 — without the "%"). When
-	 * provided AND meaningfully different from `value`, this renders next to
-	 * the Target MDE so reviewers can see what effect size the saved N is
-	 * actually powered to detect. Pass null/undefined for experiments where
-	 * achievable equals target by construction (e.g. user picked the
-	 * recommended sample size, or the experiment isn't preassigned).
-	 */
-	achievable?: string | number | null;
-	size?: "1" | "2" | "3";
+  value?: string | number | null;
+  /**
+   * Achievable MDE for the experiment's committed sample size, as a
+   * percent string or number (e.g. "7.8" or 7.8 — without the "%"). When
+   * provided AND meaningfully different from `value`, this renders next to
+   * the Target MDE so reviewers can see what effect size the saved N is
+   * actually powered to detect. Pass null/undefined for experiments where
+   * achievable equals target by construction (e.g. user picked the
+   * recommended sample size, or the experiment isn't preassigned).
+   */
+  achievable?: string | number | null;
+  size?: '1' | '2' | '3';
 };
 
 function normaliseMdeValue(v: string | number | null | undefined): number | null {
-	if (v === null || v === undefined) return null;
-	const n = typeof v === "number" ? v : Number(v);
-	return Number.isFinite(n) ? n : null;
+  if (v === null || v === undefined) return null;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
 }
 
-export function MdeBadge({ value, achievable, size = "2" }: MdeBadgeProps) {
-	const displayValue =
-		value === null || value === undefined ? "unknown" : String(value);
+export function MdeBadge({ value, achievable, size = '2' }: MdeBadgeProps) {
+  const displayValue = value === null || value === undefined ? 'unknown' : String(value);
 
-	// Only render the achievable column when (a) the caller supplied one and
-	// (b) it differs from the target by more than a hair. The recommended-size
-	// path produces achievable == target by construction, and showing
-	// "Target: 10% | Achievable: 10%" would just be noise.
-	const targetNum = normaliseMdeValue(value);
-	const achievableNum = normaliseMdeValue(achievable);
-	const showAchievable =
-		achievableNum != null &&
-		(targetNum == null || Math.abs(achievableNum - targetNum) > 0.01);
+  // Only render the achievable column when (a) the caller supplied one and
+  // (b) it differs from the target by more than a hair. The recommended-size
+  // path produces achievable == target by construction, and showing
+  // "Target: 10% | Achievable: 10%" would just be noise.
+  const targetNum = normaliseMdeValue(value);
+  const achievableNum = normaliseMdeValue(achievable);
+  const showAchievable = achievableNum != null && (targetNum == null || Math.abs(achievableNum - targetNum) > 0.01);
 
-	// When showing Achievable MDE, stack it BELOW Target MDE rather than
-	// inline. The Summary page renders this badge in a narrow column next to
-	// the metric name, and an inline Target | Achievable layout overflows and
-	// causes the metric name to wrap one character per line.
-	return (
-		<Badge size={size}>
-			<Flex direction="column" gap="1" align="start">
-				<Flex gap="2" align="center">
-					<Heading size={size}>Target MDE:</Heading>
-					<Text>{displayValue}%</Text>
-					<RadixTooltip content="The Target Minimum Detectable Effect — the effect size the experiment is designed to detect, given its confidence and power.">
-						<InfoCircledIcon />
-					</RadixTooltip>
-				</Flex>
-				{showAchievable && (
-					// Blue is also the dominant accent for Target MDE elsewhere
-					// (saved-experiment Analysis bar Badge), so coloring just the
-					// Achievable text + heading blue keeps the two MDEs visually
-					// linked while still distinguishing the achievable value from
-					// the target one on the same badge.
-					<Flex gap="2" align="center">
-						<Heading size={size} color="blue">
-							Achievable MDE:
-						</Heading>
-						<Text color="blue" weight="bold">
-							{achievableNum.toFixed(2)}%
-						</Text>
-						<RadixTooltip content="The MDE the experiment is actually powered to detect at its committed sample size. Differs from Target MDE when the user picked a sample size other than the minimum required.">
-							<InfoCircledIcon />
-						</RadixTooltip>
-					</Flex>
-				)}
-			</Flex>
-		</Badge>
-	);
+  // When showing Achievable MDE, stack it BELOW Target MDE rather than
+  // inline. The Summary page renders this badge in a narrow column next to
+  // the metric name, and an inline Target | Achievable layout overflows and
+  // causes the metric name to wrap one character per line.
+  return (
+    <Badge size={size}>
+      <Flex direction="column" gap="1" align="start">
+        <Flex gap="2" align="center">
+          <Heading size={size}>Target MDE:</Heading>
+          <Text>{displayValue}%</Text>
+          <RadixTooltip content="The Target Minimum Detectable Effect — the effect size the experiment is designed to detect, given its confidence and power.">
+            <InfoCircledIcon />
+          </RadixTooltip>
+        </Flex>
+        {showAchievable && (
+          // Blue is also the dominant accent for Target MDE elsewhere
+          // (saved-experiment Analysis bar Badge), so coloring just the
+          // Achievable text + heading blue keeps the two MDEs visually
+          // linked while still distinguishing the achievable value from
+          // the target one on the same badge.
+          <Flex gap="2" align="center">
+            <Heading size={size} color="blue">
+              Achievable MDE:
+            </Heading>
+            <Text color="blue" weight="bold">
+              {achievableNum.toFixed(2)}%
+            </Text>
+            <RadixTooltip content="The MDE the experiment is actually powered to detect at its committed sample size. Differs from Target MDE when the user picked a sample size other than the minimum required.">
+              <InfoCircledIcon />
+            </RadixTooltip>
+          </Flex>
+        )}
+      </Flex>
+    </Badge>
+  );
 }
 
 export default MdeBadge;

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -11,22 +11,71 @@ import {
 
 type MdeBadgeProps = {
 	value?: string | number | null;
+	/**
+	 * Achievable MDE for the experiment's committed sample size, as a
+	 * percent string or number (e.g. "7.8" or 7.8 — without the "%"). When
+	 * provided AND meaningfully different from `value`, this renders next to
+	 * the Target MDE so reviewers can see what effect size the saved N is
+	 * actually powered to detect. Pass null/undefined for experiments where
+	 * achievable equals target by construction (e.g. user picked the
+	 * recommended sample size, or the experiment isn't preassigned).
+	 */
+	achievable?: string | number | null;
 	size?: "1" | "2" | "3";
 };
 
-export function MdeBadge({ value, size = "2" }: MdeBadgeProps) {
+function normaliseMdeValue(v: string | number | null | undefined): number | null {
+	if (v === null || v === undefined) return null;
+	const n = typeof v === "number" ? v : Number(v);
+	return Number.isFinite(n) ? n : null;
+}
+
+export function MdeBadge({ value, achievable, size = "2" }: MdeBadgeProps) {
 	const displayValue =
 		value === null || value === undefined ? "unknown" : String(value);
+
+	// Only render the achievable column when (a) the caller supplied one and
+	// (b) it differs from the target by more than a hair. The recommended-size
+	// path produces achievable == target by construction, and showing
+	// "Target: 10% | Achievable: 10%" would just be noise.
+	const targetNum = normaliseMdeValue(value);
+	const achievableNum = normaliseMdeValue(achievable);
+	const showAchievable =
+		achievableNum != null &&
+		(targetNum == null || Math.abs(achievableNum - targetNum) > 0.01);
+
+	// When showing Achievable MDE, stack it BELOW Target MDE rather than
+	// inline. The Summary page renders this badge in a narrow column next to
+	// the metric name, and an inline Target | Achievable layout overflows and
+	// causes the metric name to wrap one character per line.
 	return (
 		<Badge size={size}>
-			<Flex gap="4" align="center">
-				<Heading size={size}>Target MDE:</Heading>
+			<Flex direction="column" gap="1" align="start">
 				<Flex gap="2" align="center">
+					<Heading size={size}>Target MDE:</Heading>
 					<Text>{displayValue}%</Text>
 					<RadixTooltip content="The Target Minimum Detectable Effect — the effect size the experiment is designed to detect, given its confidence and power.">
 						<InfoCircledIcon />
 					</RadixTooltip>
 				</Flex>
+				{showAchievable && (
+					// Blue is also the dominant accent for Target MDE elsewhere
+					// (saved-experiment Analysis bar Badge), so coloring just the
+					// Achievable text + heading blue keeps the two MDEs visually
+					// linked while still distinguishing the achievable value from
+					// the target one on the same badge.
+					<Flex gap="2" align="center">
+						<Heading size={size} color="blue">
+							Achievable MDE:
+						</Heading>
+						<Text color="blue" weight="bold">
+							{achievableNum.toFixed(2)}%
+						</Text>
+						<RadixTooltip content="The MDE the experiment is actually powered to detect at its committed sample size. Differs from Target MDE when the user picked a sample size other than the minimum required.">
+							<InfoCircledIcon />
+						</RadixTooltip>
+					</Flex>
+				)}
 			</Flex>
 		</Badge>
 	);

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -1,28 +1,35 @@
-'use client';
+"use client";
 
-import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { Badge, Flex, Heading, Text, Tooltip as RadixTooltip } from '@radix-ui/themes';
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import {
+	Badge,
+	Flex,
+	Heading,
+	Tooltip as RadixTooltip,
+	Text,
+} from "@radix-ui/themes";
 
 type MdeBadgeProps = {
-  value?: string | number | null;
-  size?: '1' | '2' | '3';
+	value?: string | number | null;
+	size?: "1" | "2" | "3";
 };
 
-export function MdeBadge({ value, size = '2' }: MdeBadgeProps) {
-  const displayValue = value === null || value === undefined ? 'unknown' : String(value);
-  return (
-    <Badge size={size}>
-      <Flex gap="4" align="center">
-        <Heading size={size}>MME:</Heading>
-        <Flex gap="2" align="center">
-          <Text>{displayValue}%</Text>
-          <RadixTooltip content="This metric's minimum meaningful effect as defined in the experiment's design that meets the confidence and power requirements.">
-            <InfoCircledIcon />
-          </RadixTooltip>
-        </Flex>
-      </Flex>
-    </Badge>
-  );
+export function MdeBadge({ value, size = "2" }: MdeBadgeProps) {
+	const displayValue =
+		value === null || value === undefined ? "unknown" : String(value);
+	return (
+		<Badge size={size}>
+			<Flex gap="4" align="center">
+				<Heading size={size}>Target MDE:</Heading>
+				<Flex gap="2" align="center">
+					<Text>{displayValue}%</Text>
+					<RadixTooltip content="The Target Minimum Detectable Effect — the effect size the experiment is designed to detect, given its confidence and power.">
+						<InfoCircledIcon />
+					</RadixTooltip>
+				</Flex>
+			</Flex>
+		</Badge>
+	);
 }
 
 export default MdeBadge;

--- a/src/components/features/experiments/power-and-balance-dialog.tsx
+++ b/src/components/features/experiments/power-and-balance-dialog.tsx
@@ -11,9 +11,20 @@ interface PowerAndBalanceDialogProps {
   power: number;
   desiredN?: number;
   assignSummary: AssignSummary | null | undefined;
+  /** Design effect (DEFF) from the power analysis — cluster experiments only. */
+  designEffect?: number | null;
+  /** Total clusters needed across all arms — cluster experiments only. */
+  numClustersTotal?: number | null;
 }
 
-export function PowerAndBalanceDialog({ confidence, power, desiredN, assignSummary }: PowerAndBalanceDialogProps) {
+export function PowerAndBalanceDialog({
+  confidence,
+  power,
+  desiredN,
+  assignSummary,
+  designEffect,
+  numClustersTotal,
+}: PowerAndBalanceDialogProps) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -33,6 +44,14 @@ export function PowerAndBalanceDialog({ confidence, power, desiredN, assignSumma
               desiredN={desiredN}
               assignSummary={assignSummary}
               showTitle={false}
+              // Hide the Desired Sample Size row on the saved experiment view:
+              // for preassigned experiments, "Desired" equals "Actual" by
+              // construction, so the row just duplicates information. Desired
+              // is still shown on the create-flow Summary page where the
+              // distinction is meaningful (the user is deciding).
+              showDesiredSampleSize={false}
+              designEffect={designEffect}
+              numClustersTotal={numClustersTotal}
             />
           </Box>
           <Flex gap="3" justify="end">

--- a/src/components/features/experiments/sections/experiment-description-section.tsx
+++ b/src/components/features/experiments/sections/experiment-description-section.tsx
@@ -1,128 +1,106 @@
-"use client";
+'use client';
 
-import { useListOrganizationWebhooks } from "@/api/admin";
-import { CreateExperimentResponse } from "@/api/methods.schemas";
-import { ExperimentTypeOptions } from "@/app/experiments/create/experiment-form/experiment-form-helpers";
-import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
-import { SectionCard } from "@/components/ui/cards/section-card";
-import { ReadMoreText } from "@/components/ui/read-more-text";
-import { XSpinner } from "@/components/ui/x-spinner";
-import { useCurrentOrganization } from "@/providers/organization-provider";
-import { formatIsoDateLocal } from "@/services/date-utils";
-import { Pencil2Icon } from "@radix-ui/react-icons";
-import { Button, DataList, Flex, Text } from "@radix-ui/themes";
-import NextLink from "next/link";
+import { useListOrganizationWebhooks } from '@/api/admin';
+import { CreateExperimentResponse } from '@/api/methods.schemas';
+import { ExperimentTypeOptions } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import { isClusterDesign } from '@/components/features/experiments/cluster-detection';
+import { SectionCard } from '@/components/ui/cards/section-card';
+import { ReadMoreText } from '@/components/ui/read-more-text';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { useCurrentOrganization } from '@/providers/organization-provider';
+import { formatIsoDateLocal } from '@/services/date-utils';
+import { Pencil2Icon } from '@radix-ui/react-icons';
+import { Button, DataList, Flex, Text } from '@radix-ui/themes';
+import NextLink from 'next/link';
 
 interface ExperimentDescriptionSectionProps {
-	response: CreateExperimentResponse;
-	onEdit?: () => void;
+  response: CreateExperimentResponse;
+  onEdit?: () => void;
 }
 
-export function ExperimentDescriptionSection({
-	response,
-	onEdit,
-}: ExperimentDescriptionSectionProps) {
-	const designSpec = response.design_spec;
-	const webhookIds = response.webhooks ?? [];
-	const org = useCurrentOrganization();
-	const organizationId = org?.current.id ?? "";
-	const { data: webhooksData, isLoading: loadingWebhooks } =
-		useListOrganizationWebhooks(organizationId, {
-			swr: { enabled: !!organizationId },
-		});
-	const selectedWebhooks =
-		webhooksData?.items?.filter((webhook) => webhookIds.includes(webhook.id)) ??
-		[];
-	// Cluster experiments are stored as freq_preassigned on the BE (the FE-only
-	// "freq_cluster_preassigned" type is translated at submit time). Show the
-	// cluster-flavoured title when this is a cluster experiment so the user
-	// sees what they actually picked on the Type screen.
-	const isCluster = isClusterDesign(
-		designSpec,
-		(response as { power_analyses?: unknown }).power_analyses,
-	);
-	const experimentTypeTitle = isCluster
-		? "Cluster Preassigned A/B Testing"
-		: (ExperimentTypeOptions.find((v) => v.value == designSpec.experiment_type)
-				?.title ?? designSpec.experiment_type);
-	return (
-		<SectionCard
-			title="Experiment Description"
-			headerRight={
-				onEdit ? (
-					<Button size="1" onClick={onEdit}>
-						<Pencil2Icon />
-						Edit
-					</Button>
-				) : undefined
-			}
-		>
-			<DataList.Root>
-				<DataList.Item>
-					<DataList.Label>Experiment Type</DataList.Label>
-					<DataList.Value>{experimentTypeTitle}</DataList.Value>
-				</DataList.Item>
-				<DataList.Item>
-					<DataList.Label>Name</DataList.Label>
-					<DataList.Value>{designSpec.experiment_name}</DataList.Value>
-				</DataList.Item>
-				<DataList.Item>
-					<DataList.Label>Hypothesis</DataList.Label>
-					<DataList.Value>
-						<ReadMoreText text={designSpec.description || "-"} />
-					</DataList.Value>
-				</DataList.Item>
-				<DataList.Item>
-					<DataList.Label>Design Document</DataList.Label>
-					<DataList.Value>
-						{designSpec.design_url ? (
-							<NextLink
-								href={designSpec.design_url}
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{designSpec.design_url}
-							</NextLink>
-						) : (
-							"-"
-						)}
-					</DataList.Value>
-				</DataList.Item>
-				<DataList.Item>
-					<DataList.Label>Start Date</DataList.Label>
-					<DataList.Value>
-						{designSpec.start_date
-							? formatIsoDateLocal(designSpec.start_date)
-							: "-"}
-					</DataList.Value>
-				</DataList.Item>
-				<DataList.Item>
-					<DataList.Label>End Date</DataList.Label>
-					<DataList.Value>
-						{designSpec.end_date
-							? formatIsoDateLocal(designSpec.end_date)
-							: "-"}
-					</DataList.Value>
-				</DataList.Item>
-				{webhookIds.length ? (
-					<DataList.Item>
-						<DataList.Label>Webhooks</DataList.Label>
-						<DataList.Value>
-							<Flex direction="column" gap="1">
-								{loadingWebhooks && <XSpinner />}
-								{selectedWebhooks.map((webhook) => (
-									<Flex key={webhook.id} direction="column" gap="1">
-										<Text weight="bold">{webhook.name}</Text>
-										<Text size="2" color="gray">
-											{webhook.url}
-										</Text>
-									</Flex>
-								))}
-							</Flex>
-						</DataList.Value>
-					</DataList.Item>
-				) : null}
-			</DataList.Root>
-		</SectionCard>
-	);
+export function ExperimentDescriptionSection({ response, onEdit }: ExperimentDescriptionSectionProps) {
+  const designSpec = response.design_spec;
+  const webhookIds = response.webhooks ?? [];
+  const org = useCurrentOrganization();
+  const organizationId = org?.current.id ?? '';
+  const { data: webhooksData, isLoading: loadingWebhooks } = useListOrganizationWebhooks(organizationId, {
+    swr: { enabled: !!organizationId },
+  });
+  const selectedWebhooks = webhooksData?.items?.filter((webhook) => webhookIds.includes(webhook.id)) ?? [];
+  // Cluster experiments are stored as freq_preassigned on the BE (the FE-only
+  // "freq_cluster_preassigned" type is translated at submit time). Show the
+  // cluster-flavoured title when this is a cluster experiment so the user
+  // sees what they actually picked on the Type screen.
+  const isCluster = isClusterDesign(designSpec, (response as { power_analyses?: unknown }).power_analyses);
+  const experimentTypeTitle = isCluster
+    ? 'Cluster Preassigned A/B Testing'
+    : (ExperimentTypeOptions.find((v) => v.value == designSpec.experiment_type)?.title ?? designSpec.experiment_type);
+  return (
+    <SectionCard
+      title="Experiment Description"
+      headerRight={
+        onEdit ? (
+          <Button size="1" onClick={onEdit}>
+            <Pencil2Icon />
+            Edit
+          </Button>
+        ) : undefined
+      }
+    >
+      <DataList.Root>
+        <DataList.Item>
+          <DataList.Label>Experiment Type</DataList.Label>
+          <DataList.Value>{experimentTypeTitle}</DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Name</DataList.Label>
+          <DataList.Value>{designSpec.experiment_name}</DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Hypothesis</DataList.Label>
+          <DataList.Value>
+            <ReadMoreText text={designSpec.description || '-'} />
+          </DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Design Document</DataList.Label>
+          <DataList.Value>
+            {designSpec.design_url ? (
+              <NextLink href={designSpec.design_url} target="_blank" rel="noopener noreferrer">
+                {designSpec.design_url}
+              </NextLink>
+            ) : (
+              '-'
+            )}
+          </DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Start Date</DataList.Label>
+          <DataList.Value>{designSpec.start_date ? formatIsoDateLocal(designSpec.start_date) : '-'}</DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>End Date</DataList.Label>
+          <DataList.Value>{designSpec.end_date ? formatIsoDateLocal(designSpec.end_date) : '-'}</DataList.Value>
+        </DataList.Item>
+        {webhookIds.length ? (
+          <DataList.Item>
+            <DataList.Label>Webhooks</DataList.Label>
+            <DataList.Value>
+              <Flex direction="column" gap="1">
+                {loadingWebhooks && <XSpinner />}
+                {selectedWebhooks.map((webhook) => (
+                  <Flex key={webhook.id} direction="column" gap="1">
+                    <Text weight="bold">{webhook.name}</Text>
+                    <Text size="2" color="gray">
+                      {webhook.url}
+                    </Text>
+                  </Flex>
+                ))}
+              </Flex>
+            </DataList.Value>
+          </DataList.Item>
+        ) : null}
+      </DataList.Root>
+    </SectionCard>
+  );
 }

--- a/src/components/features/experiments/sections/experiment-description-section.tsx
+++ b/src/components/features/experiments/sections/experiment-description-section.tsx
@@ -1,99 +1,128 @@
-'use client';
+"use client";
 
-import { Button, DataList, Flex, Text } from '@radix-ui/themes';
-import { Pencil2Icon } from '@radix-ui/react-icons';
-import NextLink from 'next/link';
-import { CreateExperimentResponse } from '@/api/methods.schemas';
-import { SectionCard } from '@/components/ui/cards/section-card';
-import { ReadMoreText } from '@/components/ui/read-more-text';
-import { formatIsoDateLocal } from '@/services/date-utils';
-import { useListOrganizationWebhooks } from '@/api/admin';
-import { useCurrentOrganization } from '@/providers/organization-provider';
-import { ExperimentTypeOptions } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
-import { XSpinner } from '@/components/ui/x-spinner';
+import { useListOrganizationWebhooks } from "@/api/admin";
+import { CreateExperimentResponse } from "@/api/methods.schemas";
+import { ExperimentTypeOptions } from "@/app/experiments/create/experiment-form/experiment-form-helpers";
+import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
+import { SectionCard } from "@/components/ui/cards/section-card";
+import { ReadMoreText } from "@/components/ui/read-more-text";
+import { XSpinner } from "@/components/ui/x-spinner";
+import { useCurrentOrganization } from "@/providers/organization-provider";
+import { formatIsoDateLocal } from "@/services/date-utils";
+import { Pencil2Icon } from "@radix-ui/react-icons";
+import { Button, DataList, Flex, Text } from "@radix-ui/themes";
+import NextLink from "next/link";
 
 interface ExperimentDescriptionSectionProps {
-  response: CreateExperimentResponse;
-  onEdit?: () => void;
+	response: CreateExperimentResponse;
+	onEdit?: () => void;
 }
 
-export function ExperimentDescriptionSection({ response, onEdit }: ExperimentDescriptionSectionProps) {
-  const designSpec = response.design_spec;
-  const webhookIds = response.webhooks ?? [];
-  const org = useCurrentOrganization();
-  const organizationId = org?.current.id ?? '';
-  const { data: webhooksData, isLoading: loadingWebhooks } = useListOrganizationWebhooks(organizationId, {
-    swr: { enabled: !!organizationId },
-  });
-  const selectedWebhooks = webhooksData?.items?.filter((webhook) => webhookIds.includes(webhook.id)) ?? [];
-  const experimentTypeTitle =
-    ExperimentTypeOptions.find((v) => v.value == designSpec.experiment_type)?.title ?? designSpec.experiment_type;
-  return (
-    <SectionCard
-      title="Experiment Description"
-      headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
-        ) : undefined
-      }
-    >
-      <DataList.Root>
-        <DataList.Item>
-          <DataList.Label>Experiment Type</DataList.Label>
-          <DataList.Value>{experimentTypeTitle}</DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Name</DataList.Label>
-          <DataList.Value>{designSpec.experiment_name}</DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Hypothesis</DataList.Label>
-          <DataList.Value>
-            <ReadMoreText text={designSpec.description || '-'} />
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Design Document</DataList.Label>
-          <DataList.Value>
-            {designSpec.design_url ? (
-              <NextLink href={designSpec.design_url} target="_blank" rel="noopener noreferrer">
-                {designSpec.design_url}
-              </NextLink>
-            ) : (
-              '-'
-            )}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Start Date</DataList.Label>
-          <DataList.Value>{designSpec.start_date ? formatIsoDateLocal(designSpec.start_date) : '-'}</DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>End Date</DataList.Label>
-          <DataList.Value>{designSpec.end_date ? formatIsoDateLocal(designSpec.end_date) : '-'}</DataList.Value>
-        </DataList.Item>
-        {webhookIds.length ? (
-          <DataList.Item>
-            <DataList.Label>Webhooks</DataList.Label>
-            <DataList.Value>
-              <Flex direction="column" gap="1">
-                {loadingWebhooks && <XSpinner />}
-                {selectedWebhooks.map((webhook) => (
-                  <Flex key={webhook.id} direction="column" gap="1">
-                    <Text weight="bold">{webhook.name}</Text>
-                    <Text size="2" color="gray">
-                      {webhook.url}
-                    </Text>
-                  </Flex>
-                ))}
-              </Flex>
-            </DataList.Value>
-          </DataList.Item>
-        ) : null}
-      </DataList.Root>
-    </SectionCard>
-  );
+export function ExperimentDescriptionSection({
+	response,
+	onEdit,
+}: ExperimentDescriptionSectionProps) {
+	const designSpec = response.design_spec;
+	const webhookIds = response.webhooks ?? [];
+	const org = useCurrentOrganization();
+	const organizationId = org?.current.id ?? "";
+	const { data: webhooksData, isLoading: loadingWebhooks } =
+		useListOrganizationWebhooks(organizationId, {
+			swr: { enabled: !!organizationId },
+		});
+	const selectedWebhooks =
+		webhooksData?.items?.filter((webhook) => webhookIds.includes(webhook.id)) ??
+		[];
+	// Cluster experiments are stored as freq_preassigned on the BE (the FE-only
+	// "freq_cluster_preassigned" type is translated at submit time). Show the
+	// cluster-flavoured title when this is a cluster experiment so the user
+	// sees what they actually picked on the Type screen.
+	const isCluster = isClusterDesign(
+		designSpec,
+		(response as { power_analyses?: unknown }).power_analyses,
+	);
+	const experimentTypeTitle = isCluster
+		? "Cluster Preassigned A/B Testing"
+		: (ExperimentTypeOptions.find((v) => v.value == designSpec.experiment_type)
+				?.title ?? designSpec.experiment_type);
+	return (
+		<SectionCard
+			title="Experiment Description"
+			headerRight={
+				onEdit ? (
+					<Button size="1" onClick={onEdit}>
+						<Pencil2Icon />
+						Edit
+					</Button>
+				) : undefined
+			}
+		>
+			<DataList.Root>
+				<DataList.Item>
+					<DataList.Label>Experiment Type</DataList.Label>
+					<DataList.Value>{experimentTypeTitle}</DataList.Value>
+				</DataList.Item>
+				<DataList.Item>
+					<DataList.Label>Name</DataList.Label>
+					<DataList.Value>{designSpec.experiment_name}</DataList.Value>
+				</DataList.Item>
+				<DataList.Item>
+					<DataList.Label>Hypothesis</DataList.Label>
+					<DataList.Value>
+						<ReadMoreText text={designSpec.description || "-"} />
+					</DataList.Value>
+				</DataList.Item>
+				<DataList.Item>
+					<DataList.Label>Design Document</DataList.Label>
+					<DataList.Value>
+						{designSpec.design_url ? (
+							<NextLink
+								href={designSpec.design_url}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{designSpec.design_url}
+							</NextLink>
+						) : (
+							"-"
+						)}
+					</DataList.Value>
+				</DataList.Item>
+				<DataList.Item>
+					<DataList.Label>Start Date</DataList.Label>
+					<DataList.Value>
+						{designSpec.start_date
+							? formatIsoDateLocal(designSpec.start_date)
+							: "-"}
+					</DataList.Value>
+				</DataList.Item>
+				<DataList.Item>
+					<DataList.Label>End Date</DataList.Label>
+					<DataList.Value>
+						{designSpec.end_date
+							? formatIsoDateLocal(designSpec.end_date)
+							: "-"}
+					</DataList.Value>
+				</DataList.Item>
+				{webhookIds.length ? (
+					<DataList.Item>
+						<DataList.Label>Webhooks</DataList.Label>
+						<DataList.Value>
+							<Flex direction="column" gap="1">
+								{loadingWebhooks && <XSpinner />}
+								{selectedWebhooks.map((webhook) => (
+									<Flex key={webhook.id} direction="column" gap="1">
+										<Text weight="bold">{webhook.name}</Text>
+										<Text size="2" color="gray">
+											{webhook.url}
+										</Text>
+									</Flex>
+								))}
+							</Flex>
+						</DataList.Value>
+					</DataList.Item>
+				) : null}
+			</DataList.Root>
+		</SectionCard>
+	);
 }

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,175 +1,153 @@
-"use client";
+'use client';
 
-import { DataType } from "@/api/methods.schemas";
-import { MdeBadge } from "@/components/features/experiments/mde-badge";
-import { SectionCard } from "@/components/ui/cards/section-card";
-import { DataTypeBadge } from "@/components/ui/data-type-badge";
-import { Pencil2Icon } from "@radix-ui/react-icons";
-import { Button, DataList, Flex, Text } from "@radix-ui/themes";
+import { DataType } from '@/api/methods.schemas';
+import { MdeBadge } from '@/components/features/experiments/mde-badge';
+import { SectionCard } from '@/components/ui/cards/section-card';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import { Pencil2Icon } from '@radix-ui/react-icons';
+import { Button, DataList, Flex, Text } from '@radix-ui/themes';
 
 export interface MetricDisplay {
-	field_name: string;
-	data_type: DataType;
-	mde: string | number;
-	/**
-	 * Optional achievable MDE for the experiment's committed sample size, as a
-	 * percent number (e.g. 7.8 for 7.8%). Render alongside the target MDE so
-	 * reviewers can see what effect the saved N is actually powered to detect.
-	 * Caller is responsible for omitting it when achievable == target (e.g. the
-	 * user picked the recommended sample size).
-	 */
-	achievable?: string | number | null;
+  field_name: string;
+  data_type: DataType;
+  mde: string | number;
+  /**
+   * Optional achievable MDE for the experiment's committed sample size, as a
+   * percent number (e.g. 7.8 for 7.8%). Render alongside the target MDE so
+   * reviewers can see what effect the saved N is actually powered to detect.
+   * Caller is responsible for omitting it when achievable == target (e.g. the
+   * user picked the recommended sample size).
+   */
+  achievable?: string | number | null;
 }
 
 export interface MetricsSectionProps {
-	metrics?: {
-		primary?: MetricDisplay;
-		secondary?: MetricDisplay[];
-	};
-	strata?: string[];
-	onEdit?: () => void;
-	/** Cluster randomization fields shown for the cluster-preassigned type (issue #217). */
-	cluster?: {
-		field_name: string;
-		icc: string | number;
-		cv: string | number;
-		avg_cluster_size: string | number;
-	};
+  metrics?: {
+    primary?: MetricDisplay;
+    secondary?: MetricDisplay[];
+  };
+  strata?: string[];
+  onEdit?: () => void;
+  /** Cluster randomization fields shown for the cluster-preassigned type (issue #217). */
+  cluster?: {
+    field_name: string;
+    icc: string | number;
+    cv: string | number;
+    avg_cluster_size: string | number;
+  };
 }
 
 const formatNum = (val: string | number) => {
-	const n = typeof val === "number" ? val : Number(val);
-	if (Number.isNaN(n)) return String(val);
-	return String(n);
+  const n = typeof val === 'number' ? val : Number(val);
+  if (Number.isNaN(n)) return String(val);
+  return String(n);
 };
 
-export function MetricsSection({
-	metrics,
-	strata,
-	onEdit,
-	cluster,
-}: MetricsSectionProps) {
-	const cvNum = cluster
-		? typeof cluster.cv === "number"
-			? cluster.cv
-			: Number(cluster.cv)
-		: NaN;
-	const highVariability = !Number.isNaN(cvNum) && cvNum > 0.5;
-	return (
-		<SectionCard
-			title="Metrics"
-			headerRight={
-				onEdit ? (
-					<Button size="1" onClick={onEdit}>
-						<Pencil2Icon />
-						Edit
-					</Button>
-				) : undefined
-			}
-		>
-			<DataList.Root>
-				<DataList.Item>
-					<DataList.Label>Primary Metric</DataList.Label>
-					<DataList.Value>
-						{metrics?.primary ? (
-							<Flex direction="row" gap="2" justify={"between"} width={"100%"}>
-								<Text>{metrics.primary.field_name}</Text>
-								<Flex direction={"row"} gap={"3"}>
-									<DataTypeBadge type={metrics.primary.data_type} />
-									<MdeBadge
-									value={metrics.primary.mde}
-									achievable={metrics.primary.achievable}
-									size="1"
-								/>
-								</Flex>
-							</Flex>
-						) : (
-							<Text>-</Text>
-						)}
-					</DataList.Value>
-				</DataList.Item>
-				<DataList.Item>
-					<DataList.Label>Secondary Metrics</DataList.Label>
-					<DataList.Value>
-						{(metrics?.secondary ?? []).length > 0 ? (
-							<Flex direction="column" gap="2" width={"100%"}>
-								{(metrics?.secondary ?? []).map((metric) => (
-									<Flex
-										key={metric.field_name}
-										gap="2"
-										justify={"between"}
-										width={"100%"}
-									>
-										<Text>{metric.field_name}</Text>
-										<Flex direction={"row"} gap={"3"}>
-											<DataTypeBadge type={metric.data_type} />
-											<MdeBadge
-												value={metric.mde}
-												achievable={metric.achievable}
-												size="1"
-											/>
-										</Flex>
-									</Flex>
-								))}
-							</Flex>
-						) : (
-							<Text>None</Text>
-						)}
-					</DataList.Value>
-				</DataList.Item>
-				{cluster ? (
-					<>
-						<DataList.Item>
-							<DataList.Label>Cluster ID field</DataList.Label>
-							<DataList.Value>
-								<Text>{cluster.field_name}</Text>
-							</DataList.Value>
-						</DataList.Item>
-						<DataList.Item>
-							<DataList.Label>ICC</DataList.Label>
-							<DataList.Value>
-								<Text>{formatNum(cluster.icc)}</Text>
-							</DataList.Value>
-						</DataList.Item>
-						<DataList.Item>
-							<DataList.Label>CV</DataList.Label>
-							<DataList.Value>
-								<Flex gap="2" align="center">
-									<Text>{formatNum(cluster.cv)}</Text>
-									{highVariability && (
-										<Text size="1" color="amber">
-											⚠ high variability
-										</Text>
-									)}
-								</Flex>
-							</DataList.Value>
-						</DataList.Item>
-						<DataList.Item>
-							<DataList.Label>Avg cluster size</DataList.Label>
-							<DataList.Value>
-								<Text>{formatNum(cluster.avg_cluster_size)}</Text>
-							</DataList.Value>
-						</DataList.Item>
-					</>
-				) : (
-					<DataList.Item>
-						<DataList.Label>Strata</DataList.Label>
-						<DataList.Value>
-							{strata && strata.length > 0 ? (
-								<Flex gap="2" wrap="wrap">
-									{strata.map((stratum) => (
-										<Text key={stratum} size="2" color="gray">
-											{stratum}
-										</Text>
-									))}
-								</Flex>
-							) : (
-								<Text>None</Text>
-							)}
-						</DataList.Value>
-					</DataList.Item>
-				)}
-			</DataList.Root>
-		</SectionCard>
-	);
+export function MetricsSection({ metrics, strata, onEdit, cluster }: MetricsSectionProps) {
+  const cvNum = cluster ? (typeof cluster.cv === 'number' ? cluster.cv : Number(cluster.cv)) : NaN;
+  const highVariability = !Number.isNaN(cvNum) && cvNum > 0.5;
+  return (
+    <SectionCard
+      title="Metrics"
+      headerRight={
+        onEdit ? (
+          <Button size="1" onClick={onEdit}>
+            <Pencil2Icon />
+            Edit
+          </Button>
+        ) : undefined
+      }
+    >
+      <DataList.Root>
+        <DataList.Item>
+          <DataList.Label>Primary Metric</DataList.Label>
+          <DataList.Value>
+            {metrics?.primary ? (
+              <Flex direction="row" gap="2" justify={'between'} width={'100%'}>
+                <Text>{metrics.primary.field_name}</Text>
+                <Flex direction={'row'} gap={'3'}>
+                  <DataTypeBadge type={metrics.primary.data_type} />
+                  <MdeBadge value={metrics.primary.mde} achievable={metrics.primary.achievable} size="1" />
+                </Flex>
+              </Flex>
+            ) : (
+              <Text>-</Text>
+            )}
+          </DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Secondary Metrics</DataList.Label>
+          <DataList.Value>
+            {(metrics?.secondary ?? []).length > 0 ? (
+              <Flex direction="column" gap="2" width={'100%'}>
+                {(metrics?.secondary ?? []).map((metric) => (
+                  <Flex key={metric.field_name} gap="2" justify={'between'} width={'100%'}>
+                    <Text>{metric.field_name}</Text>
+                    <Flex direction={'row'} gap={'3'}>
+                      <DataTypeBadge type={metric.data_type} />
+                      <MdeBadge value={metric.mde} achievable={metric.achievable} size="1" />
+                    </Flex>
+                  </Flex>
+                ))}
+              </Flex>
+            ) : (
+              <Text>None</Text>
+            )}
+          </DataList.Value>
+        </DataList.Item>
+        {cluster ? (
+          <>
+            <DataList.Item>
+              <DataList.Label>Cluster ID field</DataList.Label>
+              <DataList.Value>
+                <Text>{cluster.field_name}</Text>
+              </DataList.Value>
+            </DataList.Item>
+            <DataList.Item>
+              <DataList.Label>ICC</DataList.Label>
+              <DataList.Value>
+                <Text>{formatNum(cluster.icc)}</Text>
+              </DataList.Value>
+            </DataList.Item>
+            <DataList.Item>
+              <DataList.Label>CV</DataList.Label>
+              <DataList.Value>
+                <Flex gap="2" align="center">
+                  <Text>{formatNum(cluster.cv)}</Text>
+                  {highVariability && (
+                    <Text size="1" color="amber">
+                      ⚠ high variability
+                    </Text>
+                  )}
+                </Flex>
+              </DataList.Value>
+            </DataList.Item>
+            <DataList.Item>
+              <DataList.Label>Avg cluster size</DataList.Label>
+              <DataList.Value>
+                <Text>{formatNum(cluster.avg_cluster_size)}</Text>
+              </DataList.Value>
+            </DataList.Item>
+          </>
+        ) : (
+          <DataList.Item>
+            <DataList.Label>Strata</DataList.Label>
+            <DataList.Value>
+              {strata && strata.length > 0 ? (
+                <Flex gap="2" wrap="wrap">
+                  {strata.map((stratum) => (
+                    <Text key={stratum} size="2" color="gray">
+                      {stratum}
+                    </Text>
+                  ))}
+                </Flex>
+              ) : (
+                <Text>None</Text>
+              )}
+            </DataList.Value>
+          </DataList.Item>
+        )}
+      </DataList.Root>
+    </SectionCard>
+  );
 }

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -11,6 +11,14 @@ export interface MetricDisplay {
 	field_name: string;
 	data_type: DataType;
 	mde: string | number;
+	/**
+	 * Optional achievable MDE for the experiment's committed sample size, as a
+	 * percent number (e.g. 7.8 for 7.8%). Render alongside the target MDE so
+	 * reviewers can see what effect the saved N is actually powered to detect.
+	 * Caller is responsible for omitting it when achievable == target (e.g. the
+	 * user picked the recommended sample size).
+	 */
+	achievable?: string | number | null;
 }
 
 export interface MetricsSectionProps {
@@ -68,7 +76,11 @@ export function MetricsSection({
 								<Text>{metrics.primary.field_name}</Text>
 								<Flex direction={"row"} gap={"3"}>
 									<DataTypeBadge type={metrics.primary.data_type} />
-									<MdeBadge value={metrics.primary.mde} size="1" />
+									<MdeBadge
+									value={metrics.primary.mde}
+									achievable={metrics.primary.achievable}
+									size="1"
+								/>
 								</Flex>
 							</Flex>
 						) : (
@@ -91,7 +103,11 @@ export function MetricsSection({
 										<Text>{metric.field_name}</Text>
 										<Flex direction={"row"} gap={"3"}>
 											<DataTypeBadge type={metric.data_type} />
-											<MdeBadge value={metric.mde} size="1" />
+											<MdeBadge
+												value={metric.mde}
+												achievable={metric.achievable}
+												size="1"
+											/>
 										</Flex>
 									</Flex>
 								))}

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,94 +1,159 @@
-'use client';
+"use client";
 
-import { Button, DataList, Flex, Text } from '@radix-ui/themes';
-import { Pencil2Icon } from '@radix-ui/react-icons';
-import { DataType } from '@/api/methods.schemas';
-import { SectionCard } from '@/components/ui/cards/section-card';
-import { DataTypeBadge } from '@/components/ui/data-type-badge';
-import { MdeBadge } from '@/components/features/experiments/mde-badge';
+import { DataType } from "@/api/methods.schemas";
+import { MdeBadge } from "@/components/features/experiments/mde-badge";
+import { SectionCard } from "@/components/ui/cards/section-card";
+import { DataTypeBadge } from "@/components/ui/data-type-badge";
+import { Pencil2Icon } from "@radix-ui/react-icons";
+import { Button, DataList, Flex, Text } from "@radix-ui/themes";
 
 export interface MetricDisplay {
-  field_name: string;
-  data_type: DataType;
-  mde: string | number;
+	field_name: string;
+	data_type: DataType;
+	mde: string | number;
 }
 
 export interface MetricsSectionProps {
-  metrics?: {
-    primary?: MetricDisplay;
-    secondary?: MetricDisplay[];
-  };
-  strata?: string[];
-  onEdit?: () => void;
+	metrics?: {
+		primary?: MetricDisplay;
+		secondary?: MetricDisplay[];
+	};
+	strata?: string[];
+	onEdit?: () => void;
+	/** Cluster randomization fields shown for the cluster-preassigned type (issue #217). */
+	cluster?: {
+		field_name: string;
+		icc: string | number;
+		cv: string | number;
+		avg_cluster_size: string | number;
+	};
 }
 
-export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps) {
-  return (
-    <SectionCard
-      title="Metrics"
-      headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
-        ) : undefined
-      }
-    >
-      <DataList.Root>
-        <DataList.Item>
-          <DataList.Label>Primary Metric</DataList.Label>
-          <DataList.Value>
-            {metrics?.primary ? (
-              <Flex direction="row" gap="2" justify={'between'} width={'100%'}>
-                <Text>{metrics.primary.field_name}</Text>
-                <Flex direction={'row'} gap={'3'}>
-                  <DataTypeBadge type={metrics.primary.data_type} />
-                  <MdeBadge value={metrics.primary.mde} size="1" />
-                </Flex>
-              </Flex>
-            ) : (
-              <Text>-</Text>
-            )}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Secondary Metrics</DataList.Label>
-          <DataList.Value>
-            {(metrics?.secondary ?? []).length > 0 ? (
-              <Flex direction="column" gap="2" width={'100%'}>
-                {(metrics?.secondary ?? []).map((metric) => (
-                  <Flex key={metric.field_name} gap="2" justify={'between'} width={'100%'}>
-                    <Text>{metric.field_name}</Text>
-                    <Flex direction={'row'} gap={'3'}>
-                      <DataTypeBadge type={metric.data_type} />
-                      <MdeBadge value={metric.mde} size="1" />
-                    </Flex>
-                  </Flex>
-                ))}
-              </Flex>
-            ) : (
-              <Text>None</Text>
-            )}
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Strata</DataList.Label>
-          <DataList.Value>
-            {strata && strata.length > 0 ? (
-              <Flex gap="2" wrap="wrap">
-                {strata.map((stratum) => (
-                  <Text key={stratum} size="2" color="gray">
-                    {stratum}
-                  </Text>
-                ))}
-              </Flex>
-            ) : (
-              <Text>None</Text>
-            )}
-          </DataList.Value>
-        </DataList.Item>
-      </DataList.Root>
-    </SectionCard>
-  );
+const formatNum = (val: string | number) => {
+	const n = typeof val === "number" ? val : Number(val);
+	if (Number.isNaN(n)) return String(val);
+	return String(n);
+};
+
+export function MetricsSection({
+	metrics,
+	strata,
+	onEdit,
+	cluster,
+}: MetricsSectionProps) {
+	const cvNum = cluster
+		? typeof cluster.cv === "number"
+			? cluster.cv
+			: Number(cluster.cv)
+		: NaN;
+	const highVariability = !Number.isNaN(cvNum) && cvNum > 0.5;
+	return (
+		<SectionCard
+			title="Metrics"
+			headerRight={
+				onEdit ? (
+					<Button size="1" onClick={onEdit}>
+						<Pencil2Icon />
+						Edit
+					</Button>
+				) : undefined
+			}
+		>
+			<DataList.Root>
+				<DataList.Item>
+					<DataList.Label>Primary Metric</DataList.Label>
+					<DataList.Value>
+						{metrics?.primary ? (
+							<Flex direction="row" gap="2" justify={"between"} width={"100%"}>
+								<Text>{metrics.primary.field_name}</Text>
+								<Flex direction={"row"} gap={"3"}>
+									<DataTypeBadge type={metrics.primary.data_type} />
+									<MdeBadge value={metrics.primary.mde} size="1" />
+								</Flex>
+							</Flex>
+						) : (
+							<Text>-</Text>
+						)}
+					</DataList.Value>
+				</DataList.Item>
+				<DataList.Item>
+					<DataList.Label>Secondary Metrics</DataList.Label>
+					<DataList.Value>
+						{(metrics?.secondary ?? []).length > 0 ? (
+							<Flex direction="column" gap="2" width={"100%"}>
+								{(metrics?.secondary ?? []).map((metric) => (
+									<Flex
+										key={metric.field_name}
+										gap="2"
+										justify={"between"}
+										width={"100%"}
+									>
+										<Text>{metric.field_name}</Text>
+										<Flex direction={"row"} gap={"3"}>
+											<DataTypeBadge type={metric.data_type} />
+											<MdeBadge value={metric.mde} size="1" />
+										</Flex>
+									</Flex>
+								))}
+							</Flex>
+						) : (
+							<Text>None</Text>
+						)}
+					</DataList.Value>
+				</DataList.Item>
+				{cluster ? (
+					<>
+						<DataList.Item>
+							<DataList.Label>Cluster ID field</DataList.Label>
+							<DataList.Value>
+								<Text>{cluster.field_name}</Text>
+							</DataList.Value>
+						</DataList.Item>
+						<DataList.Item>
+							<DataList.Label>ICC</DataList.Label>
+							<DataList.Value>
+								<Text>{formatNum(cluster.icc)}</Text>
+							</DataList.Value>
+						</DataList.Item>
+						<DataList.Item>
+							<DataList.Label>CV</DataList.Label>
+							<DataList.Value>
+								<Flex gap="2" align="center">
+									<Text>{formatNum(cluster.cv)}</Text>
+									{highVariability && (
+										<Text size="1" color="amber">
+											⚠ high variability
+										</Text>
+									)}
+								</Flex>
+							</DataList.Value>
+						</DataList.Item>
+						<DataList.Item>
+							<DataList.Label>Avg cluster size</DataList.Label>
+							<DataList.Value>
+								<Text>{formatNum(cluster.avg_cluster_size)}</Text>
+							</DataList.Value>
+						</DataList.Item>
+					</>
+				) : (
+					<DataList.Item>
+						<DataList.Label>Strata</DataList.Label>
+						<DataList.Value>
+							{strata && strata.length > 0 ? (
+								<Flex gap="2" wrap="wrap">
+									{strata.map((stratum) => (
+										<Text key={stratum} size="2" color="gray">
+											{stratum}
+										</Text>
+									))}
+								</Flex>
+							) : (
+								<Text>None</Text>
+							)}
+						</DataList.Value>
+					</DataList.Item>
+				)}
+			</DataList.Root>
+		</SectionCard>
+	);
 }

--- a/src/components/features/experiments/sections/power-balance-section.tsx
+++ b/src/components/features/experiments/sections/power-balance-section.tsx
@@ -1,104 +1,151 @@
-'use client';
+"use client";
 
-import { Button, DataList, Flex } from '@radix-ui/themes';
-import { Pencil2Icon } from '@radix-ui/react-icons';
-import { AssignSummary } from '@/api/methods.schemas';
-import { SectionCard } from '@/components/ui/cards/section-card';
+import { AssignSummary } from "@/api/methods.schemas";
+import { SectionCard } from "@/components/ui/cards/section-card";
+import { Pencil2Icon } from "@radix-ui/react-icons";
+import { Button, DataList, Flex, Text } from "@radix-ui/themes";
 
 export interface PowerBalanceSectionProps {
-  confidence: number;
-  power: number;
-  desiredN?: number;
-  assignSummary: AssignSummary | null | undefined;
-  onEdit?: () => void;
-  showDesiredSampleSize?: boolean;
-  showTitle?: boolean;
+	confidence: number;
+	power: number;
+	desiredN?: number;
+	assignSummary: AssignSummary | null | undefined;
+	onEdit?: () => void;
+	showDesiredSampleSize?: boolean;
+	showTitle?: boolean;
+	/** Design effect (DEFF) from the power analysis — cluster experiments only. */
+	designEffect?: number | null;
+	/** Total clusters needed across all arms — cluster experiments only. */
+	numClustersTotal?: number | null;
 }
 
 export function PowerBalanceSection({
-  confidence,
-  power,
-  desiredN,
-  assignSummary,
-  onEdit,
-  showDesiredSampleSize = true,
-  showTitle = true,
+	confidence,
+	power,
+	desiredN,
+	assignSummary,
+	onEdit,
+	showDesiredSampleSize = true,
+	showTitle = true,
+	designEffect,
+	numClustersTotal,
 }: PowerBalanceSectionProps) {
-  const balanceCheck = assignSummary?.balance_check;
+	const balanceCheck = assignSummary?.balance_check;
 
-  return (
-    <SectionCard
-      title={showTitle ? 'Power & Balance' : undefined}
-      headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
-        ) : undefined
-      }
-    >
-      <Flex gap="4" direction="row" align="start">
-        <Flex flexGrow="1">
-          <DataList.Root>
-            <DataList.Item>
-              <DataList.Label>
-                <b>Power Parameters</b>
-              </DataList.Label>
-            </DataList.Item>
-            <DataList.Item>
-              <DataList.Label>Confidence</DataList.Label>
-              <DataList.Value>{confidence}%</DataList.Value>
-            </DataList.Item>
-            <DataList.Item>
-              <DataList.Label>Power</DataList.Label>
-              <DataList.Value>{power}%</DataList.Value>
-            </DataList.Item>
-            {showDesiredSampleSize && (
-              <DataList.Item>
-                <DataList.Label>Desired Sample Size</DataList.Label>
-                <DataList.Value>{desiredN ?? 'N/A'}</DataList.Value>
-              </DataList.Item>
-            )}
-            <DataList.Item>
-              <DataList.Label>Actual Sample Size</DataList.Label>
-              <DataList.Value>{assignSummary?.sample_size ?? 'N/A'}</DataList.Value>
-            </DataList.Item>
-          </DataList.Root>
-        </Flex>
+	return (
+		<SectionCard
+			title={showTitle ? "Power & Balance" : undefined}
+			headerRight={
+				onEdit ? (
+					<Button size="1" onClick={onEdit}>
+						<Pencil2Icon />
+						Edit
+					</Button>
+				) : undefined
+			}
+		>
+			<Flex gap="4" direction="row" align="start">
+				<Flex flexGrow="1">
+					<DataList.Root>
+						<DataList.Item>
+							<DataList.Label>
+								<b>Power Parameters</b>
+							</DataList.Label>
+						</DataList.Item>
+						<DataList.Item>
+							<DataList.Label>Confidence</DataList.Label>
+							<DataList.Value>{confidence}%</DataList.Value>
+						</DataList.Item>
+						<DataList.Item>
+							<DataList.Label>Power</DataList.Label>
+							<DataList.Value>{power}%</DataList.Value>
+						</DataList.Item>
+						{showDesiredSampleSize && (
+							<DataList.Item>
+								<DataList.Label>Desired Sample Size</DataList.Label>
+								<DataList.Value>
+									{numClustersTotal != null ? (
+										<Flex direction="column">
+											<Text color="green" weight="bold">
+												{numClustersTotal.toLocaleString()} clusters
+											</Text>
+											<Text size="1" color="gray">
+												{(desiredN ?? 0).toLocaleString()} participants
+											</Text>
+										</Flex>
+									) : (
+										(desiredN ?? "N/A")
+									)}
+								</DataList.Value>
+							</DataList.Item>
+						)}
+						<DataList.Item>
+							<DataList.Label>Actual Sample Size</DataList.Label>
+							<DataList.Value>
+								{numClustersTotal != null ? (
+									<Flex direction="column">
+										<Text color="green" weight="bold">
+											{numClustersTotal.toLocaleString()} clusters
+										</Text>
+										<Text size="1" color="gray">
+											{(
+												assignSummary?.sample_size ?? 0
+											).toLocaleString()}{" "}
+											participants
+										</Text>
+									</Flex>
+								) : (
+									(assignSummary?.sample_size ?? "N/A")
+								)}
+							</DataList.Value>
+						</DataList.Item>
+						{designEffect != null && (
+							<DataList.Item>
+								<DataList.Label>DEFF</DataList.Label>
+								<DataList.Value>{designEffect.toFixed(2)}</DataList.Value>
+							</DataList.Item>
+						)}
+					</DataList.Root>
+				</Flex>
 
-        {balanceCheck ? (
-          <Flex flexGrow="1">
-            <DataList.Root>
-              <DataList.Item>
-                <DataList.Label>
-                  <b>Balance Check</b>
-                </DataList.Label>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>F Statistic</DataList.Label>
-                <DataList.Value>{balanceCheck.f_statistic.toFixed(3)}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>Numerator DF</DataList.Label>
-                <DataList.Value>{balanceCheck.numerator_df}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>Denominator DF</DataList.Label>
-                <DataList.Value>{balanceCheck.denominator_df}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>P-Value</DataList.Label>
-                <DataList.Value>{balanceCheck.p_value.toFixed(3)}</DataList.Value>
-              </DataList.Item>
-              <DataList.Item>
-                <DataList.Label>Balance OK?</DataList.Label>
-                <DataList.Value>{balanceCheck.balance_ok ? 'Yes' : 'No'}</DataList.Value>
-              </DataList.Item>
-            </DataList.Root>
-          </Flex>
-        ) : null}
-      </Flex>
-    </SectionCard>
-  );
+				{balanceCheck ? (
+					<Flex flexGrow="1">
+						<DataList.Root>
+							<DataList.Item>
+								<DataList.Label>
+									<b>Balance Check</b>
+								</DataList.Label>
+							</DataList.Item>
+							<DataList.Item>
+								<DataList.Label>F Statistic</DataList.Label>
+								<DataList.Value>
+									{balanceCheck.f_statistic.toFixed(3)}
+								</DataList.Value>
+							</DataList.Item>
+							<DataList.Item>
+								<DataList.Label>Numerator DF</DataList.Label>
+								<DataList.Value>{balanceCheck.numerator_df}</DataList.Value>
+							</DataList.Item>
+							<DataList.Item>
+								<DataList.Label>Denominator DF</DataList.Label>
+								<DataList.Value>{balanceCheck.denominator_df}</DataList.Value>
+							</DataList.Item>
+							<DataList.Item>
+								<DataList.Label>P-Value</DataList.Label>
+								<DataList.Value>
+									{balanceCheck.p_value.toFixed(3)}
+								</DataList.Value>
+							</DataList.Item>
+							<DataList.Item>
+								<DataList.Label>Balance OK?</DataList.Label>
+								<DataList.Value>
+									{balanceCheck.balance_ok ? "Yes" : "No"}
+								</DataList.Value>
+							</DataList.Item>
+						</DataList.Root>
+					</Flex>
+				) : null}
+			</Flex>
+		</SectionCard>
+	);
 }

--- a/src/components/features/experiments/sections/power-balance-section.tsx
+++ b/src/components/features/experiments/sections/power-balance-section.tsx
@@ -1,151 +1,142 @@
-"use client";
+'use client';
 
-import { AssignSummary } from "@/api/methods.schemas";
-import { SectionCard } from "@/components/ui/cards/section-card";
-import { Pencil2Icon } from "@radix-ui/react-icons";
-import { Button, DataList, Flex, Text } from "@radix-ui/themes";
+import { AssignSummary } from '@/api/methods.schemas';
+import { SectionCard } from '@/components/ui/cards/section-card';
+import { Pencil2Icon } from '@radix-ui/react-icons';
+import { Button, DataList, Flex, Text } from '@radix-ui/themes';
 
 export interface PowerBalanceSectionProps {
-	confidence: number;
-	power: number;
-	desiredN?: number;
-	assignSummary: AssignSummary | null | undefined;
-	onEdit?: () => void;
-	showDesiredSampleSize?: boolean;
-	showTitle?: boolean;
-	/** Design effect (DEFF) from the power analysis — cluster experiments only. */
-	designEffect?: number | null;
-	/** Total clusters needed across all arms — cluster experiments only. */
-	numClustersTotal?: number | null;
+  confidence: number;
+  power: number;
+  desiredN?: number;
+  assignSummary: AssignSummary | null | undefined;
+  onEdit?: () => void;
+  showDesiredSampleSize?: boolean;
+  showTitle?: boolean;
+  /** Design effect (DEFF) from the power analysis — cluster experiments only. */
+  designEffect?: number | null;
+  /** Total clusters needed across all arms — cluster experiments only. */
+  numClustersTotal?: number | null;
 }
 
 export function PowerBalanceSection({
-	confidence,
-	power,
-	desiredN,
-	assignSummary,
-	onEdit,
-	showDesiredSampleSize = true,
-	showTitle = true,
-	designEffect,
-	numClustersTotal,
+  confidence,
+  power,
+  desiredN,
+  assignSummary,
+  onEdit,
+  showDesiredSampleSize = true,
+  showTitle = true,
+  designEffect,
+  numClustersTotal,
 }: PowerBalanceSectionProps) {
-	const balanceCheck = assignSummary?.balance_check;
+  const balanceCheck = assignSummary?.balance_check;
 
-	return (
-		<SectionCard
-			title={showTitle ? "Power & Balance" : undefined}
-			headerRight={
-				onEdit ? (
-					<Button size="1" onClick={onEdit}>
-						<Pencil2Icon />
-						Edit
-					</Button>
-				) : undefined
-			}
-		>
-			<Flex gap="4" direction="row" align="start">
-				<Flex flexGrow="1">
-					<DataList.Root>
-						<DataList.Item>
-							<DataList.Label>
-								<b>Power Parameters</b>
-							</DataList.Label>
-						</DataList.Item>
-						<DataList.Item>
-							<DataList.Label>Confidence</DataList.Label>
-							<DataList.Value>{confidence}%</DataList.Value>
-						</DataList.Item>
-						<DataList.Item>
-							<DataList.Label>Power</DataList.Label>
-							<DataList.Value>{power}%</DataList.Value>
-						</DataList.Item>
-						{showDesiredSampleSize && (
-							<DataList.Item>
-								<DataList.Label>Desired Sample Size</DataList.Label>
-								<DataList.Value>
-									{numClustersTotal != null ? (
-										<Flex direction="column">
-											<Text color="green" weight="bold">
-												{numClustersTotal.toLocaleString()} clusters
-											</Text>
-											<Text size="1" color="gray">
-												{(desiredN ?? 0).toLocaleString()} participants
-											</Text>
-										</Flex>
-									) : (
-										(desiredN ?? "N/A")
-									)}
-								</DataList.Value>
-							</DataList.Item>
-						)}
-						<DataList.Item>
-							<DataList.Label>Actual Sample Size</DataList.Label>
-							<DataList.Value>
-								{numClustersTotal != null ? (
-									<Flex direction="column">
-										<Text color="green" weight="bold">
-											{numClustersTotal.toLocaleString()} clusters
-										</Text>
-										<Text size="1" color="gray">
-											{(
-												assignSummary?.sample_size ?? 0
-											).toLocaleString()}{" "}
-											participants
-										</Text>
-									</Flex>
-								) : (
-									(assignSummary?.sample_size ?? "N/A")
-								)}
-							</DataList.Value>
-						</DataList.Item>
-						{designEffect != null && (
-							<DataList.Item>
-								<DataList.Label>DEFF</DataList.Label>
-								<DataList.Value>{designEffect.toFixed(2)}</DataList.Value>
-							</DataList.Item>
-						)}
-					</DataList.Root>
-				</Flex>
+  return (
+    <SectionCard
+      title={showTitle ? 'Power & Balance' : undefined}
+      headerRight={
+        onEdit ? (
+          <Button size="1" onClick={onEdit}>
+            <Pencil2Icon />
+            Edit
+          </Button>
+        ) : undefined
+      }
+    >
+      <Flex gap="4" direction="row" align="start">
+        <Flex flexGrow="1">
+          <DataList.Root>
+            <DataList.Item>
+              <DataList.Label>
+                <b>Power Parameters</b>
+              </DataList.Label>
+            </DataList.Item>
+            <DataList.Item>
+              <DataList.Label>Confidence</DataList.Label>
+              <DataList.Value>{confidence}%</DataList.Value>
+            </DataList.Item>
+            <DataList.Item>
+              <DataList.Label>Power</DataList.Label>
+              <DataList.Value>{power}%</DataList.Value>
+            </DataList.Item>
+            {showDesiredSampleSize && (
+              <DataList.Item>
+                <DataList.Label>Desired Sample Size</DataList.Label>
+                <DataList.Value>
+                  {numClustersTotal != null ? (
+                    <Flex direction="column">
+                      <Text color="green" weight="bold">
+                        {numClustersTotal.toLocaleString()} clusters
+                      </Text>
+                      <Text size="1" color="gray">
+                        {(desiredN ?? 0).toLocaleString()} participants
+                      </Text>
+                    </Flex>
+                  ) : (
+                    (desiredN ?? 'N/A')
+                  )}
+                </DataList.Value>
+              </DataList.Item>
+            )}
+            <DataList.Item>
+              <DataList.Label>Actual Sample Size</DataList.Label>
+              <DataList.Value>
+                {numClustersTotal != null ? (
+                  <Flex direction="column">
+                    <Text color="green" weight="bold">
+                      {numClustersTotal.toLocaleString()} clusters
+                    </Text>
+                    <Text size="1" color="gray">
+                      {(assignSummary?.sample_size ?? 0).toLocaleString()} participants
+                    </Text>
+                  </Flex>
+                ) : (
+                  (assignSummary?.sample_size ?? 'N/A')
+                )}
+              </DataList.Value>
+            </DataList.Item>
+            {designEffect != null && (
+              <DataList.Item>
+                <DataList.Label>DEFF</DataList.Label>
+                <DataList.Value>{designEffect.toFixed(2)}</DataList.Value>
+              </DataList.Item>
+            )}
+          </DataList.Root>
+        </Flex>
 
-				{balanceCheck ? (
-					<Flex flexGrow="1">
-						<DataList.Root>
-							<DataList.Item>
-								<DataList.Label>
-									<b>Balance Check</b>
-								</DataList.Label>
-							</DataList.Item>
-							<DataList.Item>
-								<DataList.Label>F Statistic</DataList.Label>
-								<DataList.Value>
-									{balanceCheck.f_statistic.toFixed(3)}
-								</DataList.Value>
-							</DataList.Item>
-							<DataList.Item>
-								<DataList.Label>Numerator DF</DataList.Label>
-								<DataList.Value>{balanceCheck.numerator_df}</DataList.Value>
-							</DataList.Item>
-							<DataList.Item>
-								<DataList.Label>Denominator DF</DataList.Label>
-								<DataList.Value>{balanceCheck.denominator_df}</DataList.Value>
-							</DataList.Item>
-							<DataList.Item>
-								<DataList.Label>P-Value</DataList.Label>
-								<DataList.Value>
-									{balanceCheck.p_value.toFixed(3)}
-								</DataList.Value>
-							</DataList.Item>
-							<DataList.Item>
-								<DataList.Label>Balance OK?</DataList.Label>
-								<DataList.Value>
-									{balanceCheck.balance_ok ? "Yes" : "No"}
-								</DataList.Value>
-							</DataList.Item>
-						</DataList.Root>
-					</Flex>
-				) : null}
-			</Flex>
-		</SectionCard>
-	);
+        {balanceCheck ? (
+          <Flex flexGrow="1">
+            <DataList.Root>
+              <DataList.Item>
+                <DataList.Label>
+                  <b>Balance Check</b>
+                </DataList.Label>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>F Statistic</DataList.Label>
+                <DataList.Value>{balanceCheck.f_statistic.toFixed(3)}</DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Numerator DF</DataList.Label>
+                <DataList.Value>{balanceCheck.numerator_df}</DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Denominator DF</DataList.Label>
+                <DataList.Value>{balanceCheck.denominator_df}</DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>P-Value</DataList.Label>
+                <DataList.Value>{balanceCheck.p_value.toFixed(3)}</DataList.Value>
+              </DataList.Item>
+              <DataList.Item>
+                <DataList.Label>Balance OK?</DataList.Label>
+                <DataList.Value>{balanceCheck.balance_ok ? 'Yes' : 'No'}</DataList.Value>
+              </DataList.Item>
+            </DataList.Root>
+          </Flex>
+        ) : null}
+      </Flex>
+    </SectionCard>
+  );
 }

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,186 +1,166 @@
-"use client";
+'use client';
 
 import {
-	ArmBandit,
-	CMABExperimentSpecOutput,
-	CreateExperimentResponse,
-	MABExperimentSpecOutput,
-	PriorTypes,
-} from "@/api/methods.schemas";
-import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
-import { SectionCard } from "@/components/ui/cards/section-card";
-import { ReadMoreText } from "@/components/ui/read-more-text";
-import { Pencil2Icon, PersonIcon } from "@radix-ui/react-icons";
-import { Badge, Button, Flex, Separator, Text } from "@radix-ui/themes";
+  ArmBandit,
+  CMABExperimentSpecOutput,
+  CreateExperimentResponse,
+  MABExperimentSpecOutput,
+  PriorTypes,
+} from '@/api/methods.schemas';
+import { isClusterDesign } from '@/components/features/experiments/cluster-detection';
+import { SectionCard } from '@/components/ui/cards/section-card';
+import { ReadMoreText } from '@/components/ui/read-more-text';
+import { Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
+import { Badge, Button, Flex, Separator, Text } from '@radix-ui/themes';
 
 function isBanditExperiment(
-	spec: CreateExperimentResponse["design_spec"],
+  spec: CreateExperimentResponse['design_spec'],
 ): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput {
-	return (
-		spec.experiment_type === "mab_online" ||
-		spec.experiment_type === "cmab_online"
-	);
+  return spec.experiment_type === 'mab_online' || spec.experiment_type === 'cmab_online';
 }
 
 interface TreatmentArmsSectionProps {
-	response: CreateExperimentResponse;
-	onEdit?: () => void;
+  response: CreateExperimentResponse;
+  onEdit?: () => void;
 }
 
-export function TreatmentArmsSection({
-	response,
-	onEdit,
-}: TreatmentArmsSectionProps) {
-	const designSpec = response.design_spec;
-	const arms = designSpec.arms;
-	const assignSummary = response.assign_summary;
-	const isBandit = isBanditExperiment(designSpec);
-	const priorType: PriorTypes | undefined = isBandit
-		? designSpec.prior_type
-		: undefined;
-	const isBetaPrior = priorType === "beta";
+export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionProps) {
+  const designSpec = response.design_spec;
+  const arms = designSpec.arms;
+  const assignSummary = response.assign_summary;
+  const isBandit = isBanditExperiment(designSpec);
+  const priorType: PriorTypes | undefined = isBandit ? designSpec.prior_type : undefined;
+  const isBetaPrior = priorType === 'beta';
 
-	if (isBandit) {
-		return (
-			<SectionCard
-				title="Treatment Arms"
-				headerRight={
-					onEdit ? (
-						<Button size="1" onClick={onEdit}>
-							<Pencil2Icon />
-							Edit
-						</Button>
-					) : undefined
-				}
-			>
-				<Flex direction="column" gap="4">
-					{arms.map((arm, index) => {
-						const banditArm = arm as ArmBandit;
-						return (
-							<Flex key={index} direction="column" gap="2">
-								<Flex align="center" justify="between" gap="3" wrap="wrap">
-									<Flex align="center" gap="2" wrap="wrap">
-										<Text weight="bold">{banditArm.arm_name}</Text>
-										{index === 0 && !isBandit ? (
-											<Text size="1" color="gray">
-												(Control)
-											</Text>
-										) : null}
-									</Flex>
-									<Flex align="center" gap="2" wrap="wrap">
-										{isBetaPrior ? (
-											<>
-												<Badge>
-													α = {banditArm.alpha_init?.toFixed(2) ?? "Not set"}
-												</Badge>
-												<Badge>
-													β ={banditArm.beta_init?.toFixed(2) ?? "Not set"}
-												</Badge>
-											</>
-										) : (
-											<>
-												<Badge>
-													μ = {banditArm.mu_init?.toFixed(2) ?? "Not set"}
-												</Badge>
-												<Badge>
-													σ = {banditArm.sigma_init?.toFixed(2) ?? "Not set"}
-												</Badge>
-											</>
-										)}
-									</Flex>
-								</Flex>
-								<ReadMoreText text={banditArm.arm_description || "-"} />
-								{index < arms.length - 1 && <Separator size="4" />}
-							</Flex>
-						);
-					})}
-				</Flex>
-			</SectionCard>
-		);
-	}
+  if (isBandit) {
+    return (
+      <SectionCard
+        title="Treatment Arms"
+        headerRight={
+          onEdit ? (
+            <Button size="1" onClick={onEdit}>
+              <Pencil2Icon />
+              Edit
+            </Button>
+          ) : undefined
+        }
+      >
+        <Flex direction="column" gap="4">
+          {arms.map((arm, index) => {
+            const banditArm = arm as ArmBandit;
+            return (
+              <Flex key={index} direction="column" gap="2">
+                <Flex align="center" justify="between" gap="3" wrap="wrap">
+                  <Flex align="center" gap="2" wrap="wrap">
+                    <Text weight="bold">{banditArm.arm_name}</Text>
+                    {index === 0 && !isBandit ? (
+                      <Text size="1" color="gray">
+                        (Control)
+                      </Text>
+                    ) : null}
+                  </Flex>
+                  <Flex align="center" gap="2" wrap="wrap">
+                    {isBetaPrior ? (
+                      <>
+                        <Badge>α = {banditArm.alpha_init?.toFixed(2) ?? 'Not set'}</Badge>
+                        <Badge>β ={banditArm.beta_init?.toFixed(2) ?? 'Not set'}</Badge>
+                      </>
+                    ) : (
+                      <>
+                        <Badge>μ = {banditArm.mu_init?.toFixed(2) ?? 'Not set'}</Badge>
+                        <Badge>σ = {banditArm.sigma_init?.toFixed(2) ?? 'Not set'}</Badge>
+                      </>
+                    )}
+                  </Flex>
+                </Flex>
+                <ReadMoreText text={banditArm.arm_description || '-'} />
+                {index < arms.length - 1 && <Separator size="4" />}
+              </Flex>
+            );
+          })}
+        </Flex>
+      </SectionCard>
+    );
+  }
 
-	// Frequentist experiment display
-	// Issue #217: when this is a cluster-randomized experiment, show a green
-	// "N clusters" badge alongside the participants badge for each arm
-	// (UI4A). The per-arm cluster split lives on the stored power_analyses;
-	// `isClusterDesign` falls back to power_analyses if the BE storage layer
-	// dropped cluster_column from design_spec.
-	const powerAnalyses = (
-		response as {
-			power_analyses?: {
-				analyses?: Array<{
-					clusters_per_arm?: number[] | null;
-					num_clusters_total?: number | null;
-				}>;
-			};
-		}
-	).power_analyses;
-	const isClusterExperiment = isClusterDesign(designSpec, powerAnalyses);
-	const firstAnalysis = powerAnalyses?.analyses?.[0];
-	const clustersPerArm = firstAnalysis?.clusters_per_arm ?? null;
-	const totalClusters = firstAnalysis?.num_clusters_total ?? null;
-	return (
-		<SectionCard
-			title="Treatment Arms"
-			headerRight={
-				onEdit ? (
-					<Button size="1" onClick={onEdit}>
-						<Pencil2Icon />
-						Edit
-					</Button>
-				) : undefined
-			}
-		>
-			<Flex direction="column" gap="4">
-				{arms.map((arm, index) => {
-					const armSize = assignSummary?.arm_sizes?.[index]?.size || 0;
-					// Prefer per-arm cluster counts from power_analyses; fall back to
-					// splitting num_clusters_total evenly across arms if the BE
-					// returned a total but no per-arm breakdown.
-					let armClusters: number | undefined;
-					if (isClusterExperiment) {
-						if (clustersPerArm && clustersPerArm.length === arms.length) {
-							armClusters = clustersPerArm[index];
-						} else if (totalClusters != null && arms.length > 0) {
-							armClusters = Math.floor(totalClusters / arms.length);
-						}
-					}
-					return (
-						<Flex key={index} direction="column" gap="2">
-							<Flex align="center" justify="between" gap="3" wrap="wrap">
-								<Flex align="center" gap="2" wrap="wrap">
-									<Text weight="bold">{arm.arm_name}</Text>
-									{index === 0 && (
-										<Text size="1" color="gray">
-											(Control)
-										</Text>
-									)}
-								</Flex>
-								<Flex align="center" gap="2" wrap="wrap">
-									{armClusters != null && (
-										<Badge color="green">
-											<Text>{armClusters.toLocaleString()} clusters</Text>
-										</Badge>
-									)}
-									{armSize > 0 && (
-										<Badge>
-											<PersonIcon />
-											<Text>{armSize.toLocaleString()} participants</Text>
-										</Badge>
-									)}
-									<Badge>
-										{arm.arm_weight == null
-											? "balanced"
-											: `${arm.arm_weight.toFixed(1)}%`}
-									</Badge>
-								</Flex>
-							</Flex>
-							<ReadMoreText text={arm.arm_description || "-"} />
-							{index < arms.length - 1 && <Separator size="4" />}
-						</Flex>
-					);
-				})}
-			</Flex>
-		</SectionCard>
-	);
+  // Frequentist experiment display
+  // Issue #217: when this is a cluster-randomized experiment, show a green
+  // "N clusters" badge alongside the participants badge for each arm
+  // (UI4A). The per-arm cluster split lives on the stored power_analyses;
+  // `isClusterDesign` falls back to power_analyses if the BE storage layer
+  // dropped cluster_column from design_spec.
+  const powerAnalyses = (
+    response as {
+      power_analyses?: {
+        analyses?: Array<{
+          clusters_per_arm?: number[] | null;
+          num_clusters_total?: number | null;
+        }>;
+      };
+    }
+  ).power_analyses;
+  const isClusterExperiment = isClusterDesign(designSpec, powerAnalyses);
+  const firstAnalysis = powerAnalyses?.analyses?.[0];
+  const clustersPerArm = firstAnalysis?.clusters_per_arm ?? null;
+  const totalClusters = firstAnalysis?.num_clusters_total ?? null;
+  return (
+    <SectionCard
+      title="Treatment Arms"
+      headerRight={
+        onEdit ? (
+          <Button size="1" onClick={onEdit}>
+            <Pencil2Icon />
+            Edit
+          </Button>
+        ) : undefined
+      }
+    >
+      <Flex direction="column" gap="4">
+        {arms.map((arm, index) => {
+          const armSize = assignSummary?.arm_sizes?.[index]?.size || 0;
+          // Prefer per-arm cluster counts from power_analyses; fall back to
+          // splitting num_clusters_total evenly across arms if the BE
+          // returned a total but no per-arm breakdown.
+          let armClusters: number | undefined;
+          if (isClusterExperiment) {
+            if (clustersPerArm && clustersPerArm.length === arms.length) {
+              armClusters = clustersPerArm[index];
+            } else if (totalClusters != null && arms.length > 0) {
+              armClusters = Math.floor(totalClusters / arms.length);
+            }
+          }
+          return (
+            <Flex key={index} direction="column" gap="2">
+              <Flex align="center" justify="between" gap="3" wrap="wrap">
+                <Flex align="center" gap="2" wrap="wrap">
+                  <Text weight="bold">{arm.arm_name}</Text>
+                  {index === 0 && (
+                    <Text size="1" color="gray">
+                      (Control)
+                    </Text>
+                  )}
+                </Flex>
+                <Flex align="center" gap="2" wrap="wrap">
+                  {armClusters != null && (
+                    <Badge color="green">
+                      <Text>{armClusters.toLocaleString()} clusters</Text>
+                    </Badge>
+                  )}
+                  {armSize > 0 && (
+                    <Badge>
+                      <PersonIcon />
+                      <Text>{armSize.toLocaleString()} participants</Text>
+                    </Badge>
+                  )}
+                  <Badge>{arm.arm_weight == null ? 'balanced' : `${arm.arm_weight.toFixed(1)}%`}</Badge>
+                </Flex>
+              </Flex>
+              <ReadMoreText text={arm.arm_description || '-'} />
+              {index < arms.length - 1 && <Separator size="4" />}
+            </Flex>
+          );
+        })}
+      </Flex>
+    </SectionCard>
+  );
 }

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,130 +1,186 @@
-'use client';
+"use client";
 
-import { Badge, Button, Flex, Separator, Text } from '@radix-ui/themes';
-import { Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
 import {
-  ArmBandit,
-  CMABExperimentSpecOutput,
-  CreateExperimentResponse,
-  MABExperimentSpecOutput,
-  PriorTypes,
-} from '@/api/methods.schemas';
-import { SectionCard } from '@/components/ui/cards/section-card';
-import { ReadMoreText } from '@/components/ui/read-more-text';
+	ArmBandit,
+	CMABExperimentSpecOutput,
+	CreateExperimentResponse,
+	MABExperimentSpecOutput,
+	PriorTypes,
+} from "@/api/methods.schemas";
+import { isClusterDesign } from "@/components/features/experiments/cluster-detection";
+import { SectionCard } from "@/components/ui/cards/section-card";
+import { ReadMoreText } from "@/components/ui/read-more-text";
+import { Pencil2Icon, PersonIcon } from "@radix-ui/react-icons";
+import { Badge, Button, Flex, Separator, Text } from "@radix-ui/themes";
 
 function isBanditExperiment(
-  spec: CreateExperimentResponse['design_spec'],
+	spec: CreateExperimentResponse["design_spec"],
 ): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput {
-  return spec.experiment_type === 'mab_online' || spec.experiment_type === 'cmab_online';
+	return (
+		spec.experiment_type === "mab_online" ||
+		spec.experiment_type === "cmab_online"
+	);
 }
 
 interface TreatmentArmsSectionProps {
-  response: CreateExperimentResponse;
-  onEdit?: () => void;
+	response: CreateExperimentResponse;
+	onEdit?: () => void;
 }
 
-export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionProps) {
-  const designSpec = response.design_spec;
-  const arms = designSpec.arms;
-  const assignSummary = response.assign_summary;
-  const isBandit = isBanditExperiment(designSpec);
-  const priorType: PriorTypes | undefined = isBandit ? designSpec.prior_type : undefined;
-  const isBetaPrior = priorType === 'beta';
+export function TreatmentArmsSection({
+	response,
+	onEdit,
+}: TreatmentArmsSectionProps) {
+	const designSpec = response.design_spec;
+	const arms = designSpec.arms;
+	const assignSummary = response.assign_summary;
+	const isBandit = isBanditExperiment(designSpec);
+	const priorType: PriorTypes | undefined = isBandit
+		? designSpec.prior_type
+		: undefined;
+	const isBetaPrior = priorType === "beta";
 
-  if (isBandit) {
-    return (
-      <SectionCard
-        title="Treatment Arms"
-        headerRight={
-          onEdit ? (
-            <Button size="1" onClick={onEdit}>
-              <Pencil2Icon />
-              Edit
-            </Button>
-          ) : undefined
-        }
-      >
-        <Flex direction="column" gap="4">
-          {arms.map((arm, index) => {
-            const banditArm = arm as ArmBandit;
-            return (
-              <Flex key={index} direction="column" gap="2">
-                <Flex align="center" justify="between" gap="3" wrap="wrap">
-                  <Flex align="center" gap="2" wrap="wrap">
-                    <Text weight="bold">{banditArm.arm_name}</Text>
-                    {index === 0 && !isBandit ? (
-                      <Text size="1" color="gray">
-                        (Control)
-                      </Text>
-                    ) : null}
-                  </Flex>
-                  <Flex align="center" gap="2" wrap="wrap">
-                    {isBetaPrior ? (
-                      <>
-                        <Badge>α = {banditArm.alpha_init?.toFixed(2) ?? 'Not set'}</Badge>
-                        <Badge>β ={banditArm.beta_init?.toFixed(2) ?? 'Not set'}</Badge>
-                      </>
-                    ) : (
-                      <>
-                        <Badge>μ = {banditArm.mu_init?.toFixed(2) ?? 'Not set'}</Badge>
-                        <Badge>σ = {banditArm.sigma_init?.toFixed(2) ?? 'Not set'}</Badge>
-                      </>
-                    )}
-                  </Flex>
-                </Flex>
-                <ReadMoreText text={banditArm.arm_description || '-'} />
-                {index < arms.length - 1 && <Separator size="4" />}
-              </Flex>
-            );
-          })}
-        </Flex>
-      </SectionCard>
-    );
-  }
+	if (isBandit) {
+		return (
+			<SectionCard
+				title="Treatment Arms"
+				headerRight={
+					onEdit ? (
+						<Button size="1" onClick={onEdit}>
+							<Pencil2Icon />
+							Edit
+						</Button>
+					) : undefined
+				}
+			>
+				<Flex direction="column" gap="4">
+					{arms.map((arm, index) => {
+						const banditArm = arm as ArmBandit;
+						return (
+							<Flex key={index} direction="column" gap="2">
+								<Flex align="center" justify="between" gap="3" wrap="wrap">
+									<Flex align="center" gap="2" wrap="wrap">
+										<Text weight="bold">{banditArm.arm_name}</Text>
+										{index === 0 && !isBandit ? (
+											<Text size="1" color="gray">
+												(Control)
+											</Text>
+										) : null}
+									</Flex>
+									<Flex align="center" gap="2" wrap="wrap">
+										{isBetaPrior ? (
+											<>
+												<Badge>
+													α = {banditArm.alpha_init?.toFixed(2) ?? "Not set"}
+												</Badge>
+												<Badge>
+													β ={banditArm.beta_init?.toFixed(2) ?? "Not set"}
+												</Badge>
+											</>
+										) : (
+											<>
+												<Badge>
+													μ = {banditArm.mu_init?.toFixed(2) ?? "Not set"}
+												</Badge>
+												<Badge>
+													σ = {banditArm.sigma_init?.toFixed(2) ?? "Not set"}
+												</Badge>
+											</>
+										)}
+									</Flex>
+								</Flex>
+								<ReadMoreText text={banditArm.arm_description || "-"} />
+								{index < arms.length - 1 && <Separator size="4" />}
+							</Flex>
+						);
+					})}
+				</Flex>
+			</SectionCard>
+		);
+	}
 
-  // Frequentist experiment display
-  return (
-    <SectionCard
-      title="Treatment Arms"
-      headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
-        ) : undefined
-      }
-    >
-      <Flex direction="column" gap="4">
-        {arms.map((arm, index) => {
-          const armSize = assignSummary?.arm_sizes?.[index]?.size || 0;
-          return (
-            <Flex key={index} direction="column" gap="2">
-              <Flex align="center" justify="between" gap="3" wrap="wrap">
-                <Flex align="center" gap="2" wrap="wrap">
-                  <Text weight="bold">{arm.arm_name}</Text>
-                  {index === 0 && (
-                    <Text size="1" color="gray">
-                      (Control)
-                    </Text>
-                  )}
-                </Flex>
-                <Flex align="center" gap="2" wrap="wrap">
-                  {armSize > 0 && (
-                    <Badge>
-                      <PersonIcon />
-                      <Text>{armSize.toLocaleString()} participants</Text>
-                    </Badge>
-                  )}
-                  <Badge>{arm.arm_weight == null ? 'balanced' : `${arm.arm_weight.toFixed(1)}%`}</Badge>
-                </Flex>
-              </Flex>
-              <ReadMoreText text={arm.arm_description || '-'} />
-              {index < arms.length - 1 && <Separator size="4" />}
-            </Flex>
-          );
-        })}
-      </Flex>
-    </SectionCard>
-  );
+	// Frequentist experiment display
+	// Issue #217: when this is a cluster-randomized experiment, show a green
+	// "N clusters" badge alongside the participants badge for each arm
+	// (UI4A). The per-arm cluster split lives on the stored power_analyses;
+	// `isClusterDesign` falls back to power_analyses if the BE storage layer
+	// dropped cluster_column from design_spec.
+	const powerAnalyses = (
+		response as {
+			power_analyses?: {
+				analyses?: Array<{
+					clusters_per_arm?: number[] | null;
+					num_clusters_total?: number | null;
+				}>;
+			};
+		}
+	).power_analyses;
+	const isClusterExperiment = isClusterDesign(designSpec, powerAnalyses);
+	const firstAnalysis = powerAnalyses?.analyses?.[0];
+	const clustersPerArm = firstAnalysis?.clusters_per_arm ?? null;
+	const totalClusters = firstAnalysis?.num_clusters_total ?? null;
+	return (
+		<SectionCard
+			title="Treatment Arms"
+			headerRight={
+				onEdit ? (
+					<Button size="1" onClick={onEdit}>
+						<Pencil2Icon />
+						Edit
+					</Button>
+				) : undefined
+			}
+		>
+			<Flex direction="column" gap="4">
+				{arms.map((arm, index) => {
+					const armSize = assignSummary?.arm_sizes?.[index]?.size || 0;
+					// Prefer per-arm cluster counts from power_analyses; fall back to
+					// splitting num_clusters_total evenly across arms if the BE
+					// returned a total but no per-arm breakdown.
+					let armClusters: number | undefined;
+					if (isClusterExperiment) {
+						if (clustersPerArm && clustersPerArm.length === arms.length) {
+							armClusters = clustersPerArm[index];
+						} else if (totalClusters != null && arms.length > 0) {
+							armClusters = Math.floor(totalClusters / arms.length);
+						}
+					}
+					return (
+						<Flex key={index} direction="column" gap="2">
+							<Flex align="center" justify="between" gap="3" wrap="wrap">
+								<Flex align="center" gap="2" wrap="wrap">
+									<Text weight="bold">{arm.arm_name}</Text>
+									{index === 0 && (
+										<Text size="1" color="gray">
+											(Control)
+										</Text>
+									)}
+								</Flex>
+								<Flex align="center" gap="2" wrap="wrap">
+									{armClusters != null && (
+										<Badge color="green">
+											<Text>{armClusters.toLocaleString()} clusters</Text>
+										</Badge>
+									)}
+									{armSize > 0 && (
+										<Badge>
+											<PersonIcon />
+											<Text>{armSize.toLocaleString()} participants</Text>
+										</Badge>
+									)}
+									<Badge>
+										{arm.arm_weight == null
+											? "balanced"
+											: `${arm.arm_weight.toFixed(1)}%`}
+									</Badge>
+								</Flex>
+							</Flex>
+							<ReadMoreText text={arm.arm_description || "-"} />
+							{index < arms.length - 1 && <Separator size="4" />}
+						</Flex>
+					);
+				})}
+			</Flex>
+		</SectionCard>
+	);
 }

--- a/src/components/features/experiments/targeting-dialog.tsx
+++ b/src/components/features/experiments/targeting-dialog.tsx
@@ -1,233 +1,193 @@
-"use client";
+'use client';
 
 import {
-	BayesABExperimentSpecOutput,
-	CMABExperimentSpecOutput,
-	DataType,
-	DesignSpecOutput,
-	MABExperimentSpecOutput,
-	OnlineFrequentistExperimentSpecOutput,
-	ParticipantsDef,
-	PreassignedFrequentistExperimentSpecOutput,
-} from "@/api/methods.schemas";
-import { ContextsSection } from "@/components/features/experiments/sections/contexts-section";
-import { DatasourceTargetingSection } from "@/components/features/experiments/sections/datasource-targeting-section";
-import {
-	MetricDisplay,
-	MetricsSection,
-} from "@/components/features/experiments/sections/metrics-section";
-import { OutcomesPriorSection } from "@/components/features/experiments/sections/outcomes-prior-section";
-import { WebhooksSection } from "@/components/features/experiments/sections/webhooks-section";
-import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
-import { Box, Button, Dialog, Flex } from "@radix-ui/themes";
-import { useState } from "react";
+  BayesABExperimentSpecOutput,
+  CMABExperimentSpecOutput,
+  DataType,
+  DesignSpecOutput,
+  MABExperimentSpecOutput,
+  OnlineFrequentistExperimentSpecOutput,
+  ParticipantsDef,
+  PreassignedFrequentistExperimentSpecOutput,
+} from '@/api/methods.schemas';
+import { ContextsSection } from '@/components/features/experiments/sections/contexts-section';
+import { DatasourceTargetingSection } from '@/components/features/experiments/sections/datasource-targeting-section';
+import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
+import { OutcomesPriorSection } from '@/components/features/experiments/sections/outcomes-prior-section';
+import { WebhooksSection } from '@/components/features/experiments/sections/webhooks-section';
+import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+import { Box, Button, Dialog, Flex } from '@radix-ui/themes';
+import { useState } from 'react';
 
 interface TargetingDialogProps {
-	designSpec: DesignSpecOutput;
-	participantType: ParticipantsDef | null | undefined;
-	webhookIds: string[];
-	/**
-	 * Stored power analysis response, used to surface cluster stats that the
-	 * BE persists on power_analyses (per-metric icc/cv/avg_cluster_size) but
-	 * does not persist on design_spec (issue #217). Optional so non-frequentist
-	 * callers don't need to pass it.
-	 */
-	powerAnalyses?: {
-		analyses?: Array<{
-			metric_spec?: {
-				field_name?: string | null;
-				icc?: number | null;
-				cv?: number | null;
-				avg_cluster_size?: number | null;
-			} | null;
-			num_clusters_total?: number | null;
-			/**
-			 * Achievable MDE for the committed sample size, as a fraction (e.g.
-			 * 0.078 for 7.8%). Populated when the user picked a non-recommended
-			 * N at create time; null otherwise.
-			 */
-			pct_change_possible?: number | null;
-		} | null> | null;
-	} | null;
+  designSpec: DesignSpecOutput;
+  participantType: ParticipantsDef | null | undefined;
+  webhookIds: string[];
+  /**
+   * Stored power analysis response, used to surface cluster stats that the
+   * BE persists on power_analyses (per-metric icc/cv/avg_cluster_size) but
+   * does not persist on design_spec (issue #217). Optional so non-frequentist
+   * callers don't need to pass it.
+   */
+  powerAnalyses?: {
+    analyses?: Array<{
+      metric_spec?: {
+        field_name?: string | null;
+        icc?: number | null;
+        cv?: number | null;
+        avg_cluster_size?: number | null;
+      } | null;
+      num_clusters_total?: number | null;
+      /**
+       * Achievable MDE for the committed sample size, as a fraction (e.g.
+       * 0.078 for 7.8%). Populated when the user picked a non-recommended
+       * N at create time; null otherwise.
+       */
+      pct_change_possible?: number | null;
+    } | null> | null;
+  } | null;
 }
 
 const isFrequentistSpec = (
-	spec: DesignSpecOutput,
-): spec is
-	| OnlineFrequentistExperimentSpecOutput
-	| PreassignedFrequentistExperimentSpecOutput =>
-	spec.experiment_type === "freq_online" ||
-	spec.experiment_type === "freq_preassigned";
+  spec: DesignSpecOutput,
+): spec is OnlineFrequentistExperimentSpecOutput | PreassignedFrequentistExperimentSpecOutput =>
+  spec.experiment_type === 'freq_online' || spec.experiment_type === 'freq_preassigned';
 
 const isBanditSpec = (
-	spec: DesignSpecOutput,
-): spec is
-	| MABExperimentSpecOutput
-	| CMABExperimentSpecOutput
-	| BayesABExperimentSpecOutput =>
-	spec.experiment_type === "mab_online" ||
-	spec.experiment_type === "cmab_online" ||
-	spec.experiment_type === "bayes_ab_online";
+  spec: DesignSpecOutput,
+): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput | BayesABExperimentSpecOutput =>
+  spec.experiment_type === 'mab_online' ||
+  spec.experiment_type === 'cmab_online' ||
+  spec.experiment_type === 'bayes_ab_online';
 
-const isCmabSpec = (spec: DesignSpecOutput): spec is CMABExperimentSpecOutput =>
-	spec.experiment_type === "cmab_online";
+const isCmabSpec = (spec: DesignSpecOutput): spec is CMABExperimentSpecOutput => spec.experiment_type === 'cmab_online';
 
 const toMdePercent = (value: number | null | undefined): string => {
-	if (value === null || value === undefined) {
-		return "unknown";
-	}
-	return (value * 100).toFixed(1);
+  if (value === null || value === undefined) {
+    return 'unknown';
+  }
+  return (value * 100).toFixed(1);
 };
 
-export function TargetingDialog({
-	designSpec,
-	participantType,
-	webhookIds,
-	powerAnalyses,
-}: TargetingDialogProps) {
-	const [open, setOpen] = useState(false);
+export function TargetingDialog({ designSpec, participantType, webhookIds, powerAnalyses }: TargetingDialogProps) {
+  const [open, setOpen] = useState(false);
 
-	const fieldTypeByName = new Map(
-		(participantType?.fields ?? []).map((field) => {
-			return [field.field_name, field.data_type];
-		}),
-	);
+  const fieldTypeByName = new Map(
+    (participantType?.fields ?? []).map((field) => {
+      return [field.field_name, field.data_type];
+    }),
+  );
 
-	// Lookup of achievable MDE by metric field_name, sourced from the stored
-	// power_analyses. When the experiment was created with a non-recommended
-	// sample size, the BE writes pct_change_possible into the saved analysis.
-	// For experiments that committed to the recommended size this stays
-	// undefined and MdeBadge will render Target MDE alone.
-	const achievableByField = new Map<string, number | null>();
-	for (const analysis of powerAnalyses?.analyses ?? []) {
-		const fieldName = analysis?.metric_spec?.field_name;
-		if (!fieldName) continue;
-		const pct = analysis?.pct_change_possible;
-		if (pct == null || !Number.isFinite(pct)) continue;
-		achievableByField.set(fieldName, pct * 100);
-	}
+  // Lookup of achievable MDE by metric field_name, sourced from the stored
+  // power_analyses. When the experiment was created with a non-recommended
+  // sample size, the BE writes pct_change_possible into the saved analysis.
+  // For experiments that committed to the recommended size this stays
+  // undefined and MdeBadge will render Target MDE alone.
+  const achievableByField = new Map<string, number | null>();
+  for (const analysis of powerAnalyses?.analyses ?? []) {
+    const fieldName = analysis?.metric_spec?.field_name;
+    if (!fieldName) continue;
+    const pct = analysis?.pct_change_possible;
+    if (pct == null || !Number.isFinite(pct)) continue;
+    achievableByField.set(fieldName, pct * 100);
+  }
 
-	const toMetricDisplay = (
-		fieldName: string,
-		mdePct: number | null | undefined,
-	): MetricDisplay => {
-		const dataType = fieldTypeByName.get(fieldName) ?? DataType.unknown;
-		return {
-			field_name: fieldName,
-			data_type: dataType,
-			mde: toMdePercent(mdePct),
-			achievable: achievableByField.get(fieldName) ?? null,
-		};
-	};
+  const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
+    const dataType = fieldTypeByName.get(fieldName) ?? DataType.unknown;
+    return {
+      field_name: fieldName,
+      data_type: dataType,
+      mde: toMdePercent(mdePct),
+      achievable: achievableByField.get(fieldName) ?? null,
+    };
+  };
 
-	let frequentistMetrics:
-		| { primary?: MetricDisplay; secondary?: MetricDisplay[] }
-		| undefined = undefined;
-	if (isFrequentistSpec(designSpec)) {
-		const [primaryMetric, ...secondaryMetrics] = designSpec.metrics;
-		frequentistMetrics = {
-			primary: primaryMetric
-				? toMetricDisplay(
-						primaryMetric.field_name,
-						primaryMetric.metric_pct_change,
-					)
-				: undefined,
-			secondary: secondaryMetrics.map((metric) =>
-				toMetricDisplay(metric.field_name, metric.metric_pct_change),
-			),
-		};
-	}
+  let frequentistMetrics: { primary?: MetricDisplay; secondary?: MetricDisplay[] } | undefined = undefined;
+  if (isFrequentistSpec(designSpec)) {
+    const [primaryMetric, ...secondaryMetrics] = designSpec.metrics;
+    frequentistMetrics = {
+      primary: primaryMetric ? toMetricDisplay(primaryMetric.field_name, primaryMetric.metric_pct_change) : undefined,
+      secondary: secondaryMetrics.map((metric) => toMetricDisplay(metric.field_name, metric.metric_pct_change)),
+    };
+  }
 
-	return (
-		<Dialog.Root open={open} onOpenChange={setOpen}>
-			<Dialog.Trigger>
-				<Button variant="ghost" color="blue">
-					<MagnifyingGlassIcon /> Targeting
-				</Button>
-			</Dialog.Trigger>
-			<Dialog.Content size="4" width="900px">
-				<Flex direction="column" gap="3">
-					<Dialog.Title>Targeting and Design</Dialog.Title>
-					<Box maxHeight="70vh" overflow="auto" pr="1">
-						<Flex direction="column" gap="3">
-							{isFrequentistSpec(designSpec) && (
-								<>
-									<DatasourceTargetingSection
-										tableName={designSpec.table_name}
-										primaryKey={designSpec.primary_key}
-										filters={designSpec.filters}
-									/>
-									<MetricsSection
-										metrics={frequentistMetrics}
-										strata={
-											designSpec.strata?.map((stratum) => stratum.field_name) ??
-											[]
-										}
-										cluster={(() => {
-											// Issue #217: surface cluster fields on the Targeting modal.
-											// The BE on PR #163 does NOT persist cluster_column or the
-											// per-metric icc/cv/avg_cluster_size onto design_spec — but
-											// the per-metric stats ARE preserved inside the stored
-											// power_analyses JSON blob. We read from design_spec when
-											// present (forward-compat) and otherwise fall back.
-											const ds = designSpec as {
-												cluster_column?: string | null;
-												metrics?: Array<{
-													icc?: number | null;
-													cv?: number | null;
-													avg_cluster_size?: number | null;
-												}>;
-											};
-											const pa = powerAnalyses?.analyses?.[0]?.metric_spec;
-											const clusterCol = ds.cluster_column;
-											const dsMetric = ds.metrics?.[0];
-											const icc = dsMetric?.icc ?? pa?.icc ?? null;
-											const cv = dsMetric?.cv ?? pa?.cv ?? null;
-											const avg =
-												dsMetric?.avg_cluster_size ??
-												pa?.avg_cluster_size ??
-												null;
-											// Show cluster block if we have ANY cluster signal.
-											if (!clusterCol && icc == null && cv == null && avg == null) {
-												return undefined;
-											}
-											return {
-												// Cluster column name isn't persisted by the BE today
-												// (storage_format_converters.py drops it). Show an em
-												// dash rather than a confusing parenthetical until the
-												// BE storage is fixed.
-												field_name: clusterCol ?? "—",
-												icc: icc ?? "?",
-												cv: cv ?? "?",
-												avg_cluster_size: avg ?? "?",
-											};
-										})()}
-									/>
-								</>
-							)}
-							{isBanditSpec(designSpec) && (
-								<OutcomesPriorSection
-									priorType={designSpec.prior_type}
-									rewardType={designSpec.reward_type}
-								/>
-							)}
-							{isCmabSpec(designSpec) && (
-								<ContextsSection contexts={designSpec.contexts ?? []} />
-							)}
-							{webhookIds.length > 0 && (
-								<WebhooksSection webhookIds={webhookIds} />
-							)}
-						</Flex>
-					</Box>
-					<Flex gap="3" justify="end">
-						<Dialog.Close>
-							<Button variant="soft" color="gray">
-								Close
-							</Button>
-						</Dialog.Close>
-					</Flex>
-				</Flex>
-			</Dialog.Content>
-		</Dialog.Root>
-	);
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger>
+        <Button variant="ghost" color="blue">
+          <MagnifyingGlassIcon /> Targeting
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content size="4" width="900px">
+        <Flex direction="column" gap="3">
+          <Dialog.Title>Targeting and Design</Dialog.Title>
+          <Box maxHeight="70vh" overflow="auto" pr="1">
+            <Flex direction="column" gap="3">
+              {isFrequentistSpec(designSpec) && (
+                <>
+                  <DatasourceTargetingSection
+                    tableName={designSpec.table_name}
+                    primaryKey={designSpec.primary_key}
+                    filters={designSpec.filters}
+                  />
+                  <MetricsSection
+                    metrics={frequentistMetrics}
+                    strata={designSpec.strata?.map((stratum) => stratum.field_name) ?? []}
+                    cluster={(() => {
+                      // Issue #217: surface cluster fields on the Targeting modal.
+                      // The BE on PR #163 does NOT persist cluster_column or the
+                      // per-metric icc/cv/avg_cluster_size onto design_spec — but
+                      // the per-metric stats ARE preserved inside the stored
+                      // power_analyses JSON blob. We read from design_spec when
+                      // present (forward-compat) and otherwise fall back.
+                      const ds = designSpec as {
+                        cluster_column?: string | null;
+                        metrics?: Array<{
+                          icc?: number | null;
+                          cv?: number | null;
+                          avg_cluster_size?: number | null;
+                        }>;
+                      };
+                      const pa = powerAnalyses?.analyses?.[0]?.metric_spec;
+                      const clusterCol = ds.cluster_column;
+                      const dsMetric = ds.metrics?.[0];
+                      const icc = dsMetric?.icc ?? pa?.icc ?? null;
+                      const cv = dsMetric?.cv ?? pa?.cv ?? null;
+                      const avg = dsMetric?.avg_cluster_size ?? pa?.avg_cluster_size ?? null;
+                      // Show cluster block if we have ANY cluster signal.
+                      if (!clusterCol && icc == null && cv == null && avg == null) {
+                        return undefined;
+                      }
+                      return {
+                        // Cluster column name isn't persisted by the BE today
+                        // (storage_format_converters.py drops it). Show an em
+                        // dash rather than a confusing parenthetical until the
+                        // BE storage is fixed.
+                        field_name: clusterCol ?? '—',
+                        icc: icc ?? '?',
+                        cv: cv ?? '?',
+                        avg_cluster_size: avg ?? '?',
+                      };
+                    })()}
+                  />
+                </>
+              )}
+              {isBanditSpec(designSpec) && (
+                <OutcomesPriorSection priorType={designSpec.prior_type} rewardType={designSpec.reward_type} />
+              )}
+              {isCmabSpec(designSpec) && <ContextsSection contexts={designSpec.contexts ?? []} />}
+              {webhookIds.length > 0 && <WebhooksSection webhookIds={webhookIds} />}
+            </Flex>
+          </Box>
+          <Flex gap="3" justify="end">
+            <Dialog.Close>
+              <Button variant="soft" color="gray">
+                Close
+              </Button>
+            </Dialog.Close>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
 }

--- a/src/components/features/experiments/targeting-dialog.tsx
+++ b/src/components/features/experiments/targeting-dialog.tsx
@@ -35,11 +35,18 @@ interface TargetingDialogProps {
 	powerAnalyses?: {
 		analyses?: Array<{
 			metric_spec?: {
+				field_name?: string | null;
 				icc?: number | null;
 				cv?: number | null;
 				avg_cluster_size?: number | null;
 			} | null;
 			num_clusters_total?: number | null;
+			/**
+			 * Achievable MDE for the committed sample size, as a fraction (e.g.
+			 * 0.078 for 7.8%). Populated when the user picked a non-recommended
+			 * N at create time; null otherwise.
+			 */
+			pct_change_possible?: number | null;
 		} | null> | null;
 	} | null;
 }
@@ -86,6 +93,20 @@ export function TargetingDialog({
 		}),
 	);
 
+	// Lookup of achievable MDE by metric field_name, sourced from the stored
+	// power_analyses. When the experiment was created with a non-recommended
+	// sample size, the BE writes pct_change_possible into the saved analysis.
+	// For experiments that committed to the recommended size this stays
+	// undefined and MdeBadge will render Target MDE alone.
+	const achievableByField = new Map<string, number | null>();
+	for (const analysis of powerAnalyses?.analyses ?? []) {
+		const fieldName = analysis?.metric_spec?.field_name;
+		if (!fieldName) continue;
+		const pct = analysis?.pct_change_possible;
+		if (pct == null || !Number.isFinite(pct)) continue;
+		achievableByField.set(fieldName, pct * 100);
+	}
+
 	const toMetricDisplay = (
 		fieldName: string,
 		mdePct: number | null | undefined,
@@ -95,6 +116,7 @@ export function TargetingDialog({
 			field_name: fieldName,
 			data_type: dataType,
 			mde: toMdePercent(mdePct),
+			achievable: achievableByField.get(fieldName) ?? null,
 		};
 	};
 

--- a/src/components/features/experiments/targeting-dialog.tsx
+++ b/src/components/features/experiments/targeting-dialog.tsx
@@ -1,119 +1,211 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { Box, Button, Dialog, Flex } from '@radix-ui/themes';
 import {
-  BayesABExperimentSpecOutput,
-  CMABExperimentSpecOutput,
-  DataType,
-  DesignSpecOutput,
-  MABExperimentSpecOutput,
-  OnlineFrequentistExperimentSpecOutput,
-  ParticipantsDef,
-  PreassignedFrequentistExperimentSpecOutput,
-} from '@/api/methods.schemas';
-import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
-import { DatasourceTargetingSection } from '@/components/features/experiments/sections/datasource-targeting-section';
-import { ContextsSection } from '@/components/features/experiments/sections/contexts-section';
-import { OutcomesPriorSection } from '@/components/features/experiments/sections/outcomes-prior-section';
-import { WebhooksSection } from '@/components/features/experiments/sections/webhooks-section';
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
+	BayesABExperimentSpecOutput,
+	CMABExperimentSpecOutput,
+	DataType,
+	DesignSpecOutput,
+	MABExperimentSpecOutput,
+	OnlineFrequentistExperimentSpecOutput,
+	ParticipantsDef,
+	PreassignedFrequentistExperimentSpecOutput,
+} from "@/api/methods.schemas";
+import { ContextsSection } from "@/components/features/experiments/sections/contexts-section";
+import { DatasourceTargetingSection } from "@/components/features/experiments/sections/datasource-targeting-section";
+import {
+	MetricDisplay,
+	MetricsSection,
+} from "@/components/features/experiments/sections/metrics-section";
+import { OutcomesPriorSection } from "@/components/features/experiments/sections/outcomes-prior-section";
+import { WebhooksSection } from "@/components/features/experiments/sections/webhooks-section";
+import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
+import { Box, Button, Dialog, Flex } from "@radix-ui/themes";
+import { useState } from "react";
 
 interface TargetingDialogProps {
-  designSpec: DesignSpecOutput;
-  participantType: ParticipantsDef | null | undefined;
-  webhookIds: string[];
+	designSpec: DesignSpecOutput;
+	participantType: ParticipantsDef | null | undefined;
+	webhookIds: string[];
+	/**
+	 * Stored power analysis response, used to surface cluster stats that the
+	 * BE persists on power_analyses (per-metric icc/cv/avg_cluster_size) but
+	 * does not persist on design_spec (issue #217). Optional so non-frequentist
+	 * callers don't need to pass it.
+	 */
+	powerAnalyses?: {
+		analyses?: Array<{
+			metric_spec?: {
+				icc?: number | null;
+				cv?: number | null;
+				avg_cluster_size?: number | null;
+			} | null;
+			num_clusters_total?: number | null;
+		} | null> | null;
+	} | null;
 }
 
 const isFrequentistSpec = (
-  spec: DesignSpecOutput,
-): spec is OnlineFrequentistExperimentSpecOutput | PreassignedFrequentistExperimentSpecOutput =>
-  spec.experiment_type === 'freq_online' || spec.experiment_type === 'freq_preassigned';
+	spec: DesignSpecOutput,
+): spec is
+	| OnlineFrequentistExperimentSpecOutput
+	| PreassignedFrequentistExperimentSpecOutput =>
+	spec.experiment_type === "freq_online" ||
+	spec.experiment_type === "freq_preassigned";
 
 const isBanditSpec = (
-  spec: DesignSpecOutput,
-): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput | BayesABExperimentSpecOutput =>
-  spec.experiment_type === 'mab_online' ||
-  spec.experiment_type === 'cmab_online' ||
-  spec.experiment_type === 'bayes_ab_online';
+	spec: DesignSpecOutput,
+): spec is
+	| MABExperimentSpecOutput
+	| CMABExperimentSpecOutput
+	| BayesABExperimentSpecOutput =>
+	spec.experiment_type === "mab_online" ||
+	spec.experiment_type === "cmab_online" ||
+	spec.experiment_type === "bayes_ab_online";
 
-const isCmabSpec = (spec: DesignSpecOutput): spec is CMABExperimentSpecOutput => spec.experiment_type === 'cmab_online';
+const isCmabSpec = (spec: DesignSpecOutput): spec is CMABExperimentSpecOutput =>
+	spec.experiment_type === "cmab_online";
 
 const toMdePercent = (value: number | null | undefined): string => {
-  if (value === null || value === undefined) {
-    return 'unknown';
-  }
-  return (value * 100).toFixed(1);
+	if (value === null || value === undefined) {
+		return "unknown";
+	}
+	return (value * 100).toFixed(1);
 };
 
-export function TargetingDialog({ designSpec, participantType, webhookIds }: TargetingDialogProps) {
-  const [open, setOpen] = useState(false);
+export function TargetingDialog({
+	designSpec,
+	participantType,
+	webhookIds,
+	powerAnalyses,
+}: TargetingDialogProps) {
+	const [open, setOpen] = useState(false);
 
-  const fieldTypeByName = new Map(
-    (participantType?.fields ?? []).map((field) => {
-      return [field.field_name, field.data_type];
-    }),
-  );
+	const fieldTypeByName = new Map(
+		(participantType?.fields ?? []).map((field) => {
+			return [field.field_name, field.data_type];
+		}),
+	);
 
-  const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
-    const dataType = fieldTypeByName.get(fieldName) ?? DataType.unknown;
-    return {
-      field_name: fieldName,
-      data_type: dataType,
-      mde: toMdePercent(mdePct),
-    };
-  };
+	const toMetricDisplay = (
+		fieldName: string,
+		mdePct: number | null | undefined,
+	): MetricDisplay => {
+		const dataType = fieldTypeByName.get(fieldName) ?? DataType.unknown;
+		return {
+			field_name: fieldName,
+			data_type: dataType,
+			mde: toMdePercent(mdePct),
+		};
+	};
 
-  let frequentistMetrics: { primary?: MetricDisplay; secondary?: MetricDisplay[] } | undefined = undefined;
-  if (isFrequentistSpec(designSpec)) {
-    const [primaryMetric, ...secondaryMetrics] = designSpec.metrics;
-    frequentistMetrics = {
-      primary: primaryMetric ? toMetricDisplay(primaryMetric.field_name, primaryMetric.metric_pct_change) : undefined,
-      secondary: secondaryMetrics.map((metric) => toMetricDisplay(metric.field_name, metric.metric_pct_change)),
-    };
-  }
+	let frequentistMetrics:
+		| { primary?: MetricDisplay; secondary?: MetricDisplay[] }
+		| undefined = undefined;
+	if (isFrequentistSpec(designSpec)) {
+		const [primaryMetric, ...secondaryMetrics] = designSpec.metrics;
+		frequentistMetrics = {
+			primary: primaryMetric
+				? toMetricDisplay(
+						primaryMetric.field_name,
+						primaryMetric.metric_pct_change,
+					)
+				: undefined,
+			secondary: secondaryMetrics.map((metric) =>
+				toMetricDisplay(metric.field_name, metric.metric_pct_change),
+			),
+		};
+	}
 
-  return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Trigger>
-        <Button variant="ghost" color="blue">
-          <MagnifyingGlassIcon /> Targeting
-        </Button>
-      </Dialog.Trigger>
-      <Dialog.Content size="4" width="900px">
-        <Flex direction="column" gap="3">
-          <Dialog.Title>Targeting and Design</Dialog.Title>
-          <Box maxHeight="70vh" overflow="auto" pr="1">
-            <Flex direction="column" gap="3">
-              {isFrequentistSpec(designSpec) && (
-                <>
-                  <DatasourceTargetingSection
-                    tableName={designSpec.table_name}
-                    primaryKey={designSpec.primary_key}
-                    filters={designSpec.filters}
-                  />
-                  <MetricsSection
-                    metrics={frequentistMetrics}
-                    strata={designSpec.strata?.map((stratum) => stratum.field_name) ?? []}
-                  />
-                </>
-              )}
-              {isBanditSpec(designSpec) && (
-                <OutcomesPriorSection priorType={designSpec.prior_type} rewardType={designSpec.reward_type} />
-              )}
-              {isCmabSpec(designSpec) && <ContextsSection contexts={designSpec.contexts ?? []} />}
-              {webhookIds.length > 0 && <WebhooksSection webhookIds={webhookIds} />}
-            </Flex>
-          </Box>
-          <Flex gap="3" justify="end">
-            <Dialog.Close>
-              <Button variant="soft" color="gray">
-                Close
-              </Button>
-            </Dialog.Close>
-          </Flex>
-        </Flex>
-      </Dialog.Content>
-    </Dialog.Root>
-  );
+	return (
+		<Dialog.Root open={open} onOpenChange={setOpen}>
+			<Dialog.Trigger>
+				<Button variant="ghost" color="blue">
+					<MagnifyingGlassIcon /> Targeting
+				</Button>
+			</Dialog.Trigger>
+			<Dialog.Content size="4" width="900px">
+				<Flex direction="column" gap="3">
+					<Dialog.Title>Targeting and Design</Dialog.Title>
+					<Box maxHeight="70vh" overflow="auto" pr="1">
+						<Flex direction="column" gap="3">
+							{isFrequentistSpec(designSpec) && (
+								<>
+									<DatasourceTargetingSection
+										tableName={designSpec.table_name}
+										primaryKey={designSpec.primary_key}
+										filters={designSpec.filters}
+									/>
+									<MetricsSection
+										metrics={frequentistMetrics}
+										strata={
+											designSpec.strata?.map((stratum) => stratum.field_name) ??
+											[]
+										}
+										cluster={(() => {
+											// Issue #217: surface cluster fields on the Targeting modal.
+											// The BE on PR #163 does NOT persist cluster_column or the
+											// per-metric icc/cv/avg_cluster_size onto design_spec — but
+											// the per-metric stats ARE preserved inside the stored
+											// power_analyses JSON blob. We read from design_spec when
+											// present (forward-compat) and otherwise fall back.
+											const ds = designSpec as {
+												cluster_column?: string | null;
+												metrics?: Array<{
+													icc?: number | null;
+													cv?: number | null;
+													avg_cluster_size?: number | null;
+												}>;
+											};
+											const pa = powerAnalyses?.analyses?.[0]?.metric_spec;
+											const clusterCol = ds.cluster_column;
+											const dsMetric = ds.metrics?.[0];
+											const icc = dsMetric?.icc ?? pa?.icc ?? null;
+											const cv = dsMetric?.cv ?? pa?.cv ?? null;
+											const avg =
+												dsMetric?.avg_cluster_size ??
+												pa?.avg_cluster_size ??
+												null;
+											// Show cluster block if we have ANY cluster signal.
+											if (!clusterCol && icc == null && cv == null && avg == null) {
+												return undefined;
+											}
+											return {
+												// Cluster column name isn't persisted by the BE today
+												// (storage_format_converters.py drops it). Show an em
+												// dash rather than a confusing parenthetical until the
+												// BE storage is fixed.
+												field_name: clusterCol ?? "—",
+												icc: icc ?? "?",
+												cv: cv ?? "?",
+												avg_cluster_size: avg ?? "?",
+											};
+										})()}
+									/>
+								</>
+							)}
+							{isBanditSpec(designSpec) && (
+								<OutcomesPriorSection
+									priorType={designSpec.prior_type}
+									rewardType={designSpec.reward_type}
+								/>
+							)}
+							{isCmabSpec(designSpec) && (
+								<ContextsSection contexts={designSpec.contexts ?? []} />
+							)}
+							{webhookIds.length > 0 && (
+								<WebhooksSection webhookIds={webhookIds} />
+							)}
+						</Flex>
+					</Box>
+					<Flex gap="3" justify="end">
+						<Dialog.Close>
+							<Button variant="soft" color="gray">
+								Close
+							</Button>
+						</Dialog.Close>
+					</Flex>
+				</Flex>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
 }

--- a/src/components/features/experiments/targeting-dialog.tsx
+++ b/src/components/features/experiments/targeting-dialog.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  BayesABExperimentSpecOutput,
   CMABExperimentSpecOutput,
   DataType,
   DesignSpecOutput,
@@ -55,10 +54,8 @@ const isFrequentistSpec = (
 
 const isBanditSpec = (
   spec: DesignSpecOutput,
-): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput | BayesABExperimentSpecOutput =>
-  spec.experiment_type === 'mab_online' ||
-  spec.experiment_type === 'cmab_online' ||
-  spec.experiment_type === 'bayes_ab_online';
+): spec is MABExperimentSpecOutput | CMABExperimentSpecOutput =>
+  spec.experiment_type === 'mab_online' || spec.experiment_type === 'cmab_online';
 
 const isCmabSpec = (spec: DesignSpecOutput): spec is CMABExperimentSpecOutput => spec.experiment_type === 'cmab_online';
 
@@ -135,13 +132,13 @@ export function TargetingDialog({ designSpec, participantType, webhookIds, power
                     strata={designSpec.strata?.map((stratum) => stratum.field_name) ?? []}
                     cluster={(() => {
                       // Issue #217: surface cluster fields on the Targeting modal.
-                      // The BE on PR #163 does NOT persist cluster_column or the
+                      // The BE on PR #163 does NOT persist cluster_key or the
                       // per-metric icc/cv/avg_cluster_size onto design_spec — but
                       // the per-metric stats ARE preserved inside the stored
                       // power_analyses JSON blob. We read from design_spec when
                       // present (forward-compat) and otherwise fall back.
                       const ds = designSpec as {
-                        cluster_column?: string | null;
+                        cluster_key?: string | null;
                         metrics?: Array<{
                           icc?: number | null;
                           cv?: number | null;
@@ -149,21 +146,17 @@ export function TargetingDialog({ designSpec, participantType, webhookIds, power
                         }>;
                       };
                       const pa = powerAnalyses?.analyses?.[0]?.metric_spec;
-                      const clusterCol = ds.cluster_column;
+                      const clusterKey = ds.cluster_key;
                       const dsMetric = ds.metrics?.[0];
                       const icc = dsMetric?.icc ?? pa?.icc ?? null;
                       const cv = dsMetric?.cv ?? pa?.cv ?? null;
                       const avg = dsMetric?.avg_cluster_size ?? pa?.avg_cluster_size ?? null;
                       // Show cluster block if we have ANY cluster signal.
-                      if (!clusterCol && icc == null && cv == null && avg == null) {
+                      if (!clusterKey && icc == null && cv == null && avg == null) {
                         return undefined;
                       }
                       return {
-                        // Cluster column name isn't persisted by the BE today
-                        // (storage_format_converters.py drops it). Show an em
-                        // dash rather than a confusing parenthetical until the
-                        // BE storage is fixed.
-                        field_name: clusterCol ?? '—',
+                        field_name: clusterKey ?? '—',
                         icc: icc ?? '?',
                         cv: cv ?? '?',
                         avg_cluster_size: avg ?? '?',


### PR DESCRIPTION
## Summary

Implements the frontend for cluster-randomized experiments per [issue #217 on evidential-be](https://github.com/agency-fund/evidential-be/issues/217).

A new **"Cluster Preassigned A/B Testing"** type is added to the Type screen alongside the existing four. It's an FE-only variant: at submit time it's translated to `freq_preassigned` with `cluster_column` set on the design spec. The regular Preassigned A/B Testing flow is **unchanged**.

## What's new (by surface)

| Surface | Change |
|---|---|
| **Type screen** | New "Cluster Preassigned A/B Testing" card |
| **Parameters page** | Strata section replaced by a Cluster section: cluster ID dropdown, ICC/CV/Avg cluster size inputs with auto-calculate-from-datasource button, high-variability (CV > 0.5) warning |
| **Power Analysis** | Clusters-first display in success callout and primary metric card (Required / Available / Available non-null). Linked Clusters ↔ Participants inputs with 500ms debounce on the "Use custom sample size" option. Mockup CV warning copy |
| **Arms & Allocations** | Green clusters total badge in section header + Clusters column in the table |
| **Summary page** | Cluster ID / ICC / CV / Avg cluster size rows in Metrics section, DEFF row in Power & Balance, clusters-first sample-size display, per-arm cluster badges |
| **Targeting & Design modal** | Cluster ID / ICC / CV / Avg cluster size rows added when the experiment is cluster-randomized |
| **Experiment Details — Analysis bar** | New ICC pill with tooltip (`"Intraclass Correlation Coefficient: measures how similar participants within the same cluster are. Higher values reduce statistical power."`) |
| **MME → Target MDE** | Renamed on `MdeBadge` and the Power Analysis DataList label, per the issue's rename ask |

## Backend dependencies

This PR cannot be fully tested end-to-end without the following BE PRs landing first:

1. **agency-fund/evidential-be#163** — cluster API surface (`cluster_column` on the design spec, `icc`/`cv`/`avg_cluster_size` on metrics, cluster handling in `power_check`).
2. **Follow-up storage PR (TBD)** — persists `cluster_column` on `tables.Experiment` so it survives save/load. Without this, cluster experiments load with `cluster_column` missing from the response and the FE has to fall back to `power_analyses` signals (which this PR handles gracefully — see `cluster-detection.ts`).
3. **agency-fund/evidential-be#201** — adds `pct_change_with_desired_n` to `MetricPowerAnalysis`, required to avoid the 422 the FE was hitting when posting `power_analyses` back during create-experiment.

## Notable implementation choices

- **`cluster-detection.ts`** centralises "is this a cluster experiment?" detection with a fallback chain (`design_spec.cluster_column` → `power_analyses.analyses[0].num_clusters_total / metric_spec.icc / design_effect`). This lets the UI work today even before the BE storage PR lands.
- **`methods.schemas.ts` has small manual additions** for cluster fields (`DesignSpecMetricRequestIcc`, `cluster_column` on the four frequentist spec interfaces, etc.) labeled with `(Manually added; not regenerated yet from PR #163 BE.)` comments. This was necessary because the local `npx orval` reports success but doesn't actually write files; once that environment issue is resolved, these patches should be removed and replaced with a clean regeneration.
- **`admin.zod.ts` is intentionally unpatched.** Adding cluster fields to that 376KB auto-generated file would have required ~50 surgical edits. Instead, in `experiment-freq-stack-screen.tsx`'s `handleCreate`, the cluster fields are re-injected onto the `createExperimentRequest` *after* the strict zod parse so they survive into the network request.

## Testing

- TypeScript: `npx tsc --noEmit --skipLibCheck` ✓
- Lint: `npm run lint` ✓
- Production build: `npm run build` ✓
- Manual end-to-end with the BE on `feature/cluster-api-layer` (PR #163's branch):
  - Created a Cluster Preassigned A/B Testing experiment with `school_id` as the cluster field
  - Verified auto-fill calculates ICC/CV/Avg from the datasource
  - Ran power check; verified clusters-first display and CV warning
  - Saved; verified the Summary cards show cluster fields and DEFF
  - Viewed the saved experiment; verified the "Cluster" badge, the green clusters total in Arms & Allocations, the Clusters column per arm, the ICC pill on the Analysis bar, and the cluster fields in the Targeting modal
- Manually verified the regular Preassigned A/B Testing type is unchanged (Strata section still appears, no cluster UI).

## Screenshots
Create experiment: 

<img width="611" height="293" alt="Screenshot 2026-05-13 at 9 59 50 AM" src="https://github.com/user-attachments/assets/e1b99230-1362-430c-9424-9541b8539c2f" />

<img width="598" height="442" alt="Screenshot 2026-05-13 at 10 00 18 AM" src="https://github.com/user-attachments/assets/6eae74b6-786c-4732-9c49-248fc1dd866a" />

<img width="610" height="774" alt="Screenshot 2026-05-13 at 10 00 35 AM" src="https://github.com/user-attachments/assets/1a18fe91-ae85-45b6-9eed-b3d554224b5f" />

<img width="603" height="597" alt="Screenshot 2026-05-13 at 10 00 44 AM" src="https://github.com/user-attachments/assets/b2bd9d56-7754-4d8e-8996-e44d6873d704" />


View experiment:

<img width="613" height="746" alt="Screenshot 2026-05-13 at 10 01 02 AM" src="https://github.com/user-attachments/assets/dac0ecc1-0ad7-493a-80dd-9621196c92d6" />

<img width="600" height="731" alt="Screenshot 2026-05-13 at 10 01 22 AM" src="https://github.com/user-attachments/assets/f62a6eab-732a-4701-879d-3163234e4dad" />

<img width="620" height="745" alt="Screenshot 2026-05-13 at 10 01 11 AM" src="https://github.com/user-attachments/assets/405511a5-33d6-4b8a-acf4-1ce87c2608ab" />





