### PR TITLE
Fix rendering of 'live' bug

### DIFF
--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { mutate } from 'swr';
@@ -94,19 +94,14 @@ export default function ExperimentViewPage() {
     effectSizesByMetric: undefined,
     banditEffects: undefined,
   });
-  // which analysis we're actually displaying (live or a snapshot)
-  const [selectedAnalysisState, setSelectedAnalysisState] = useState<AnalysisState>(liveAnalysis);
-  const selectedAnalysisKeyRef = useRef<AnalysisState['key']>(liveAnalysis.key);
-  const [selectedMetricAnalysis, setSelectedMetricAnalysis] = useState<MetricAnalysis | null>(null);
+  // The key of the selected analysis to display ('live' or a snapshot ID) in the Forest Plot.
+  const [selectedAnalysisKey, setSelectedAnalysisKey] = useState<AnalysisState['key'] | null>(null);
   const [selectedMetricName, setSelectedMetricName] = useState<string>('unknown');
   const [cmabAnalysisRequest, setCmabAnalysisRequest] = useState<CMABContextInputRequest>({
     type: 'cmab_assignment',
     context_inputs: [],
   });
   const cmabContextInputs = cmabAnalysisRequest.context_inputs ?? [];
-
-  // Track the min/max CI bounds across a recent window of snapshots for more stable forest plot display.
-  const [ciBounds, setCiBounds] = useState<[number | undefined, number | undefined]>([undefined, undefined]);
 
   const {
     data: experiment,
@@ -215,10 +210,6 @@ export default function ExperimentViewPage() {
 
           setLastErrorTimestamp(data.latest_failure === null ? null : new Date(data.latest_failure));
           setAnalysisHistory(history);
-          // If we're not viewing real data, set the selected analysis to the most recent snapshot
-          if (selectedAnalysisState.data === undefined) {
-            handleSelectedAnalysisAndMetrics(history[0], selectedMetricName, history);
-          }
         },
         onError: async () => {
           // Trigger live analysis if snapshot loading fails
@@ -235,43 +226,6 @@ export default function ExperimentViewPage() {
       },
     },
   });
-
-  const handleSelectedAnalysisAndMetrics = (
-    analysis: AnalysisState,
-    forMetricName: string | undefined = undefined,
-    historyOverride: AnalysisState[] | undefined = undefined,
-  ) => {
-    selectedAnalysisKeyRef.current = analysis.key;
-    setSelectedAnalysisState(analysis);
-    if (!isFrequentistAnalysis(analysis.data)) {
-      setSelectedMetricAnalysis(null);
-      return;
-    }
-
-    // Try to maintain the same metric as before when switching between snapshots.
-    // The fallback to the first metric should not actually happen in practice.
-    const nameToFind = forMetricName || selectedMetricName;
-    const metricAnalyses = analysis.data.metric_analyses;
-    const newMetric: MetricAnalysis | null =
-      metricAnalyses.find((metric) => metric.metric_name === nameToFind) || metricAnalyses[0] || null;
-    const newMetricName = newMetric?.metric_name || 'unknown';
-    // Recompute bounds if the metric changed
-    if (selectedMetricName !== newMetricName) {
-      setSelectedMetricName(newMetricName);
-
-      // First make a copy since we may mutate contents by adding live data.
-      const snapshotsToUse = [...(historyOverride || analysisHistory)];
-      // Include the live analysis if it has data.
-      if (analysis.key === 'live' && analysis.data) {
-        snapshotsToUse.push(analysis);
-      } else if (liveAnalysis.data) {
-        snapshotsToUse.push(liveAnalysis);
-      }
-      const bounds = computeBoundsForMetric(newMetricName, snapshotsToUse);
-      setCiBounds(bounds);
-    }
-    setSelectedMetricAnalysis(newMetric);
-  };
 
   // Wrapper around the live analysis functions for CMAB and non-CMAB experiments.
   const triggerLiveAnalysis = async (requestOverride?: CMABContextInputRequest) => {
@@ -290,24 +244,15 @@ export default function ExperimentViewPage() {
       banditEffects: precomputeBanditEffects(analysisData),
     };
     setLiveAnalysis(analysis);
-    // Use a ref so async success handlers don't rely on a stale selectedAnalysisState closure.
-    if (selectedAnalysisKeyRef.current === 'live') {
-      handleSelectedAnalysisAndMetrics(analysis);
-    }
   };
 
   const handleSelectAnalysis = async (key: string) => {
+    setSelectedAnalysisKey(key);
     if (key === 'live') {
       // If we haven't fetched it yet, trigger a live analysis.
       if (liveAnalysis.data === undefined) {
-        selectedAnalysisKeyRef.current = 'live';
         await triggerLiveAnalysis();
-        return;
       }
-      handleSelectedAnalysisAndMetrics(liveAnalysis);
-    } else {
-      const analysis = analysisHistory.find((opt) => opt.key === key) || liveAnalysis;
-      handleSelectedAnalysisAndMetrics(analysis);
     }
   };
 
@@ -320,6 +265,39 @@ export default function ExperimentViewPage() {
       console.warn('Cannot update context values for snapshot analyses.');
     }
   };
+
+  // Using this key, we derive the displayed analysis for the Forest Plot:
+  // selected analysis > first historical analysis > live.
+  const activeAnalysisKey = selectedAnalysisKey ?? analysisHistory[0]?.key ?? 'live';
+  // And if the selected key is stale, try to fall back to the first again else live.
+  const selectedAnalysisState: AnalysisState =
+    activeAnalysisKey === 'live'
+      ? liveAnalysis
+      : (analysisHistory.find((opt) => opt.key === activeAnalysisKey) ?? analysisHistory[0] ?? liveAnalysis);
+
+  // Get the list of metrics' analyses that may be displayed for dropdown selection.
+  const selectedMetricAnalyses = isFrequentistAnalysis(selectedAnalysisState.data)
+    ? selectedAnalysisState.data.metric_analyses
+    : null;
+
+  // Now look up the last selected metric's analysis from the selected state.
+  const selectedMetricAnalysis: MetricAnalysis | null = (() => {
+    if (!selectedMetricAnalyses) return null;
+    // The fallback to the first metric should not actually happen in practice, but just in case.
+    return (
+      selectedMetricAnalyses.find((metric) => metric.metric_name === selectedMetricName) ||
+      selectedMetricAnalyses[0] ||
+      null
+    );
+  })();
+
+  const activeMetricName = selectedMetricAnalysis?.metric_name || 'unknown';
+
+  // Track the min/max CI bounds across a recent window of snapshots for a more stable forest plot display.
+  const ciBounds: [number | undefined, number | undefined] = (() => {
+    const analysesForBounds = liveAnalysis.data ? [...analysisHistory, liveAnalysis] : analysisHistory;
+    return computeBoundsForMetric(activeMetricName, analysesForBounds);
+  })();
 
   const showLoadingAnalysisSpinner = isLoadingLiveAnalysis || isLoadingLiveCmabAnalysis || isLoadingHistory;
 
@@ -341,11 +319,6 @@ export default function ExperimentViewPage() {
   const isFrequentistExperiment = isFrequentistSpec(design_spec);
   const contexts = isBanditSpec(design_spec) ? (design_spec.contexts ?? []) : [];
 
-  const selectedMetricAnalyses =
-    selectedAnalysisState.data && 'metric_analyses' in selectedAnalysisState.data
-      ? selectedAnalysisState.data.metric_analyses
-      : null;
-
   // Calculate MDE percentage for the selected metric
   let mdePct: string | null = null;
   if (selectedMetricAnalysis?.metric?.metric_pct_change) {
@@ -354,7 +327,7 @@ export default function ExperimentViewPage() {
 
   const { timeseriesData, armMetadata, minDate, maxDate } = transformAnalysisForForestTimeseriesPlot(
     analysisHistory,
-    selectedMetricName,
+    activeMetricName,
   );
 
   const isLastSnapshotErrorRelevant =
@@ -507,9 +480,9 @@ export default function ExperimentViewPage() {
                       {selectedMetricAnalyses && selectedMetricAnalyses.length > 1 ? (
                         <Select.Root
                           size="1"
-                          value={selectedMetricName}
+                          value={activeMetricName}
                           onValueChange={(metricName) => {
-                            handleSelectedAnalysisAndMetrics(selectedAnalysisState, metricName);
+                            setSelectedMetricName(metricName);
                           }}
                         >
                           <Select.Trigger style={{ height: 18 }} />
@@ -524,7 +497,7 @@ export default function ExperimentViewPage() {
                           </Select.Content>
                         </Select.Root>
                       ) : (
-                        <Text>{selectedMetricName}</Text>
+                        <Text>{activeMetricName}</Text>
                       )}
                     </Flex>
                   </Badge>
@@ -568,7 +541,7 @@ export default function ExperimentViewPage() {
                       <Text>{liveAnalysis.label}</Text>
                     ) : (
                       <>
-                        <Select.Root size="1" value={selectedAnalysisState.key} onValueChange={handleSelectAnalysis}>
+                        <Select.Root size="1" value={activeAnalysisKey} onValueChange={handleSelectAnalysis}>
                           <Select.Trigger style={{ height: 18 }} />
                           <Select.Content>
                             <Select.Group>
@@ -673,7 +646,7 @@ export default function ExperimentViewPage() {
 
                     {selectedAnalysisState.data && (
                       <ForestPlot
-                        effectSizes={selectedAnalysisState.effectSizesByMetric?.get(selectedMetricName)}
+                        effectSizes={selectedAnalysisState.effectSizesByMetric?.get(activeMetricName)}
                         banditEffects={selectedAnalysisState.banditEffects}
                         minX={ciBounds[0]}
                         maxX={ciBounds[1]}

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -77,6 +77,58 @@ import { PowerAndBalanceDialog } from '@/components/features/experiments/power-a
 
 const SNAPSHOT_ERROR_ALERT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
+/**
+ * Returns the metric's analysis corresponding to the selectedMetricName from a list of analyses.
+ * This list should normally come from the selected AnalysisState.
+ *
+ * If no analysis is found for the selectedMetricName, falls back to the first metric available.
+ * This could happen e.g. when the selection is null on the first page load.
+ */
+function resolveSelectedMetricAnalysis(
+  selectedMetricAnalyses: MetricAnalysis[] | null,
+  selectedMetricName: string | null,
+): MetricAnalysis | null {
+  if (!selectedMetricAnalyses) return null;
+
+  const selectedMetric = selectedMetricAnalyses.find((metric) => metric.metric_name === selectedMetricName);
+  if (selectedMetric) return selectedMetric;
+
+  return selectedMetricAnalyses[0] ?? null;
+}
+
+/**
+ * Fallback metric name to use as the active metric if there even were no metric analyses available,
+ * as can happen when viewing 'live' data that has not been fetched yet.
+ */
+function resolveFallbackMetricName(
+  selectedMetricAnalyses: MetricAnalysis[] | null,
+  analysisHistory: AnalysisState[],
+  liveAnalysisData: ExperimentAnalysisResponse | undefined,
+): string | undefined {
+  const historicalMetricAnalyses = isFrequentistAnalysis(analysisHistory[0]?.data)
+    ? analysisHistory[0].data.metric_analyses
+    : null;
+  const liveMetricAnalyses = isFrequentistAnalysis(liveAnalysisData) ? liveAnalysisData.metric_analyses : null;
+  return (
+    selectedMetricAnalyses?.[0]?.metric_name ??
+    historicalMetricAnalyses?.[0]?.metric_name ??
+    liveMetricAnalyses?.[0]?.metric_name ??
+    undefined
+  );
+}
+
+/**
+ * Derives min/max CI bounds for more stable plot axes from a recent window of snapshots.
+ */
+function computeCiBoundsForForestPlot(
+  activeMetricName: string | undefined,
+  analysisHistory: AnalysisState[],
+  liveAnalysis: AnalysisState,
+): ReturnType<typeof computeBoundsForMetric> {
+  const analysesForBounds = liveAnalysis.data ? [...analysisHistory, liveAnalysis] : analysisHistory;
+  return computeBoundsForMetric(activeMetricName, analysesForBounds);
+}
+
 export default function ExperimentViewPage() {
   const params = useParams();
   const orgCtx = useCurrentOrganization();
@@ -271,7 +323,7 @@ export default function ExperimentViewPage() {
   const activeAnalysisKey = selectedAnalysisKey ?? analysisHistory[0]?.key ?? 'live';
 
   // And if the selected key is stale, try to fall back to the first again else live.
-  const selectedAnalysisState: AnalysisState =
+  const selectedAnalysisState =
     activeAnalysisKey === 'live'
       ? liveAnalysis
       : (analysisHistory.find((opt) => opt.key === activeAnalysisKey) ?? analysisHistory[0] ?? liveAnalysis);
@@ -281,40 +333,17 @@ export default function ExperimentViewPage() {
     ? selectedAnalysisState.data.metric_analyses
     : null;
 
-  // Now look up the last selected metric's analysis from the selected state.
-  const selectedMetricAnalysis: MetricAnalysis | null = (() => {
-    if (!selectedMetricAnalyses) return null;
+  const selectedMetricAnalysis = resolveSelectedMetricAnalysis(selectedMetricAnalyses, selectedMetricName);
 
-    const selectedMetric = selectedMetricAnalyses.find((metric) => metric.metric_name === selectedMetricName);
-    if (selectedMetric) return selectedMetric;
-
-    // Fall back to the first metric available in the selected state; possible when
-    // selectedMetricName is null to start.
-    return selectedMetricAnalyses[0] || null;
-  })();
-
-  // Fallback metric name to use as the active metric if there even were no metric analyses
-  // available, as can happen when viewing 'live' data that has not been fetched yet.
-  const fallbackMetricName = (() => {
-    const historicalMetricAnalyses = isFrequentistAnalysis(analysisHistory[0]?.data)
-      ? analysisHistory[0].data.metric_analyses
-      : null;
-    const liveMetricAnalyses = isFrequentistAnalysis(liveAnalysis.data) ? liveAnalysis.data.metric_analyses : null;
-    return (
-      selectedMetricAnalyses?.[0]?.metric_name ??
-      historicalMetricAnalyses?.[0]?.metric_name ??
-      liveMetricAnalyses?.[0]?.metric_name ??
-      undefined
-    );
-  })();
+  const fallbackMetricName = resolveFallbackMetricName(selectedMetricAnalyses, analysisHistory, liveAnalysis.data);
 
   const activeMetricName = selectedMetricAnalysis?.metric_name ?? fallbackMetricName;
 
-  // Track the min/max CI bounds across a recent window of snapshots for a more stable forest plot display.
-  const ciBounds: [number | undefined, number | undefined] = (() => {
-    const analysesForBounds = liveAnalysis.data ? [...analysisHistory, liveAnalysis] : analysisHistory;
-    return computeBoundsForMetric(activeMetricName, analysesForBounds);
-  })();
+  const activeMetricEffectSizes = activeMetricName
+    ? selectedAnalysisState.effectSizesByMetric?.get(activeMetricName)
+    : undefined;
+
+  const ciBounds = computeCiBoundsForForestPlot(activeMetricName, analysisHistory, liveAnalysis);
 
   const showLoadingAnalysisSpinner = isLoadingLiveAnalysis || isLoadingLiveCmabAnalysis || isLoadingHistory;
 
@@ -663,11 +692,7 @@ export default function ExperimentViewPage() {
 
                     {selectedAnalysisState.data && (
                       <ForestPlot
-                        effectSizes={
-                          activeMetricName
-                            ? selectedAnalysisState.effectSizesByMetric?.get(activeMetricName)
-                            : undefined
-                        }
+                        effectSizes={activeMetricEffectSizes}
                         banditEffects={selectedAnalysisState.banditEffects}
                         minX={ciBounds[0]}
                         maxX={ciBounds[1]}

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { mutate } from 'swr';
@@ -96,6 +96,7 @@ export default function ExperimentViewPage() {
   });
   // which analysis we're actually displaying (live or a snapshot)
   const [selectedAnalysisState, setSelectedAnalysisState] = useState<AnalysisState>(liveAnalysis);
+  const selectedAnalysisKeyRef = useRef<AnalysisState['key']>(liveAnalysis.key);
   const [selectedMetricAnalysis, setSelectedMetricAnalysis] = useState<MetricAnalysis | null>(null);
   const [selectedMetricName, setSelectedMetricName] = useState<string>('unknown');
   const [cmabAnalysisRequest, setCmabAnalysisRequest] = useState<CMABContextInputRequest>({
@@ -240,6 +241,7 @@ export default function ExperimentViewPage() {
     forMetricName: string | undefined = undefined,
     historyOverride: AnalysisState[] | undefined = undefined,
   ) => {
+    selectedAnalysisKeyRef.current = analysis.key;
     setSelectedAnalysisState(analysis);
     if (!isFrequentistAnalysis(analysis.data)) {
       setSelectedMetricAnalysis(null);
@@ -288,8 +290,8 @@ export default function ExperimentViewPage() {
       banditEffects: precomputeBanditEffects(analysisData),
     };
     setLiveAnalysis(analysis);
-    // Only update the display if we were previously viewing live data.
-    if (selectedAnalysisState.key === 'live') {
+    // Use a ref so async success handlers don't rely on a stale selectedAnalysisState closure.
+    if (selectedAnalysisKeyRef.current === 'live') {
       handleSelectedAnalysisAndMetrics(analysis);
     }
   };
@@ -298,7 +300,9 @@ export default function ExperimentViewPage() {
     if (key === 'live') {
       // If we haven't fetched it yet, trigger a live analysis.
       if (liveAnalysis.data === undefined) {
+        selectedAnalysisKeyRef.current = 'live';
         await triggerLiveAnalysis();
+        return;
       }
       handleSelectedAnalysisAndMetrics(liveAnalysis);
     } else {

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -96,7 +96,7 @@ export default function ExperimentViewPage() {
   });
   // The key of the selected analysis to display ('live' or a snapshot ID) in the Forest Plot.
   const [selectedAnalysisKey, setSelectedAnalysisKey] = useState<AnalysisState['key'] | null>(null);
-  const [selectedMetricName, setSelectedMetricName] = useState<string>('unknown');
+  const [selectedMetricName, setSelectedMetricName] = useState<string | null>(null);
   const [cmabAnalysisRequest, setCmabAnalysisRequest] = useState<CMABContextInputRequest>({
     type: 'cmab_assignment',
     context_inputs: [],
@@ -269,6 +269,7 @@ export default function ExperimentViewPage() {
   // Using this key, we derive the displayed analysis for the Forest Plot:
   // selected analysis > first historical analysis > live.
   const activeAnalysisKey = selectedAnalysisKey ?? analysisHistory[0]?.key ?? 'live';
+
   // And if the selected key is stale, try to fall back to the first again else live.
   const selectedAnalysisState: AnalysisState =
     activeAnalysisKey === 'live'
@@ -283,15 +284,31 @@ export default function ExperimentViewPage() {
   // Now look up the last selected metric's analysis from the selected state.
   const selectedMetricAnalysis: MetricAnalysis | null = (() => {
     if (!selectedMetricAnalyses) return null;
-    // The fallback to the first metric should not actually happen in practice, but just in case.
+
+    const selectedMetric = selectedMetricAnalyses.find((metric) => metric.metric_name === selectedMetricName);
+    if (selectedMetric) return selectedMetric;
+
+    // Fall back to the first metric available in the selected state; possible when
+    // selectedMetricName is null to start.
+    return selectedMetricAnalyses[0] || null;
+  })();
+
+  // Fallback metric name to use as the active metric if there even were no metric analyses
+  // available, as can happen when viewing 'live' data that has not been fetched yet.
+  const fallbackMetricName = (() => {
+    const historicalMetricAnalyses = isFrequentistAnalysis(analysisHistory[0]?.data)
+      ? analysisHistory[0].data.metric_analyses
+      : null;
+    const liveMetricAnalyses = isFrequentistAnalysis(liveAnalysis.data) ? liveAnalysis.data.metric_analyses : null;
     return (
-      selectedMetricAnalyses.find((metric) => metric.metric_name === selectedMetricName) ||
-      selectedMetricAnalyses[0] ||
-      null
+      selectedMetricAnalyses?.[0]?.metric_name ??
+      historicalMetricAnalyses?.[0]?.metric_name ??
+      liveMetricAnalyses?.[0]?.metric_name ??
+      undefined
     );
   })();
 
-  const activeMetricName = selectedMetricAnalysis?.metric_name || 'unknown';
+  const activeMetricName = selectedMetricAnalysis?.metric_name ?? fallbackMetricName;
 
   // Track the min/max CI bounds across a recent window of snapshots for a more stable forest plot display.
   const ciBounds: [number | undefined, number | undefined] = (() => {
@@ -480,7 +497,7 @@ export default function ExperimentViewPage() {
                       {selectedMetricAnalyses && selectedMetricAnalyses.length > 1 ? (
                         <Select.Root
                           size="1"
-                          value={activeMetricName}
+                          value={activeMetricName ?? undefined}
                           onValueChange={(metricName) => {
                             setSelectedMetricName(metricName);
                           }}
@@ -497,7 +514,7 @@ export default function ExperimentViewPage() {
                           </Select.Content>
                         </Select.Root>
                       ) : (
-                        <Text>{activeMetricName}</Text>
+                        <Text>{activeMetricName ?? 'Unknown Metric'}</Text>
                       )}
                     </Flex>
                   </Badge>
@@ -646,7 +663,11 @@ export default function ExperimentViewPage() {
 
                     {selectedAnalysisState.data && (
                       <ForestPlot
-                        effectSizes={selectedAnalysisState.effectSizesByMetric?.get(activeMetricName)}
+                        effectSizes={
+                          activeMetricName
+                            ? selectedAnalysisState.effectSizesByMetric?.get(activeMetricName)
+                            : undefined
+                        }
                         banditEffects={selectedAnalysisState.banditEffects}
                         minX={ciBounds[0]}
                         maxX={ciBounds[1]}

--- a/src/components/features/experiments/plots/forest-plot-utils.tsx
+++ b/src/components/features/experiments/plots/forest-plot-utils.tsx
@@ -413,13 +413,14 @@ export const getColorWithSignificance = (
  */
 export const transformAnalysisForForestTimeseriesPlot = (
   analysisStates: AnalysisState[],
-  metricName: string,
+  metricName: string | undefined,
 ): {
   timeseriesData: TimeSeriesDataPoint[];
   armMetadata: ArmMetadata[];
   minDate: Date;
   maxDate: Date;
 } => {
+  metricName = metricName ?? '';
   const timeseriesData: TimeSeriesDataPoint[] = [];
 
   // Sort by date ascending (oldest to newest)

--- a/src/components/features/experiments/plots/forest-timeseries-plot.tsx
+++ b/src/components/features/experiments/plots/forest-timeseries-plot.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { Box, Callout, Card, Flex, Text } from '@radix-ui/themes';
+import { Box, Callout, Card, Flex, Heading, Text } from '@radix-ui/themes';
 import {
   CartesianGrid,
   Legend,
@@ -160,113 +160,118 @@ export default function ForestTimeseriesPlot({
       : [allDateTicks[0] - minWidth / 2, allDateTicks[0] + minWidth / 2];
 
   return (
-    <Box height={`${height}px`} overflowY="clip" overflowX="auto">
-      <ResponsiveContainer height="100%" minWidth={`${minWidth}px`}>
-        <LineChart data={chartData} margin={{ top: 20, right: 30, bottom: 20, left: 20 }}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis
-            dataKey="dateTimestampMs"
-            type="number"
-            domain={domainXAxis}
-            ticks={allDateTicks}
-            style={COMMON_AXIS_STYLE}
-            // WARNING: If we offset the axis with padding, we need to also factor in the reduced
-            // plot width in the lines and CIs! Arguably a bug in recharts' useOffset hook?
-            padding={{ left: 0, right: 0 }}
-            interval="preserveStartEnd"
-            angle={-30}
-            textAnchor="end"
-            height={40}
-            tickFormatter={(timestamp) => {
-              const date = new Date(timestamp);
-              return formatDateUtcYYYYMMDD(date);
-            }}
-          />
-          <YAxis
-            domain={[minY, maxY]}
-            style={COMMON_AXIS_STYLE}
-            tickFormatter={(value) =>
-              // Show <= 2 decimal places only for values < 10
-              Math.abs(value) >= 10 || value === 0
-                ? value.toFixed()
-                : Math.abs(value) >= 1
-                  ? value.toFixed(1)
-                  : value.toFixed(2)
-            }
-          />
-          <Tooltip
-            content={(props) => (
-              <CustomTimeseriesTooltip {...props} armMetadata={armMetadata} selectedArmId={selectedArmId} />
-            )}
-          />
-          <Legend
-            wrapperStyle={{
-              position: 'fixed', // 1. Break it out of the chart's flow
-              left: '50%', // 2. Position it relative to the viewport
-              transform: 'translateX(-50%)', // 3. Center it based on its own width
-              zIndex: 1000, // 4. Ensure it's above other page content
-              cursor: 'pointer',
-              // Allow the legend to wrap to multiple lines if the text is too long:
-              whiteSpace: 'normal',
-              width: '100%',
-              paddingBottom: '20px',
-            }}
-            formatter={(value) => {
-              // value is the name passed to the line, i.e. the arm id
-              const index = armMetadata.findIndex((arm) => arm.id === value);
-              const arm = armMetadata[index];
-              const textColorEnum = getArmColorEnumForText(index, arm.isBaseline);
-              const selected = arm.name === selectedArmName;
+    <Flex direction="column" gap="3">
+      <Heading size="2" align="center" mt="5">
+        Historical Means
+      </Heading>
+      <Box height={`${height}px`} overflowY="clip" overflowX="auto">
+        <ResponsiveContainer height="100%" minWidth={`${minWidth}px`}>
+          <LineChart data={chartData} margin={{ top: 20, right: 30, bottom: 20, left: 20 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="dateTimestampMs"
+              type="number"
+              domain={domainXAxis}
+              ticks={allDateTicks}
+              style={COMMON_AXIS_STYLE}
+              // WARNING: If we offset the axis with padding, we need to also factor in the reduced
+              // plot width in the lines and CIs! Arguably a bug in recharts' useOffset hook?
+              padding={{ left: 0, right: 0 }}
+              interval="preserveStartEnd"
+              angle={-30}
+              textAnchor="end"
+              height={40}
+              tickFormatter={(timestamp) => {
+                const date = new Date(timestamp);
+                return formatDateUtcYYYYMMDD(date);
+              }}
+            />
+            <YAxis
+              domain={[minY, maxY]}
+              style={COMMON_AXIS_STYLE}
+              tickFormatter={(value) =>
+                // Show <= 2 decimal places only for values < 10
+                Math.abs(value) >= 10 || value === 0
+                  ? value.toFixed()
+                  : Math.abs(value) >= 1
+                    ? value.toFixed(1)
+                    : value.toFixed(2)
+              }
+            />
+            <Tooltip
+              content={(props) => (
+                <CustomTimeseriesTooltip {...props} armMetadata={armMetadata} selectedArmId={selectedArmId} />
+              )}
+            />
+            <Legend
+              wrapperStyle={{
+                position: 'fixed', // 1. Break it out of the chart's flow
+                left: '50%', // 2. Position it relative to the viewport
+                transform: 'translateX(-50%)', // 3. Center it based on its own width
+                zIndex: 1000, // 4. Ensure it's above other page content
+                cursor: 'pointer',
+                // Allow the legend to wrap to multiple lines if the text is too long:
+                whiteSpace: 'normal',
+                width: '100%',
+                paddingBottom: '20px',
+              }}
+              formatter={(value) => {
+                // value is the name passed to the line, i.e. the arm id
+                const index = armMetadata.findIndex((arm) => arm.id === value);
+                const arm = armMetadata[index];
+                const textColorEnum = getArmColorEnumForText(index, arm.isBaseline);
+                const selected = arm.name === selectedArmName;
+                return (
+                  <Text size="3" weight={selected ? 'bold' : 'regular'} color={textColorEnum} key={arm.id}>
+                    {arm.name}
+                  </Text>
+                );
+              }}
+              onClick={(data) => {
+                setSelectedArmId(data.value ?? null);
+              }}
+            />
+
+            {/* Render jittered line segments with dots for each arm */}
+            {armMetadata.map((armInfo, index) => {
+              const selected = selectedArmId === armInfo.id;
+              // Always emphasize dots (use true for isSelected in getArmColor)
+              const baseDotColor = getArmColor(index, armInfo.isBaseline, true);
+              const fillDotColor = getColorWithSignificance(baseDotColor, Significance.No, selected);
               return (
-                <Text size="3" weight={selected ? 'bold' : 'regular'} color={textColorEnum} key={arm.id}>
-                  {arm.name}
-                </Text>
+                <JitteredLine
+                  key={`line_${armInfo.id}`}
+                  data={armPointsMap.get(armInfo.id) || []}
+                  dataKey="dateTimestampMs"
+                  xDomain={domainXAxis}
+                  jitterOffset={calculateJitterOffset(index, armMetadata.length)}
+                  color={getArmColor(index, armInfo.isBaseline, selected)}
+                  name={armInfo.id}
+                  showDots
+                  dotConfig={{ fill: fillDotColor, stroke: baseDotColor }}
+                  activeDotConfig={{ fill: fillDotColor, stroke: baseDotColor }}
+                  onPointClick={(tsDataPoint) => handlePointClick(armInfo.id, tsDataPoint.key)}
+                />
               );
-            }}
-            onClick={(data) => {
-              setSelectedArmId(data.value ?? null);
-            }}
-          />
+            })}
 
-          {/* Render jittered line segments with dots for each arm */}
-          {armMetadata.map((armInfo, index) => {
-            const selected = selectedArmId === armInfo.id;
-            // Always emphasize dots (use true for isSelected in getArmColor)
-            const baseDotColor = getArmColor(index, armInfo.isBaseline, true);
-            const fillDotColor = getColorWithSignificance(baseDotColor, Significance.No, selected);
-            return (
-              <JitteredLine
-                key={`line_${armInfo.id}`}
-                data={armPointsMap.get(armInfo.id) || []}
-                dataKey="dateTimestampMs"
-                xDomain={domainXAxis}
-                jitterOffset={calculateJitterOffset(index, armMetadata.length)}
-                color={getArmColor(index, armInfo.isBaseline, selected)}
-                name={armInfo.id}
-                showDots
-                dotConfig={{ fill: fillDotColor, stroke: baseDotColor }}
-                activeDotConfig={{ fill: fillDotColor, stroke: baseDotColor }}
-                onPointClick={(tsDataPoint) => handlePointClick(armInfo.id, tsDataPoint.key)}
-              />
-            );
-          })}
-
-          {/* Render confidence intervals for each arm */}
-          {armMetadata.map((armInfo, index) => {
-            const selected = selectedArmId === armInfo.id;
-            return (
-              <ConfidenceInterval
-                key={`ci_${armInfo.id}`}
-                chartData={chartData}
-                armId={armInfo.id}
-                baseColor={getArmColor(index, armInfo.isBaseline, selected)}
-                jitterOffset={calculateJitterOffset(index, armMetadata.length)}
-                onClick={(tsDataPoint) => handlePointClick(armInfo.id, tsDataPoint.key)}
-              />
-            );
-          })}
-        </LineChart>
-      </ResponsiveContainer>
-    </Box>
+            {/* Render confidence intervals for each arm */}
+            {armMetadata.map((armInfo, index) => {
+              const selected = selectedArmId === armInfo.id;
+              return (
+                <ConfidenceInterval
+                  key={`ci_${armInfo.id}`}
+                  chartData={chartData}
+                  armId={armInfo.id}
+                  baseColor={getArmColor(index, armInfo.isBaseline, selected)}
+                  jitterOffset={calculateJitterOffset(index, armMetadata.length)}
+                  onClick={(tsDataPoint) => handlePointClick(armInfo.id, tsDataPoint.key)}
+                />
+              );
+            })}
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+    </Flex>
   );
 }


### PR DESCRIPTION
## Description

Fixes a stale render of bad 'live' state. (Original bug: in the Viewing dropdown, selecting live data to view would fetch the live analysis, but not render anything to the screen after loading completed.)

Introduces a new selectedAnalysisKey representing what snapshot (live or historical) a user wishes to see, and derives selectedAnalysisState, selectedMetricAnalysis, and CI bounds from existing react-managed state.

Review of timeseries plot code will be simpler if you ignore the indenting (&w=1) due to the addition of a <Flex>.

### Future Tasks (optional)

Experiment details page.tsx could use further state simplification and splitting out some child components.

## How has this been tested?

Manually, in particular selecting 'LIVE' after loading a page and its timeseries.

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts
