### PR TITLE
Invite new users to create an organization.

### DIFF
--- a/src/components/layout/header/header-bar.tsx
+++ b/src/components/layout/header/header-bar.tsx
@@ -73,19 +73,15 @@ export function HeaderBar() {
                     setDropdownOpen('organizations');
                   }}
                 >
-                  <BackpackIcon /> Organizations
+                  <BackpackIcon /> Switch Organization
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator />
               </>
             )}
-            {auth.isPrivileged && (
-              <>
-                <DropdownMenu.Item onClick={() => router.push('/organizations')}>
-                  <GearIcon /> Manage Organizations
-                </DropdownMenu.Item>
-                <DropdownMenu.Separator />
-              </>
-            )}
+            <DropdownMenu.Item onClick={() => router.push('/organizations')}>
+              <GearIcon /> Manage Organizations
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator />
 
             <DropdownMenu.Item asChild>
               <a href={XNGIN_API_DOCS_LINK} target="_blank" rel="noopener noreferrer">

--- a/src/providers/organization-provider.tsx
+++ b/src/providers/organization-provider.tsx
@@ -5,12 +5,13 @@ import { createContext, PropsWithChildren, useContext, useEffect } from 'react';
 import { useListOrganizations } from '@/api/admin';
 import { useAuth } from '@/providers/auth-provider';
 import { useLocalStorage } from '@/providers/use-local-storage';
-import { Button, Callout, Flex, Text } from '@radix-ui/themes';
+import { Button, Callout, Flex, Heading, Text } from '@radix-ui/themes';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ApiError } from '@/services/orval-fetch';
 import { SUPPORT_EMAIL } from '@/services/constants';
+import { CreateOrganizationDialog } from '@/components/features/organizations/create-organization-dialog';
 
 export const CURRENT_ORG_ID_KEY = 'org_id' as const;
 
@@ -79,7 +80,15 @@ export function OrganizationProvider({ children }: PropsWithChildren) {
 
   const organizations = orgsList.items;
   if (organizations.length === 0) {
-    return <Text>Sorry, you are not a member of any organizations.</Text>;
+    return (
+      <Flex direction="column" gap="3" align="center" py="6">
+        <Heading size="7">Welcome to Evidential.</Heading>
+        <Text size="3" color="gray">
+          Create your first organization to get started.
+        </Text>
+        <CreateOrganizationDialog />
+      </Flex>
+    );
   }
 
   const currentOrgId = orgId ?? organizations[0].id;


### PR DESCRIPTION
Freshly invited users that are not a member of any organizations will now see a
"Welcome to Evidential / Create your first organization" panel.

Header dropdown moves "Manage Organizations" out of the privileged-
only block so all authenticated users can manage orgs they belong to.
Renames the org-switcher entry from "Organizations" to "Switch
Organization" to disambiguate from "Manage Organizations".

This is one of a series of PRs that support new functionality for managing
users. Upcoming PRs will depend on this functionality.
