### PR TITLE
Add a reusable debounce hook.

### DIFF
--- a/src/components/features/organizations/create-organization-dialog.tsx
+++ b/src/components/features/organizations/create-organization-dialog.tsx
@@ -1,10 +1,10 @@
 'use client';
-import { getListOrganizationsKey, useCreateOrganizations } from '@/api/admin';
+import { useCreateOrganizations } from '@/api/admin';
 import { useState } from 'react';
 import { Button, Dialog, Flex, Text, TextField } from '@radix-ui/themes';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { PlusIcon } from '@radix-ui/react-icons';
-import { mutate } from 'swr';
+import { invalidatePath } from '@/services/swr-cache';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 
 interface FormFields {
@@ -23,7 +23,7 @@ export function CreateOrganizationDialog() {
     swr: {
       onSuccess: async () => {
         handleClose();
-        await mutate(getListOrganizationsKey());
+        await invalidatePath('/v1/m/organizations');
       },
     },
   });

--- a/src/providers/use-debounced.ts
+++ b/src/providers/use-debounced.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/** Returns `value`, updated only after `delay` ms have elapsed without a new change. */
+export function useDebounced<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/services/swr-cache.ts
+++ b/src/services/swr-cache.ts
@@ -1,0 +1,25 @@
+import { mutate } from 'swr';
+
+/**
+ * Invalidate every SWR cache entry whose key starts with one of the given URL path prefixes,
+ * optionally excluding specific exact-match paths.
+ *
+ * Generated SWR keys are tuples shaped like [`/v1/m/<resource>`, params?]. Calling
+ * `mutate(getXxxKey())` only revalidates the no-params variant; pages that subscribe with query
+ * params (pagination, filters, scopes) keep stale data. This helper matches by path prefix so a
+ * mutation handler can refresh every parameterized variant in one call.
+ *
+ * The optional `exclude` list takes exact key paths to skip — useful when an item is being deleted
+ * (so we want to refresh /v1/m/users but not revalidate /v1/m/users/{deletedId} into a 404).
+ */
+export const invalidatePath = (prefixes: string | string[], exclude?: string[]) => {
+  const prefixList = Array.isArray(prefixes) ? prefixes : [prefixes];
+  const excludeSet = exclude ? new Set(exclude) : null;
+  return mutate(
+    (key) =>
+      Array.isArray(key) &&
+      typeof key[0] === 'string' &&
+      !excludeSet?.has(key[0]) &&
+      prefixList.some((prefix) => key[0].startsWith(prefix)),
+  );
+};


### PR DESCRIPTION
Two reusable helpers:

* `invalidatePath` matches every SWR cache key whose path starts with one
of the given prefixes, optionally excluding exact paths. Generated SWR
keys are tuples shaped like [path, params?], so mutate(getXxxKey())
only revalidates the no-params variant; this helper refreshes every
parameterized variant in one call.

* `useDebounced<T>(value, delay)` returns the value updated only after the
delay has elapsed without a new change. 

This is one of a series of PRs that support new functionality for managing
users. Upcoming PRs will depend on this functionality.
