### PR TITLE
Shave ~150KB from JS bundle, ~90KB from first page loads.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,6 +74,11 @@ tasks:
   build:
     desc: 'Production build of the NextJS application'
     cmd: npm run build
+  analyze:
+    desc: 'Production build with bundle-analyzer reports written to .next/analyze/{client,nodejs,edge}.html'
+    env:
+      ANALYZE: 'true'
+    cmd: npm run build
   railway-build:
     desc: 'Builds the Docker image used by the Railway deployment.'
     cmd: docker build -t evidential-fe -f Dockerfile.railway .

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -6,22 +6,6 @@ import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-
-  // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,4 +34,7 @@ export default withSentryConfig(bundleAnalyzer(nextConfig), {
   disableLogger: true,
   automaticVercelMonitors: false,
   telemetry: false,
+  bundleSizeOptimizations: {
+    excludeTracing: true,
+  },
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import { withSentryConfig } from '@sentry/nextjs';
+import withBundleAnalyzer from '@next/bundle-analyzer';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
@@ -14,7 +15,11 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(nextConfig, {
+const bundleAnalyzer = withBundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
+
+export default withSentryConfig(bundleAnalyzer(nextConfig), {
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'orval';
+import { OpenAPIObject } from 'openapi3-ts/oas30';
+import { JSONPath } from 'jsonpath-plus';
 
 // Rewrites orvalFetch imports to use @/ instead of relative paths.
 const rewriteImports = (filenames: string[]) => {
@@ -15,6 +17,46 @@ const rewriteImports = (filenames: string[]) => {
   }
 };
 
+// JSONPath expressions matching OpenAPI documentation fields anywhere in the spec.
+const STRIP_PATHS: ReadonlyArray<string> = [
+  '$..description',
+  '$..summary',
+  '$..example',
+  '$..examples',
+  '$..externalDocs',
+];
+
+// Keys whose immediate children are user-defined names rather than OpenAPI
+// keywords. We skip matches inside these maps so that an API field literally
+// named "description" (or a schema named "examples", etc.) isn't removed.
+const NAME_MAPS = new Set([
+  'callbacks',
+  'examples',
+  'headers',
+  'links',
+  'parameters',
+  'paths',
+  'properties',
+  'requestBodies',
+  'responses',
+  'schemas',
+  'securitySchemes',
+]);
+
+const removeOpenApiDocsZodCannotTreeshake = (doc: OpenAPIObject): OpenAPIObject => {
+  const cloned = structuredClone(doc);
+  for (const path of STRIP_PATHS) {
+    const matches = JSONPath({ path, json: cloned, resultType: 'all' });
+    for (const m of matches) {
+      const segments = m.pointer.split('/');
+      const grandparent = segments[segments.length - 2];
+      if (NAME_MAPS.has(grandparent)) continue;
+      m.parent[m.parentProperty] = '';
+    }
+  }
+  return cloned;
+};
+
 export default defineConfig({
   xnginapi: {
     input: {
@@ -22,6 +64,9 @@ export default defineConfig({
       filters: {
         mode: 'include',
         tags: ['Admin', 'Admin: Third-Party Tools Integrations'],
+      },
+      override: {
+        transformer: removeOpenApiDocsZodCannotTreeshake,
       },
     },
     hooks: {
@@ -51,6 +96,9 @@ export default defineConfig({
         mode: 'include',
         tags: ['Admin'],
       },
+      override: {
+        transformer: removeOpenApiDocsZodCannotTreeshake,
+      },
     },
     output: {
       client: 'zod',
@@ -59,6 +107,17 @@ export default defineConfig({
       target: './src/api/methods.ts',
       fileExtension: '.zod.ts',
       biome: true,
+      override: {
+        zod: {
+          generate: {
+            header: false,
+            param: false,
+            query: false,
+            response: false,
+            body: true,
+          },
+        },
+      },
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.5.18",
         "eslint-config-prettier": "^10.0.2",
+        "jsonpath-plus": "^10.4.0",
         "orval": "7.19.0",
         "prettier": "^3.6.2",
         "typescript": "^5"
@@ -10010,9 +10011,9 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
-      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
+        "@next/bundle-analyzer": "^16.2.6",
         "@types/node": "^22.14.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -553,6 +554,16 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1964,6 +1975,16 @@
         "jsep": "^0.4.0||^1.0.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.6.tgz",
+      "integrity": "sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.18",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.18.tgz",
@@ -3064,6 +3085,13 @@
         "lodash.uniq": "^4.5.0",
         "openapi3-ts": "4.5.0"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
       "version": "6.11.1",
@@ -6865,6 +6893,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -7719,6 +7760,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -7866,6 +7914,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -9215,6 +9270,22 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -9308,6 +9379,13 @@
       "dependencies": {
         "react-is": "^16.7.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http2-client": {
       "version": "1.3.5",
@@ -9683,6 +9761,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-reference": {
@@ -10435,6 +10523,16 @@
       "integrity": "sha512-GYVauZEbca8/zOhEiYOY9/uJeedYQld6co/GJFKOy//0c/4lDqk0zB549sBYqqV2iMuX+uHrY1E5zd8A2L+1Lw==",
       "license": "MIT"
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10864,6 +10962,16 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.0"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -12201,6 +12309,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12630,6 +12753,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -13193,6 +13326,44 @@
         }
       }
     },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
@@ -13366,6 +13537,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@next/bundle-analyzer": "^16.2.6",
     "@types/node": "^22.14.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.18",
     "eslint-config-prettier": "^10.0.2",
+    "jsonpath-plus": "^10.4.0",
     "orval": "7.19.0",
     "prettier": "^3.6.2",
     "typescript": "^5"

--- a/src/api/admin-third-party-tools-integrations.ts
+++ b/src/api/admin-third-party-tools-integrations.ts
@@ -28,13 +28,6 @@ import type { ErrorType } from "@/services/orval-fetch";
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
-/**
- * Sets (or rotates) the Turn.io API token for an organization.
-
-Creates a Turn connection for the organization if one does not yet exist, otherwise
-overwrites the existing token. An organization has at most one Turn connection.
- * @summary Set Organization Turn Connection
- */
 export const getSetOrganizationTurnConnectionUrl = (organizationId: string) => {
 	return `/v1/m/integrations/turn-connection/${organizationId}`;
 };
@@ -71,9 +64,6 @@ export type SetOrganizationTurnConnectionMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Set Organization Turn Connection
- */
 export const useSetOrganizationTurnConnection = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -106,13 +96,6 @@ export const useSetOrganizationTurnConnection = <
 		...query,
 	};
 };
-/**
- * Returns a preview of the organization's configured Turn.io API token.
-
-Raises 404 if no Turn connection has been configured for the organization (or if the
-organization does not exist / the user does not have access to it).
- * @summary Get Organization Turn Connection
- */
 export const getGetOrganizationTurnConnectionUrl = (
 	organizationId: string,
 	params?: GetOrganizationTurnConnectionParams,
@@ -162,9 +145,6 @@ export type GetOrganizationTurnConnectionQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Organization Turn Connection
- */
 export const useGetOrganizationTurnConnection = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -201,10 +181,6 @@ export const useGetOrganizationTurnConnection = <
 		...query,
 	};
 };
-/**
- * Removes an organization's Turn.io connection.
- * @summary Delete Turn Connection From Organization
- */
 export const getDeleteTurnConnectionFromOrganizationUrl = (
 	organizationId: string,
 	params?: DeleteTurnConnectionFromOrganizationParams,
@@ -267,9 +243,6 @@ export type DeleteTurnConnectionFromOrganizationMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Turn Connection From Organization
- */
 export const useDeleteTurnConnectionFromOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -304,13 +277,6 @@ export const useDeleteTurnConnectionFromOrganization = <
 		...query,
 	};
 };
-/**
- * Returns a {name: uuid} map of Turn.io journeys available to the organization.
-
-The result is cached on the TurnConnection row and refreshed when older than
-TURN_JOURNEYS_CACHE_TTL_SECONDS, or when the API token is rotated.
- * @summary Get Organization Turn Journeys
- */
 export const getGetOrganizationTurnJourneysUrl = (organizationId: string) => {
 	return `/v1/m/integrations/turn-connection/${organizationId}/journeys`;
 };
@@ -338,9 +304,6 @@ export type GetOrganizationTurnJourneysQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Organization Turn Journeys
- */
 export const useGetOrganizationTurnJourneys = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -374,10 +337,6 @@ export const useGetOrganizationTurnJourneys = <
 		...query,
 	};
 };
-/**
- * Adds or updates the mapping from each arm ID of the experiment to a Turn.io Journey ID.
- * @summary Set Turn Arm Journey Mapping
- */
 export const getSetTurnArmJourneyMappingUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -426,9 +385,6 @@ export type SetTurnArmJourneyMappingMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Set Turn Arm Journey Mapping
- */
 export const useSetTurnArmJourneyMapping = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -463,10 +419,6 @@ export const useSetTurnArmJourneyMapping = <
 		...query,
 	};
 };
-/**
- * Returns the current mapping from each arm ID of the experiment to a Turn.io Journey ID, if it exists.
- * @summary Get Turn Arm Journey Mapping
- */
 export const getGetTurnArmJourneyMappingUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -503,9 +455,6 @@ export type GetTurnArmJourneyMappingQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Turn Arm Journey Mapping
- */
 export const useGetTurnArmJourneyMapping = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -543,10 +492,6 @@ export const useGetTurnArmJourneyMapping = <
 		...query,
 	};
 };
-/**
- * Deletes the mapping from each arm ID of the experiment to a Turn.io Journey ID, if it exists.
- * @summary Delete Turn Arm Journey Mapping
- */
 export const getDeleteTurnArmJourneyMappingUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -614,9 +559,6 @@ export type DeleteTurnArmJourneyMappingMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Turn Arm Journey Mapping
- */
 export const useDeleteTurnArmJourneyMapping = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -79,10 +79,6 @@ import type { ErrorType } from "@/services/orval-fetch";
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
-/**
- * Returns basic metadata about the authenticated caller of this method.
- * @summary Caller Identity
- */
 export const getCallerIdentityUrl = () => {
 	return `/v1/m/caller-identity`;
 };
@@ -103,9 +99,6 @@ export type CallerIdentityQueryResult = NonNullable<
 >;
 export type CallerIdentityQueryError = ErrorType<HTTPExceptionError>;
 
-/**
- * @summary Caller Identity
- */
 export const useCallerIdentity = <
 	TError = ErrorType<HTTPExceptionError>,
 >(options?: {
@@ -133,10 +126,6 @@ export const useCallerIdentity = <
 		...query,
 	};
 };
-/**
- * Invalidates all previously created session tokens.
- * @summary Logout
- */
 export const getLogoutUrl = () => {
 	return `/v1/m/logout`;
 };
@@ -162,9 +151,6 @@ export type LogoutMutationResult = NonNullable<
 >;
 export type LogoutMutationError = ErrorType<HTTPExceptionError>;
 
-/**
- * @summary Logout
- */
 export const useLogout = <TError = ErrorType<HTTPExceptionError>>(options?: {
 	swr?: SWRMutationConfiguration<
 		Awaited<ReturnType<typeof logout>>,
@@ -187,10 +173,6 @@ export const useLogout = <TError = ErrorType<HTTPExceptionError>>(options?: {
 		...query,
 	};
 };
-/**
- * Fetches a snapshot by ID.
- * @summary Get Snapshot
- */
 export const getGetSnapshotUrl = (
 	organizationId: string,
 	datasourceId: string,
@@ -233,9 +215,6 @@ export type GetSnapshotQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Snapshot
- */
 export const useGetSnapshot = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -287,10 +266,6 @@ export const useGetSnapshot = <
 		...query,
 	};
 };
-/**
- * Deletes a snapshot.
- * @summary Delete Snapshot
- */
 export const getDeleteSnapshotUrl = (
 	organizationId: string,
 	datasourceId: string,
@@ -374,9 +349,6 @@ export type DeleteSnapshotMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Snapshot
- */
 export const useDeleteSnapshot = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -423,10 +395,6 @@ export const useDeleteSnapshot = <
 		...query,
 	};
 };
-/**
- * Lists snapshots for an experiment, ordered by timestamp.
- * @summary List Snapshots
- */
 export const getListSnapshotsUrl = (
 	organizationId: string,
 	datasourceId: string,
@@ -482,9 +450,6 @@ export type ListSnapshotsQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Snapshots
- */
 export const useListSnapshots = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -536,12 +501,6 @@ export const useListSnapshots = <
 		...query,
 	};
 };
-/**
- * Request the asynchronous creation of a snapshot for an experiment.
-
-Returns the ID of the snapshot. Poll get_snapshot until the job is completed.
- * @summary Create Snapshot
- */
 export const getCreateSnapshotUrl = (
 	organizationId: string,
 	datasourceId: string,
@@ -591,9 +550,6 @@ export type CreateSnapshotMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Create Snapshot
- */
 export const useCreateSnapshot = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -630,10 +586,6 @@ export const useCreateSnapshot = <
 		...query,
 	};
 };
-/**
- * Returns a list of organizations that the authenticated user is a member of.
- * @summary List Organizations
- */
 export const getListOrganizationsUrl = () => {
 	return `/v1/m/organizations`;
 };
@@ -654,9 +606,6 @@ export type ListOrganizationsQueryResult = NonNullable<
 >;
 export type ListOrganizationsQueryError = ErrorType<HTTPExceptionError>;
 
-/**
- * @summary List Organizations
- */
 export const useListOrganizations = <
 	TError = ErrorType<HTTPExceptionError>,
 >(options?: {
@@ -685,12 +634,6 @@ export const useListOrganizations = <
 		...query,
 	};
 };
-/**
- * Creates a new organization.
-
-Only privileged users can create organizations.
- * @summary Create Organizations
- */
 export const getCreateOrganizationsUrl = () => {
 	return `/v1/m/organizations`;
 };
@@ -724,9 +667,6 @@ export type CreateOrganizationsMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Create Organizations
- */
 export const useCreateOrganizations = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(options?: {
@@ -751,10 +691,6 @@ export const useCreateOrganizations = <
 		...query,
 	};
 };
-/**
- * Adds a Webhook to an organization.
- * @summary Add Webhook To Organization
- */
 export const getAddWebhookToOrganizationUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}/webhooks`;
 };
@@ -794,9 +730,6 @@ export type AddWebhookToOrganizationMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Add Webhook To Organization
- */
 export const useAddWebhookToOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -829,10 +762,6 @@ export const useAddWebhookToOrganization = <
 		...query,
 	};
 };
-/**
- * Lists all the webhooks for an organization.
- * @summary List Organization Webhooks
- */
 export const getListOrganizationWebhooksUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}/webhooks`;
 };
@@ -860,9 +789,6 @@ export type ListOrganizationWebhooksQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Organization Webhooks
- */
 export const useListOrganizationWebhooks = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -894,10 +820,6 @@ export const useListOrganizationWebhooks = <
 		...query,
 	};
 };
-/**
- * Updates a webhook's name and URL in an organization.
- * @summary Update Organization Webhook
- */
 export const getUpdateOrganizationWebhookUrl = (
 	organizationId: string,
 	webhookId: string,
@@ -943,9 +865,6 @@ export type UpdateOrganizationWebhookMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Update Organization Webhook
- */
 export const useUpdateOrganizationWebhook = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -980,10 +899,6 @@ export const useUpdateOrganizationWebhook = <
 		...query,
 	};
 };
-/**
- * Removes a Webhook from an organization.
- * @summary Delete Webhook From Organization
- */
 export const getDeleteWebhookFromOrganizationUrl = (
 	organizationId: string,
 	webhookId: string,
@@ -1051,9 +966,6 @@ export type DeleteWebhookFromOrganizationMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Webhook From Organization
- */
 export const useDeleteWebhookFromOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1094,10 +1006,6 @@ export const useDeleteWebhookFromOrganization = <
 		...query,
 	};
 };
-/**
- * Regenerates the auth token for a webhook in an organization.
- * @summary Regenerate Webhook Auth Token
- */
 export const getRegenerateWebhookAuthTokenUrl = (
 	organizationId: string,
 	webhookId: string,
@@ -1143,9 +1051,6 @@ export type RegenerateWebhookAuthTokenMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Regenerate Webhook Auth Token
- */
 export const useRegenerateWebhookAuthToken = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1180,10 +1085,6 @@ export const useRegenerateWebhookAuthToken = <
 		...query,
 	};
 };
-/**
- * Returns events in an organization, newest first.
- * @summary List Organization Events
- */
 export const getListOrganizationEventsUrl = (
 	organizationId: string,
 	params?: ListOrganizationEventsParams,
@@ -1233,9 +1134,6 @@ export type ListOrganizationEventsQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Organization Events
- */
 export const useListOrganizationEvents = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1270,12 +1168,6 @@ export const useListOrganizationEvents = <
 		...query,
 	};
 };
-/**
- * Adds a new member to an organization.
-
-The authenticated user must be part of the organization to add members.
- * @summary Add Member To Organization
- */
 export const getAddMemberToOrganizationUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}/members`;
 };
@@ -1311,9 +1203,6 @@ export type AddMemberToOrganizationMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Add Member To Organization
- */
 export const useAddMemberToOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1345,12 +1234,6 @@ export const useAddMemberToOrganization = <
 		...query,
 	};
 };
-/**
- * Removes a member from an organization.
-
-The authenticated user must be part of the organization to remove members.
- * @summary Remove Member From Organization
- */
 export const getRemoveMemberFromOrganizationUrl = (
 	organizationId: string,
 	userId: string,
@@ -1418,9 +1301,6 @@ export type RemoveMemberFromOrganizationMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Remove Member From Organization
- */
 export const useRemoveMemberFromOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1457,13 +1337,6 @@ export const useRemoveMemberFromOrganization = <
 		...query,
 	};
 };
-/**
- * Updates an organization's properties.
-
-The authenticated user must be a member of the organization.
-Currently only supports updating the organization name.
- * @summary Update Organization
- */
 export const getUpdateOrganizationUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}`;
 };
@@ -1499,9 +1372,6 @@ export type UpdateOrganizationMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Update Organization
- */
 export const useUpdateOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1533,12 +1403,6 @@ export const useUpdateOrganization = <
 		...query,
 	};
 };
-/**
- * Returns detailed information about a specific organization.
-
-The authenticated user must be a member of the organization.
- * @summary Get Organization
- */
 export const getGetOrganizationUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}`;
 };
@@ -1566,9 +1430,6 @@ export type GetOrganizationQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Organization
- */
 export const useGetOrganization = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1600,10 +1461,6 @@ export const useGetOrganization = <
 		...query,
 	};
 };
-/**
- * Returns a list of datasources accessible to the authenticated user for an org.
- * @summary List Organization Datasources
- */
 export const getListOrganizationDatasourcesUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}/datasources`;
 };
@@ -1631,9 +1488,6 @@ export type ListOrganizationDatasourcesQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Organization Datasources
- */
 export const useListOrganizationDatasources = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1667,10 +1521,6 @@ export const useListOrganizationDatasources = <
 		...query,
 	};
 };
-/**
- * Creates a new datasource for the specified organization.
- * @summary Create Datasource
- */
 export const getCreateDatasourceUrl = (params?: CreateDatasourceParams) => {
 	const normalizedParams = new URLSearchParams();
 
@@ -1719,9 +1569,6 @@ export type CreateDatasourceMutationError = ErrorType<
 	HTTPExceptionError | XHTTPValidationError | MessageError
 >;
 
-/**
- * @summary Create Datasource
- */
 export const useCreateDatasource = <
 	TError = ErrorType<HTTPExceptionError | XHTTPValidationError | MessageError>,
 >(
@@ -1749,9 +1596,6 @@ export const useCreateDatasource = <
 		...query,
 	};
 };
-/**
- * @summary Update Datasource
- */
 export const getUpdateDatasourceUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}`;
 };
@@ -1787,9 +1631,6 @@ export type UpdateDatasourceMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Update Datasource
- */
 export const useUpdateDatasource = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1821,10 +1662,6 @@ export const useUpdateDatasource = <
 		...query,
 	};
 };
-/**
- * Returns detailed information about a specific datasource.
- * @summary Get Datasource
- */
 export const getGetDatasourceUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}`;
 };
@@ -1849,9 +1686,6 @@ export type GetDatasourceQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Datasource
- */
 export const useGetDatasource = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -1883,10 +1717,6 @@ export const useGetDatasource = <
 		...query,
 	};
 };
-/**
- * Verifies connectivity to a datasource and returns a list of readable tables.
- * @summary Inspect Datasource
- */
 export const getInspectDatasourceUrl = (
 	datasourceId: string,
 	params?: InspectDatasourceParams,
@@ -1936,9 +1766,6 @@ export type InspectDatasourceQueryError = ErrorType<
 	HTTPExceptionError | MessageError | XHTTPValidationError
 >;
 
-/**
- * @summary Inspect Datasource
- */
 export const useInspectDatasource = <
 	TError = ErrorType<HTTPExceptionError | MessageError | XHTTPValidationError>,
 >(
@@ -1971,10 +1798,6 @@ export const useInspectDatasource = <
 		...query,
 	};
 };
-/**
- * Inspects a single table in a datasource and returns a summary of its fields.
- * @summary Inspect Table In Datasource
- */
 export const getInspectTableInDatasourceUrl = (
 	datasourceId: string,
 	tableName: string,
@@ -2027,9 +1850,6 @@ export type InspectTableInDatasourceQueryError = ErrorType<
 	HTTPExceptionError | MessageError | XHTTPValidationError
 >;
 
-/**
- * @summary Inspect Table In Datasource
- */
 export const useInspectTableInDatasource = <
 	TError = ErrorType<HTTPExceptionError | MessageError | XHTTPValidationError>,
 >(
@@ -2068,12 +1888,6 @@ export const useInspectTableInDatasource = <
 		...query,
 	};
 };
-/**
- * Deletes a datasource.
-
-The user must be a member of the organization that owns the datasource.
- * @summary Delete Datasource
- */
 export const getDeleteDatasourceUrl = (
 	organizationId: string,
 	datasourceId: string,
@@ -2136,9 +1950,6 @@ export type DeleteDatasourceMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Datasource
- */
 export const useDeleteDatasource = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2175,9 +1986,6 @@ export const useDeleteDatasource = <
 		...query,
 	};
 };
-/**
- * @summary List Participant Types
- */
 export const getListParticipantTypesUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}/participants`;
 };
@@ -2205,9 +2013,6 @@ export type ListParticipantTypesQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Participant Types
- */
 export const useListParticipantTypes = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2239,9 +2044,6 @@ export const useListParticipantTypes = <
 		...query,
 	};
 };
-/**
- * @summary Create Participant Type
- */
 export const getCreateParticipantTypeUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}/participants`;
 };
@@ -2280,9 +2082,6 @@ export type CreateParticipantTypeMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Create Participant Type
- */
 export const useCreateParticipantType = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2314,11 +2113,6 @@ export const useCreateParticipantType = <
 		...query,
 	};
 };
-/**
- * Returns filter, strata, and metric field metadata for a participant type, including exemplars for
-filter fields.
- * @summary Inspect Participant Types
- */
 export const getInspectParticipantTypesUrl = (
 	datasourceId: string,
 	participantId: string,
@@ -2371,9 +2165,6 @@ export type InspectParticipantTypesQueryError = ErrorType<
 	HTTPExceptionError | MessageError | XHTTPValidationError
 >;
 
-/**
- * @summary Inspect Participant Types
- */
 export const useInspectParticipantTypes = <
 	TError = ErrorType<HTTPExceptionError | MessageError | XHTTPValidationError>,
 >(
@@ -2417,9 +2208,6 @@ export const useInspectParticipantTypes = <
 		...query,
 	};
 };
-/**
- * @summary Get Participant Type
- */
 export const getGetParticipantTypeUrl = (
 	datasourceId: string,
 	participantId: string,
@@ -2454,9 +2242,6 @@ export type GetParticipantTypeQueryError = ErrorType<
 	HTTPExceptionError | MessageError | XHTTPValidationError
 >;
 
-/**
- * @summary Get Participant Type
- */
 export const useGetParticipantType = <
 	TError = ErrorType<HTTPExceptionError | MessageError | XHTTPValidationError>,
 >(
@@ -2492,9 +2277,6 @@ export const useGetParticipantType = <
 		...query,
 	};
 };
-/**
- * @summary Update Participant Type
- */
 export const getUpdateParticipantTypeUrl = (
 	datasourceId: string,
 	participantId: string,
@@ -2541,9 +2323,6 @@ export type UpdateParticipantTypeMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Update Participant Type
- */
 export const useUpdateParticipantType = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2578,9 +2357,6 @@ export const useUpdateParticipantType = <
 		...query,
 	};
 };
-/**
- * @summary Delete Participant
- */
 export const getDeleteParticipantUrl = (
 	datasourceId: string,
 	participantId: string,
@@ -2643,9 +2419,6 @@ export type DeleteParticipantMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Participant
- */
 export const useDeleteParticipant = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2682,10 +2455,6 @@ export const useDeleteParticipant = <
 		...query,
 	};
 };
-/**
- * Returns API keys that have access to the datasource.
- * @summary List Api Keys
- */
 export const getListApiKeysUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}/apikeys`;
 };
@@ -2710,9 +2479,6 @@ export type ListApiKeysQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Api Keys
- */
 export const useListApiKeys = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2744,12 +2510,6 @@ export const useListApiKeys = <
 		...query,
 	};
 };
-/**
- * Creates an API key for the specified datasource.
-
-The user must belong to the organization that owns the requested datasource.
- * @summary Create Api Key
- */
 export const getCreateApiKeyUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}/apikeys`;
 };
@@ -2782,9 +2542,6 @@ export type CreateApiKeyMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Create Api Key
- */
 export const useCreateApiKey = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2812,10 +2569,6 @@ export const useCreateApiKey = <
 		...query,
 	};
 };
-/**
- * Deletes the specified API key.
- * @summary Delete Api Key
- */
 export const getDeleteApiKeyUrl = (
 	datasourceId: string,
 	apiKeyId: string,
@@ -2875,9 +2628,6 @@ export type DeleteApiKeyMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Api Key
- */
 export const useDeleteApiKey = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -2914,10 +2664,6 @@ export const useDeleteApiKey = <
 		...query,
 	};
 };
-/**
- * Creates a new experiment in the specified datasource.
- * @summary Create Experiment
- */
 export const getCreateExperimentUrl = (
 	datasourceId: string,
 	params?: CreateExperimentParams,
@@ -2979,9 +2725,6 @@ export type CreateExperimentMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Create Experiment
- */
 export const useCreateExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3015,11 +2758,6 @@ export const useCreateExperiment = <
 		...query,
 	};
 };
-/**
- * For preassigned experiments, and online experiments (except contextual bandits),
-    returns an analysis of the experiment's performance, given datasource and experiment ID.
- * @summary Analyze Experiment
- */
 export const getAnalyzeExperimentUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3072,9 +2810,6 @@ export type AnalyzeExperimentQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Analyze Experiment
- */
 export const useAnalyzeExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3113,11 +2848,6 @@ export const useAnalyzeExperiment = <
 		...query,
 	};
 };
-/**
- * For contextual bandit experiments, returns an analysis of the experiment's performance,
-    given datasource and experiment ID and context values as input.
- * @summary Analyze Cmab Experiment
- */
 export const getAnalyzeCmabExperimentUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3166,9 +2896,6 @@ export type AnalyzeCmabExperimentMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Analyze Cmab Experiment
- */
 export const useAnalyzeCmabExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3203,9 +2930,6 @@ export const useAnalyzeCmabExperiment = <
 		...query,
 	};
 };
-/**
- * @summary Commit Experiment
- */
 export const getCommitExperimentUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3248,9 +2972,6 @@ export type CommitExperimentMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Commit Experiment
- */
 export const useCommitExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3285,9 +3006,6 @@ export const useCommitExperiment = <
 		...query,
 	};
 };
-/**
- * @summary Abandon Experiment
- */
 export const getAbandonExperimentUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3330,9 +3048,6 @@ export type AbandonExperimentMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Abandon Experiment
- */
 export const useAbandonExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3367,10 +3082,6 @@ export const useAbandonExperiment = <
 		...query,
 	};
 };
-/**
- * Returns a list of experiments in the organization.
- * @summary List Organization Experiments
- */
 export const getListOrganizationExperimentsUrl = (organizationId: string) => {
 	return `/v1/m/organizations/${organizationId}/experiments`;
 };
@@ -3398,9 +3109,6 @@ export type ListOrganizationExperimentsQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary List Organization Experiments
- */
 export const useListOrganizationExperiments = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3434,10 +3142,6 @@ export const useListOrganizationExperiments = <
 		...query,
 	};
 };
-/**
- * Returns the experiment with the specified ID.
- * @summary Get Experiment For Ui
- */
 export const getGetExperimentForUiUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3471,9 +3175,6 @@ export type GetExperimentForUiQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Get Experiment For Ui
- */
 export const useGetExperimentForUi = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3509,9 +3210,6 @@ export const useGetExperimentForUi = <
 		...query,
 	};
 };
-/**
- * @summary Update Experiment
- */
 export const getUpdateExperimentUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3554,9 +3252,6 @@ export type UpdateExperimentMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Update Experiment
- */
 export const useUpdateExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3591,10 +3286,6 @@ export const useUpdateExperiment = <
 		...query,
 	};
 };
-/**
- * Deletes the experiment with the specified ID.
- * @summary Delete Experiment
- */
 export const getDeleteExperimentUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3657,9 +3348,6 @@ export type DeleteExperimentMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Experiment
- */
 export const useDeleteExperiment = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3696,9 +3384,6 @@ export const useDeleteExperiment = <
 		...query,
 	};
 };
-/**
- * @summary Export experiment assignments as CSV file; BalanceCheck not included. csv header form: participant_id,arm_id,arm_name,strata_name1,strata_name2,...
- */
 export const getGetExperimentAssignmentsAsCsvForUiUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3735,9 +3420,6 @@ export type GetExperimentAssignmentsAsCsvForUiQueryError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Export experiment assignments as CSV file; BalanceCheck not included. csv header form: participant_id,arm_id,arm_name,strata_name1,strata_name2,...
- */
 export const useGetExperimentAssignmentsAsCsvForUi = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3779,10 +3461,6 @@ export const useGetExperimentAssignmentsAsCsvForUi = <
 		...query,
 	};
 };
-/**
- * Deletes specific data associated with an experiment.
- * @summary Delete Experiment Data
- */
 export const getDeleteExperimentDataUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3831,9 +3509,6 @@ export type DeleteExperimentDataMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Delete Experiment Data
- */
 export const useDeleteExperimentData = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3868,9 +3543,6 @@ export const useDeleteExperimentData = <
 		...query,
 	};
 };
-/**
- * @summary Update Arm
- */
 export const getUpdateArmUrl = (
 	datasourceId: string,
 	experimentId: string,
@@ -3920,9 +3592,6 @@ export type UpdateArmMutationError = ErrorType<
 	HTTPExceptionError | HTTPValidationError
 >;
 
-/**
- * @summary Update Arm
- */
 export const useUpdateArm = <
 	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
 >(
@@ -3959,10 +3628,6 @@ export const useUpdateArm = <
 		...query,
 	};
 };
-/**
- * Performs a power check for the specified datasource.
- * @summary Power Check
- */
 export const getPowerCheckUrl = (datasourceId: string) => {
 	return `/v1/m/datasources/${datasourceId}/power`;
 };
@@ -3998,9 +3663,6 @@ export type PowerCheckMutationError = ErrorType<
 	HTTPExceptionError | MessageError | XHTTPValidationError
 >;
 
-/**
- * @summary Power Check
- */
 export const usePowerCheck = <
 	TError = ErrorType<HTTPExceptionError | MessageError | XHTTPValidationError>,
 >(

--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -6,853 +6,10 @@
  */
 import * as zod from "zod";
 
-/**
- * Returns basic metadata about the authenticated caller of this method.
- * @summary Caller Identity
- */
-export const callerIdentityResponse = zod
-	.object({
-		email: zod.string(),
-		iss: zod.string(),
-		sub: zod.string(),
-		hd: zod.string(),
-		is_privileged: zod.boolean(),
-	})
-	.describe(
-		"Describes the user's identity in a format suitable for use in the frontend.",
-	);
-
-/**
- * Fetches a snapshot by ID.
- * @summary Get Snapshot
- */
-export const getSnapshotParams = zod.object({
-	organization_id: zod.string(),
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-	snapshot_id: zod.string(),
-});
-
-export const getSnapshotResponseSnapshotDataMetricAnalysesItemMetricFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getSnapshotResponseSnapshotDataMetricAnalysesItemArmAnalysesItemArmNameMax = 100;
-
-export const getSnapshotResponseSnapshotDataMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const getSnapshotResponseSnapshotDataMetricAnalysesItemArmAnalysesItemNumMissingValuesMin =
-	-1;
-
-export const getSnapshotResponseSnapshotDataArmAnalysesItemArmNameMax = 100;
-
-export const getSnapshotResponseSnapshotDataArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const getSnapshotResponse = zod
-	.object({
-		snapshot: zod.object({
-			experiment_id: zod
-				.string()
-				.describe("The experiment that this snapshot was captured for."),
-			id: zod.string().describe("The unique ID of the snapshot."),
-			status: zod
-				.enum(["success", "running", "failed"])
-				.describe("Describes the status of a snapshot."),
-			details: zod
-				.union([zod.record(zod.string(), zod.unknown()), zod.null()])
-				.describe("Additional data about this snapshot."),
-			created_at: zod
-				.string()
-				.datetime({})
-				.describe("The time the snapshot was requested."),
-			updated_at: zod
-				.string()
-				.datetime({})
-				.describe("The time the snapshot was acquired."),
-			data: zod
-				.union([
-					zod
-						.union([
-							zod
-								.object({
-									type: zod.enum(["freq"]),
-									experiment_id: zod.string().describe("ID of the experiment."),
-									metric_analyses: zod
-										.array(
-											zod
-												.object({
-													metric_name: zod.string(),
-													metric: zod
-														.object({
-															field_name: zod
-																.string()
-																.regex(
-																	getSnapshotResponseSnapshotDataMetricAnalysesItemMetricFieldNameRegExp,
-																),
-															metric_pct_change: zod
-																.union([zod.number(), zod.null()])
-																.optional()
-																.describe(
-																	"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-																),
-															metric_target: zod
-																.union([zod.number(), zod.null()])
-																.optional()
-																.describe(
-																	"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-																),
-														})
-														.describe(
-															"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-														),
-													arm_analyses: zod
-														.array(
-															zod.object({
-																arm_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-																	),
-																arm_name: zod
-																	.string()
-																	.max(
-																		getSnapshotResponseSnapshotDataMetricAnalysesItemArmAnalysesItemArmNameMax,
-																	),
-																arm_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				getSnapshotResponseSnapshotDataMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																arm_weight: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-																	),
-																estimate: zod
-																	.number()
-																	.describe(
-																		"The estimated treatment effect relative to the baseline arm.",
-																	),
-																p_value: zod
-																	.union([zod.number(), zod.null()])
-																	.describe(
-																		"The p-value indicating statistical significance of the treatment effect. Value may be None if the t-stat is not available, e.g. due to inability to calculate the standard error.",
-																	),
-																t_stat: zod
-																	.union([zod.number(), zod.null()])
-																	.describe(
-																		"The t-statistic from the statistical test. If the value is actually NaN, e.g. due to inability to calculate the standard error, we return None.",
-																	),
-																std_error: zod
-																	.union([zod.number(), zod.null()])
-																	.describe(
-																		"The standard error of the treatment effect estimate.",
-																	),
-																ci_lower: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval lower bound for the regression coefficient estimate.",
-																	),
-																ci_upper: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval upper bound for the regression coefficient estimate.",
-																	),
-																mean_ci_lower: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval lower bound for the arm's mean.",
-																	),
-																mean_ci_upper: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval upper bound for the arm's mean.",
-																	),
-																num_missing_values: zod
-																	.number()
-																	.min(
-																		getSnapshotResponseSnapshotDataMetricAnalysesItemArmAnalysesItemNumMissingValuesMin,
-																	)
-																	.describe(
-																		"The number of participants assigned to this arm with missing values (NaNs) for this metric. These rows are excluded from the analysis. -1 indicates arm analysis not available due to all assignments missing outcomes for this metric.",
-																	),
-																is_baseline: zod
-																	.boolean()
-																	.describe(
-																		"Whether this arm is the baseline/control arm for comparison.",
-																	),
-															}),
-														)
-														.describe(
-															"The results of the analysis for each arm (coefficient) for this specific metric.",
-														),
-												})
-												.describe(
-													"Describes the change in a single metric for each arm of an experiment.",
-												),
-										)
-										.describe(
-											"Contains one analysis per metric targeted by the experiment.",
-										),
-									num_participants: zod
-										.number()
-										.describe(
-											"The number of participants assigned to the experiment pulled from the dwh across all arms. Metric outcomes are not guaranteed to be present for all participants.",
-										),
-									num_missing_participants: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"The number of participants assigned to the experiment across all arms that are not found in the data warehouse when pulling metrics.",
-										),
-									created_at: zod
-										.string()
-										.datetime({})
-										.describe(
-											"The date and time the experiment analysis was created.",
-										),
-								})
-								.describe(
-									"Describes the change if any in metrics targeted by an experiment.",
-								),
-							zod
-								.object({
-									type: zod.enum(["bandit"]),
-									experiment_id: zod.string().describe("ID of the experiment."),
-									arm_analyses: zod
-										.array(
-											zod
-												.object({
-													arm_id: zod
-														.union([zod.string(), zod.null()])
-														.optional()
-														.describe(
-															"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-														),
-													arm_name: zod
-														.string()
-														.max(
-															getSnapshotResponseSnapshotDataArmAnalysesItemArmNameMax,
-														),
-													arm_description: zod
-														.union([
-															zod
-																.string()
-																.max(
-																	getSnapshotResponseSnapshotDataArmAnalysesItemArmDescriptionMaxOne,
-																),
-															zod.null(),
-														])
-														.optional(),
-													arm_weight: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-														),
-													alpha_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Initial alpha parameter for Beta prior"),
-													beta_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Initial beta parameter for Beta prior"),
-													mu_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Initial mean parameter for Normal prior",
-														),
-													sigma_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Initial standard deviation parameter for Normal prior",
-														),
-													alpha: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Updated alpha parameter for Beta prior"),
-													beta: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Updated beta parameter for Beta prior"),
-													mu: zod
-														.union([zod.array(zod.number()), zod.null()])
-														.optional()
-														.describe("Updated mean vector for Normal prior"),
-													covariance: zod
-														.union([
-															zod.array(zod.array(zod.number())),
-															zod.null(),
-														])
-														.optional()
-														.describe(
-															"Updated covariance matrix for Normal prior",
-														),
-													prior_pred_mean: zod
-														.number()
-														.describe("Prior predictive mean for this arm."),
-													prior_pred_stdev: zod
-														.number()
-														.describe(
-															"Prior predictive standard deviation for this arm.",
-														),
-													prior_pred_ci_upper: zod
-														.number()
-														.describe(
-															"Prior predictive upper bound of 95% confidence interval for this arm.",
-														),
-													prior_pred_ci_lower: zod
-														.number()
-														.describe(
-															"Prior predictive lower bound of 95% confidence interval for this arm.",
-														),
-													post_pred_mean: zod
-														.number()
-														.describe(
-															"Posterior predictive mean for this arm.",
-														),
-													post_pred_stdev: zod
-														.number()
-														.describe(
-															"Posterior predictive standard deviation for this arm.",
-														),
-													post_pred_ci_upper: zod
-														.number()
-														.describe(
-															"Posterior predictive upper bound of 95% confidence interval for this arm.",
-														),
-													post_pred_ci_lower: zod
-														.number()
-														.describe(
-															"Posterior predictive lower bound of 95% confidence interval for this arm.",
-														),
-												})
-												.describe(
-													"Describes an experiment arm analysis for bandit experiments.",
-												),
-										)
-										.describe(
-											"Contains one analysis per metric targeted by the experiment.",
-										),
-									n_outcomes: zod
-										.number()
-										.describe(
-											"The number of outcomes observed for this experiment.",
-										),
-									created_at: zod
-										.string()
-										.datetime({})
-										.describe(
-											"The date and time the experiment analysis was created.",
-										),
-									contexts: zod
-										.union([zod.array(zod.number()), zod.null()])
-										.optional()
-										.describe(
-											"The context values used for the analysis, if applicable.",
-										),
-								})
-								.describe("Describes changes in arms for a bandit experiment"),
-						])
-						.describe("The type of experiment analysis response."),
-					zod.null(),
-				])
-				.describe("Analysis results as of the updated_at time."),
-		}),
-	})
-	.describe("Describes the status and content of a snapshot.");
-
-/**
- * Deletes a snapshot.
- * @summary Delete Snapshot
- */
-export const deleteSnapshotParams = zod.object({
-	organization_id: zod.string(),
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-	snapshot_id: zod.string(),
-});
-
-export const deleteSnapshotQueryAllowMissingDefault = false;
-
-export const deleteSnapshotQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-export const deleteSnapshotResponse = zod.unknown();
-
-/**
- * Lists snapshots for an experiment, ordered by timestamp.
- * @summary List Snapshots
- */
-export const listSnapshotsParams = zod.object({
-	organization_id: zod.string(),
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-export const listSnapshotsQueryPageSizeDefault = 20;
-export const listSnapshotsQueryPageSizeMax = 100;
-
-export const listSnapshotsQuerySkipDefault = 0;
-export const listSnapshotsQuerySkipMin = 0;
-
-export const listSnapshotsQueryParams = zod.object({
-	status: zod
-		.union([
-			zod.array(
-				zod
-					.enum(["success", "running", "failed"])
-					.describe("Describes the status of a snapshot."),
-			),
-			zod.null(),
-		])
-		.optional()
-		.describe(
-			"Filter the returned snapshots to only those of this status. May be specified multiple times.",
-		),
-	page_size: zod
-		.number()
-		.min(1)
-		.max(listSnapshotsQueryPageSizeMax)
-		.default(listSnapshotsQueryPageSizeDefault)
-		.describe("Maximum number of items to return per page."),
-	page_token: zod
-		.union([zod.string(), zod.null()])
-		.optional()
-		.describe("Token from a previous response to fetch the next page."),
-	skip: zod
-		.number()
-		.min(listSnapshotsQuerySkipMin)
-		.optional()
-		.describe(
-			"Number of items to skip after page_token (or from the start when page_token is omitted).",
-		),
-});
-
-export const listSnapshotsResponseNextPageTokenDefault = "";
-export const listSnapshotsResponseItemsItemDataMetricAnalysesItemMetricFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listSnapshotsResponseItemsItemDataMetricAnalysesItemArmAnalysesItemArmNameMax = 100;
-
-export const listSnapshotsResponseItemsItemDataMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const listSnapshotsResponseItemsItemDataMetricAnalysesItemArmAnalysesItemNumMissingValuesMin =
-	-1;
-
-export const listSnapshotsResponseItemsItemDataArmAnalysesItemArmNameMax = 100;
-
-export const listSnapshotsResponseItemsItemDataArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const listSnapshotsResponse = zod.object({
-	next_page_token: zod
-		.string()
-		.optional()
-		.describe("Token to retrieve the next page. Empty when no more results."),
-	items: zod.array(
-		zod.object({
-			experiment_id: zod
-				.string()
-				.describe("The experiment that this snapshot was captured for."),
-			id: zod.string().describe("The unique ID of the snapshot."),
-			status: zod
-				.enum(["success", "running", "failed"])
-				.describe("Describes the status of a snapshot."),
-			details: zod
-				.union([zod.record(zod.string(), zod.unknown()), zod.null()])
-				.describe("Additional data about this snapshot."),
-			created_at: zod
-				.string()
-				.datetime({})
-				.describe("The time the snapshot was requested."),
-			updated_at: zod
-				.string()
-				.datetime({})
-				.describe("The time the snapshot was acquired."),
-			data: zod
-				.union([
-					zod
-						.union([
-							zod
-								.object({
-									type: zod.enum(["freq"]),
-									experiment_id: zod.string().describe("ID of the experiment."),
-									metric_analyses: zod
-										.array(
-											zod
-												.object({
-													metric_name: zod.string(),
-													metric: zod
-														.object({
-															field_name: zod
-																.string()
-																.regex(
-																	listSnapshotsResponseItemsItemDataMetricAnalysesItemMetricFieldNameRegExp,
-																),
-															metric_pct_change: zod
-																.union([zod.number(), zod.null()])
-																.optional()
-																.describe(
-																	"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-																),
-															metric_target: zod
-																.union([zod.number(), zod.null()])
-																.optional()
-																.describe(
-																	"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-																),
-														})
-														.describe(
-															"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-														),
-													arm_analyses: zod
-														.array(
-															zod.object({
-																arm_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-																	),
-																arm_name: zod
-																	.string()
-																	.max(
-																		listSnapshotsResponseItemsItemDataMetricAnalysesItemArmAnalysesItemArmNameMax,
-																	),
-																arm_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				listSnapshotsResponseItemsItemDataMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																arm_weight: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-																	),
-																estimate: zod
-																	.number()
-																	.describe(
-																		"The estimated treatment effect relative to the baseline arm.",
-																	),
-																p_value: zod
-																	.union([zod.number(), zod.null()])
-																	.describe(
-																		"The p-value indicating statistical significance of the treatment effect. Value may be None if the t-stat is not available, e.g. due to inability to calculate the standard error.",
-																	),
-																t_stat: zod
-																	.union([zod.number(), zod.null()])
-																	.describe(
-																		"The t-statistic from the statistical test. If the value is actually NaN, e.g. due to inability to calculate the standard error, we return None.",
-																	),
-																std_error: zod
-																	.union([zod.number(), zod.null()])
-																	.describe(
-																		"The standard error of the treatment effect estimate.",
-																	),
-																ci_lower: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval lower bound for the regression coefficient estimate.",
-																	),
-																ci_upper: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval upper bound for the regression coefficient estimate.",
-																	),
-																mean_ci_lower: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval lower bound for the arm's mean.",
-																	),
-																mean_ci_upper: zod
-																	.union([zod.number(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Confidence interval upper bound for the arm's mean.",
-																	),
-																num_missing_values: zod
-																	.number()
-																	.min(
-																		listSnapshotsResponseItemsItemDataMetricAnalysesItemArmAnalysesItemNumMissingValuesMin,
-																	)
-																	.describe(
-																		"The number of participants assigned to this arm with missing values (NaNs) for this metric. These rows are excluded from the analysis. -1 indicates arm analysis not available due to all assignments missing outcomes for this metric.",
-																	),
-																is_baseline: zod
-																	.boolean()
-																	.describe(
-																		"Whether this arm is the baseline/control arm for comparison.",
-																	),
-															}),
-														)
-														.describe(
-															"The results of the analysis for each arm (coefficient) for this specific metric.",
-														),
-												})
-												.describe(
-													"Describes the change in a single metric for each arm of an experiment.",
-												),
-										)
-										.describe(
-											"Contains one analysis per metric targeted by the experiment.",
-										),
-									num_participants: zod
-										.number()
-										.describe(
-											"The number of participants assigned to the experiment pulled from the dwh across all arms. Metric outcomes are not guaranteed to be present for all participants.",
-										),
-									num_missing_participants: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"The number of participants assigned to the experiment across all arms that are not found in the data warehouse when pulling metrics.",
-										),
-									created_at: zod
-										.string()
-										.datetime({})
-										.describe(
-											"The date and time the experiment analysis was created.",
-										),
-								})
-								.describe(
-									"Describes the change if any in metrics targeted by an experiment.",
-								),
-							zod
-								.object({
-									type: zod.enum(["bandit"]),
-									experiment_id: zod.string().describe("ID of the experiment."),
-									arm_analyses: zod
-										.array(
-											zod
-												.object({
-													arm_id: zod
-														.union([zod.string(), zod.null()])
-														.optional()
-														.describe(
-															"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-														),
-													arm_name: zod
-														.string()
-														.max(
-															listSnapshotsResponseItemsItemDataArmAnalysesItemArmNameMax,
-														),
-													arm_description: zod
-														.union([
-															zod
-																.string()
-																.max(
-																	listSnapshotsResponseItemsItemDataArmAnalysesItemArmDescriptionMaxOne,
-																),
-															zod.null(),
-														])
-														.optional(),
-													arm_weight: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-														),
-													alpha_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Initial alpha parameter for Beta prior"),
-													beta_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Initial beta parameter for Beta prior"),
-													mu_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Initial mean parameter for Normal prior",
-														),
-													sigma_init: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Initial standard deviation parameter for Normal prior",
-														),
-													alpha: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Updated alpha parameter for Beta prior"),
-													beta: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe("Updated beta parameter for Beta prior"),
-													mu: zod
-														.union([zod.array(zod.number()), zod.null()])
-														.optional()
-														.describe("Updated mean vector for Normal prior"),
-													covariance: zod
-														.union([
-															zod.array(zod.array(zod.number())),
-															zod.null(),
-														])
-														.optional()
-														.describe(
-															"Updated covariance matrix for Normal prior",
-														),
-													prior_pred_mean: zod
-														.number()
-														.describe("Prior predictive mean for this arm."),
-													prior_pred_stdev: zod
-														.number()
-														.describe(
-															"Prior predictive standard deviation for this arm.",
-														),
-													prior_pred_ci_upper: zod
-														.number()
-														.describe(
-															"Prior predictive upper bound of 95% confidence interval for this arm.",
-														),
-													prior_pred_ci_lower: zod
-														.number()
-														.describe(
-															"Prior predictive lower bound of 95% confidence interval for this arm.",
-														),
-													post_pred_mean: zod
-														.number()
-														.describe(
-															"Posterior predictive mean for this arm.",
-														),
-													post_pred_stdev: zod
-														.number()
-														.describe(
-															"Posterior predictive standard deviation for this arm.",
-														),
-													post_pred_ci_upper: zod
-														.number()
-														.describe(
-															"Posterior predictive upper bound of 95% confidence interval for this arm.",
-														),
-													post_pred_ci_lower: zod
-														.number()
-														.describe(
-															"Posterior predictive lower bound of 95% confidence interval for this arm.",
-														),
-												})
-												.describe(
-													"Describes an experiment arm analysis for bandit experiments.",
-												),
-										)
-										.describe(
-											"Contains one analysis per metric targeted by the experiment.",
-										),
-									n_outcomes: zod
-										.number()
-										.describe(
-											"The number of outcomes observed for this experiment.",
-										),
-									created_at: zod
-										.string()
-										.datetime({})
-										.describe(
-											"The date and time the experiment analysis was created.",
-										),
-									contexts: zod
-										.union([zod.array(zod.number()), zod.null()])
-										.optional()
-										.describe(
-											"The context values used for the analysis, if applicable.",
-										),
-								})
-								.describe("Describes changes in arms for a bandit experiment"),
-						])
-						.describe("The type of experiment analysis response."),
-					zod.null(),
-				])
-				.describe("Analysis results as of the updated_at time."),
-		}),
-	),
-	latest_failure: zod
-		.union([zod.string().datetime({}), zod.null()])
-		.describe(
-			"The timestamp of the latest snapshot that failed, or null if there have been no snapshot failures.",
-		),
-});
-
-/**
- * Request the asynchronous creation of a snapshot for an experiment.
-
-Returns the ID of the snapshot. Poll get_snapshot until the job is completed.
- * @summary Create Snapshot
- */
-export const createSnapshotParams = zod.object({
-	organization_id: zod.string(),
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-export const createSnapshotResponse = zod.object({
-	id: zod.string(),
-});
-
-/**
- * Returns a list of organizations that the authenticated user is a member of.
- * @summary List Organizations
- */
-export const listOrganizationsResponseItemsItemIdMax = 64;
-
-export const listOrganizationsResponseItemsItemNameMax = 100;
-
-export const listOrganizationsResponse = zod.object({
-	items: zod.array(
-		zod.object({
-			id: zod.string().max(listOrganizationsResponseItemsItemIdMax),
-			name: zod.string().max(listOrganizationsResponseItemsItemNameMax),
-		}),
-	),
-});
-
-/**
- * Creates a new organization.
-
-Only privileged users can create organizations.
- * @summary Create Organizations
- */
 export const createOrganizationsBodyNameMax = 100;
 
 export const createOrganizationsBody = zod.object({
 	name: zod.string().max(createOrganizationsBodyNameMax),
-});
-
-export const createOrganizationsResponseIdMax = 64;
-
-export const createOrganizationsResponse = zod.object({
-	id: zod.string().max(createOrganizationsResponseIdMax),
-});
-
-/**
- * Adds a Webhook to an organization.
- * @summary Add Webhook To Organization
- */
-export const addWebhookToOrganizationParams = zod.object({
-	organization_id: zod.string(),
 });
 
 export const addWebhookToOrganizationBodyNameMax = 100;
@@ -861,225 +18,21 @@ export const addWebhookToOrganizationBodyUrlMax = 500;
 
 export const addWebhookToOrganizationBody = zod.object({
 	type: zod.literal("experiment.created"),
-	name: zod
-		.string()
-		.max(addWebhookToOrganizationBodyNameMax)
-		.describe(
-			"User-friendly name for the webhook. This name is displayed in the UI and helps identify the webhook's purpose.",
-		),
-	url: zod
-		.string()
-		.max(addWebhookToOrganizationBodyUrlMax)
-		.describe(
-			"The HTTP or HTTPS URL that will receive webhook notifications when events occur.",
-		),
-});
-
-export const addWebhookToOrganizationResponse = zod
-	.object({
-		id: zod.string().describe("The ID of the newly created webhook."),
-		type: zod.string().describe("The type of webhook; e.g. experiment.created"),
-		name: zod.string().describe("User-friendly name for the webhook."),
-		url: zod.string().describe("The URL to notify."),
-		auth_token: zod
-			.union([zod.string(), zod.null()])
-			.describe(
-				"The value of the Webhook-Token: header that will be sent with the request to the configured URL.",
-			),
-	})
-	.describe("Information on the successfully created webhook.");
-
-/**
- * Lists all the webhooks for an organization.
- * @summary List Organization Webhooks
- */
-export const listOrganizationWebhooksParams = zod.object({
-	organization_id: zod.string(),
-});
-
-export const listOrganizationWebhooksResponse = zod.object({
-	items: zod.array(
-		zod
-			.object({
-				id: zod.string().describe("The ID of the webhook."),
-				type: zod
-					.string()
-					.describe("The type of webhook; e.g. experiment.created"),
-				name: zod.string().describe("User-friendly name for the webhook."),
-				url: zod.string().describe("The URL to notify."),
-				auth_token: zod
-					.union([zod.string(), zod.null()])
-					.describe(
-						"The value of the Webhook-Token: header that will be sent with the request to the configured URL.",
-					),
-			})
-			.describe("Summarizes a Webhook configuration for an organization."),
-	),
-});
-
-/**
- * Updates a webhook's name and URL in an organization.
- * @summary Update Organization Webhook
- */
-export const updateOrganizationWebhookParams = zod.object({
-	organization_id: zod.string(),
-	webhook_id: zod.string(),
+	name: zod.string().max(addWebhookToOrganizationBodyNameMax),
+	url: zod.string().max(addWebhookToOrganizationBodyUrlMax),
 });
 
 export const updateOrganizationWebhookBodyNameMax = 100;
 
 export const updateOrganizationWebhookBodyUrlMax = 500;
 
-export const updateOrganizationWebhookBody = zod
-	.object({
-		name: zod
-			.string()
-			.max(updateOrganizationWebhookBodyNameMax)
-			.describe(
-				"User-friendly name for the webhook. This name is displayed in the UI and helps identify the webhook's purpose.",
-			),
-		url: zod
-			.string()
-			.max(updateOrganizationWebhookBodyUrlMax)
-			.describe(
-				"The HTTP or HTTPS URL that will receive webhook notifications when events occur.",
-			),
-	})
-	.describe("Request to update a webhook's name and URL.");
-
-/**
- * Removes a Webhook from an organization.
- * @summary Delete Webhook From Organization
- */
-export const deleteWebhookFromOrganizationParams = zod.object({
-	organization_id: zod.string(),
-	webhook_id: zod.string(),
-});
-
-export const deleteWebhookFromOrganizationQueryAllowMissingDefault = false;
-
-export const deleteWebhookFromOrganizationQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-/**
- * Regenerates the auth token for a webhook in an organization.
- * @summary Regenerate Webhook Auth Token
- */
-export const regenerateWebhookAuthTokenParams = zod.object({
-	organization_id: zod.string(),
-	webhook_id: zod.string(),
-});
-
-/**
- * Returns events in an organization, newest first.
- * @summary List Organization Events
- */
-export const listOrganizationEventsParams = zod.object({
-	organization_id: zod.string(),
-});
-
-export const listOrganizationEventsQueryPageSizeDefault = 20;
-export const listOrganizationEventsQueryPageSizeMax = 100;
-
-export const listOrganizationEventsQuerySkipDefault = 0;
-export const listOrganizationEventsQuerySkipMin = 0;
-
-export const listOrganizationEventsQueryParams = zod.object({
-	page_size: zod
-		.number()
-		.min(1)
-		.max(listOrganizationEventsQueryPageSizeMax)
-		.default(listOrganizationEventsQueryPageSizeDefault)
-		.describe("Maximum number of items to return per page."),
-	page_token: zod
-		.union([zod.string(), zod.null()])
-		.optional()
-		.describe("Token from a previous response to fetch the next page."),
-	skip: zod
-		.number()
-		.min(listOrganizationEventsQuerySkipMin)
-		.optional()
-		.describe(
-			"Number of items to skip after page_token (or from the start when page_token is omitted).",
-		),
-});
-
-export const listOrganizationEventsResponseNextPageTokenDefault = "";
-
-export const listOrganizationEventsResponse = zod.object({
-	next_page_token: zod
-		.string()
-		.optional()
-		.describe("Token to retrieve the next page. Empty when no more results."),
-	items: zod.array(
-		zod
-			.object({
-				id: zod.string().describe("The ID of the event."),
-				created_at: zod
-					.string()
-					.datetime({})
-					.describe("The time the event was created."),
-				type: zod.string().describe("The type of event."),
-				summary: zod.string().describe("Human-readable summary of the event."),
-				link: zod
-					.union([zod.string(), zod.null()])
-					.optional()
-					.describe("A navigable link to related information."),
-				details: zod
-					.union([zod.record(zod.string(), zod.unknown()), zod.null()])
-					.describe("Details"),
-			})
-			.describe("Describes an event."),
-	),
-});
-
-/**
- * Adds a new member to an organization.
-
-The authenticated user must be part of the organization to add members.
- * @summary Add Member To Organization
- */
-export const addMemberToOrganizationParams = zod.object({
-	organization_id: zod.string(),
+export const updateOrganizationWebhookBody = zod.object({
+	name: zod.string().max(updateOrganizationWebhookBodyNameMax),
+	url: zod.string().max(updateOrganizationWebhookBodyUrlMax),
 });
 
 export const addMemberToOrganizationBody = zod.object({
 	email: zod.string(),
-});
-
-/**
- * Removes a member from an organization.
-
-The authenticated user must be part of the organization to remove members.
- * @summary Remove Member From Organization
- */
-export const removeMemberFromOrganizationParams = zod.object({
-	organization_id: zod.string(),
-	user_id: zod.string(),
-});
-
-export const removeMemberFromOrganizationQueryAllowMissingDefault = false;
-
-export const removeMemberFromOrganizationQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-/**
- * Updates an organization's properties.
-
-The authenticated user must be a member of the organization.
-Currently only supports updating the organization name.
- * @summary Update Organization
- */
-export const updateOrganizationParams = zod.object({
-	organization_id: zod.string(),
 });
 
 export const updateOrganizationBodyNameMaxOne = 100;
@@ -1088,111 +41,6 @@ export const updateOrganizationBody = zod.object({
 	name: zod
 		.union([zod.string().max(updateOrganizationBodyNameMaxOne), zod.null()])
 		.optional(),
-});
-
-export const updateOrganizationResponse = zod.unknown();
-
-/**
- * Returns detailed information about a specific organization.
-
-The authenticated user must be a member of the organization.
- * @summary Get Organization
- */
-export const getOrganizationParams = zod.object({
-	organization_id: zod.string(),
-});
-
-export const getOrganizationResponseIdMax = 64;
-
-export const getOrganizationResponseNameMax = 100;
-
-export const getOrganizationResponseUsersItemIdMax = 64;
-
-export const getOrganizationResponseUsersItemEmailMax = 64;
-
-export const getOrganizationResponseDatasourcesItemIdMax = 64;
-
-export const getOrganizationResponseDatasourcesItemNameMax = 100;
-
-export const getOrganizationResponseDatasourcesItemOrganizationIdMax = 64;
-
-export const getOrganizationResponseDatasourcesItemOrganizationNameMax = 100;
-
-export const getOrganizationResponse = zod.object({
-	id: zod.string().max(getOrganizationResponseIdMax),
-	name: zod.string().max(getOrganizationResponseNameMax),
-	users: zod.array(
-		zod.object({
-			id: zod.string().max(getOrganizationResponseUsersItemIdMax),
-			email: zod.string().max(getOrganizationResponseUsersItemEmailMax),
-		}),
-	),
-	datasources: zod.array(
-		zod.object({
-			id: zod.string().max(getOrganizationResponseDatasourcesItemIdMax),
-			name: zod.string().max(getOrganizationResponseDatasourcesItemNameMax),
-			driver: zod.string(),
-			type: zod.string(),
-			organization_id: zod
-				.string()
-				.max(getOrganizationResponseDatasourcesItemOrganizationIdMax),
-			organization_name: zod
-				.string()
-				.max(getOrganizationResponseDatasourcesItemOrganizationNameMax),
-		}),
-	),
-});
-
-/**
- * Returns a list of datasources accessible to the authenticated user for an org.
- * @summary List Organization Datasources
- */
-export const listOrganizationDatasourcesParams = zod.object({
-	organization_id: zod.string(),
-});
-
-export const listOrganizationDatasourcesResponseItemsItemIdMax = 64;
-
-export const listOrganizationDatasourcesResponseItemsItemNameMax = 100;
-
-export const listOrganizationDatasourcesResponseItemsItemOrganizationIdMax = 64;
-
-export const listOrganizationDatasourcesResponseItemsItemOrganizationNameMax = 100;
-
-export const listOrganizationDatasourcesResponse = zod.object({
-	items: zod
-		.array(
-			zod.object({
-				id: zod.string().max(listOrganizationDatasourcesResponseItemsItemIdMax),
-				name: zod
-					.string()
-					.max(listOrganizationDatasourcesResponseItemsItemNameMax),
-				driver: zod.string(),
-				type: zod.string(),
-				organization_id: zod
-					.string()
-					.max(listOrganizationDatasourcesResponseItemsItemOrganizationIdMax),
-				organization_name: zod
-					.string()
-					.max(listOrganizationDatasourcesResponseItemsItemOrganizationNameMax),
-			}),
-		)
-		.describe(
-			"Descriptions of the datasources in this organization, ordered in descending order of frequency of use.",
-		),
-});
-
-/**
- * Creates a new datasource for the specified organization.
- * @summary Create Datasource
- */
-export const createDatasourceQueryConnectivityCheckDefault = false;
-
-export const createDatasourceQueryParams = zod.object({
-	connectivity_check: zod
-		.boolean()
-		.optional()
-		.describe("When true, validate datasource connectivity before creation."),
 });
 
 export const createDatasourceBodyOrganizationIdMax = 64;
@@ -1229,148 +77,88 @@ export const createDatasourceBody = zod.object({
 	organization_id: zod.string().max(createDatasourceBodyOrganizationIdMax),
 	name: zod.string(),
 	dsn: zod.union([
-		zod
-			.object({
-				type: zod.enum(["api_only"]),
-			})
-			.describe(
-				"ApiOnlyDsn describes a datasource where data is included in Evidential API requests.",
-			),
-		zod
-			.object({
-				type: zod.enum(["postgres"]),
-				host: zod.string(),
-				port: zod
-					.number()
-					.min(createDatasourceBodyDsnPortMin)
-					.max(createDatasourceBodyDsnPortMax),
-				user: zod.string(),
-				password: zod
-					.union([
-						zod
-							.object({
-								type: zod
-									.literal("revealed")
-									.default(createDatasourceBodyDsnPasswordTypeDefault),
-								value: zod.string(),
-							})
-							.describe("RevealedStr contains a credential."),
-						zod
-							.object({
-								type: zod
-									.literal("hidden")
-									.default(createDatasourceBodyDsnPasswordTypeDefaultOne),
-							})
-							.describe(
-								"Hidden represents a credential that is intentionally omitted.",
-							),
-					])
-					.describe(
-						"This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-					),
-				dbname: zod.string(),
-				sslmode: zod.enum(["disable", "require", "verify-ca", "verify-full"]),
-				search_path: zod.union([zod.string(), zod.null()]),
-			})
-			.describe(
-				"PostgresDsn describes a connection to a Postgres-compatible database.",
-			),
-		zod
-			.object({
-				type: zod.enum(["bigquery"]),
-				project_id: zod
-					.string()
-					.min(createDatasourceBodyDsnProjectIdMin)
-					.max(createDatasourceBodyDsnProjectIdMax)
-					.regex(createDatasourceBodyDsnProjectIdRegExp)
-					.describe("The Google Cloud Project ID containing the dataset."),
-				dataset_id: zod
-					.string()
-					.min(1)
-					.max(createDatasourceBodyDsnDatasetIdMax)
-					.regex(createDatasourceBodyDsnDatasetIdRegExp)
-					.describe("The dataset name."),
-				credentials: zod
-					.union([
-						zod
-							.object({
-								type: zod
-									.literal("serviceaccountinfo")
-									.default(createDatasourceBodyDsnCredentialsTypeDefault),
-								content: zod
-									.string()
-									.min(createDatasourceBodyDsnCredentialsContentMin)
-									.max(createDatasourceBodyDsnCredentialsContentMax)
-									.describe(
-										"The service account info in the canonical JSON form. Required fields: type, project_id, private_key_id, private_key, client_email.",
-									),
-							})
-							.describe("Describes a Google Cloud Platform service account."),
-						zod
-							.object({
-								type: zod
-									.literal("hidden")
-									.default(createDatasourceBodyDsnCredentialsTypeDefaultOne),
-							})
-							.describe(
-								"Hidden represents a credential that is intentionally omitted.",
-							),
-					])
-					.describe(
-						"This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-					),
-			})
-			.describe("BqDsn describes a connection to a BigQuery database."),
-		zod
-			.object({
-				type: zod.enum(["redshift"]),
-				host: zod.string(),
-				port: zod
-					.number()
-					.min(createDatasourceBodyDsnPortMinOne)
-					.max(createDatasourceBodyDsnPortMaxOne),
-				user: zod.string(),
-				password: zod
-					.union([
-						zod
-							.object({
-								type: zod
-									.literal("revealed")
-									.default(createDatasourceBodyDsnPasswordTypeDefaultTwo),
-								value: zod.string(),
-							})
-							.describe("RevealedStr contains a credential."),
-						zod
-							.object({
-								type: zod
-									.literal("hidden")
-									.default(createDatasourceBodyDsnPasswordTypeDefaultThree),
-							})
-							.describe(
-								"Hidden represents a credential that is intentionally omitted.",
-							),
-					])
-					.describe(
-						"This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-					),
-				dbname: zod.string(),
-				search_path: zod.union([zod.string(), zod.null()]),
-			})
-			.describe("RedshiftDsn describes a connection to a Redshift database."),
+		zod.object({
+			type: zod.enum(["api_only"]),
+		}),
+		zod.object({
+			type: zod.enum(["postgres"]),
+			host: zod.string(),
+			port: zod
+				.number()
+				.min(createDatasourceBodyDsnPortMin)
+				.max(createDatasourceBodyDsnPortMax),
+			user: zod.string(),
+			password: zod.union([
+				zod.object({
+					type: zod
+						.literal("revealed")
+						.default(createDatasourceBodyDsnPasswordTypeDefault),
+					value: zod.string(),
+				}),
+				zod.object({
+					type: zod
+						.literal("hidden")
+						.default(createDatasourceBodyDsnPasswordTypeDefaultOne),
+				}),
+			]),
+			dbname: zod.string(),
+			sslmode: zod.enum(["disable", "require", "verify-ca", "verify-full"]),
+			search_path: zod.union([zod.string(), zod.null()]),
+		}),
+		zod.object({
+			type: zod.enum(["bigquery"]),
+			project_id: zod
+				.string()
+				.min(createDatasourceBodyDsnProjectIdMin)
+				.max(createDatasourceBodyDsnProjectIdMax)
+				.regex(createDatasourceBodyDsnProjectIdRegExp),
+			dataset_id: zod
+				.string()
+				.min(1)
+				.max(createDatasourceBodyDsnDatasetIdMax)
+				.regex(createDatasourceBodyDsnDatasetIdRegExp),
+			credentials: zod.union([
+				zod.object({
+					type: zod
+						.literal("serviceaccountinfo")
+						.default(createDatasourceBodyDsnCredentialsTypeDefault),
+					content: zod
+						.string()
+						.min(createDatasourceBodyDsnCredentialsContentMin)
+						.max(createDatasourceBodyDsnCredentialsContentMax),
+				}),
+				zod.object({
+					type: zod
+						.literal("hidden")
+						.default(createDatasourceBodyDsnCredentialsTypeDefaultOne),
+				}),
+			]),
+		}),
+		zod.object({
+			type: zod.enum(["redshift"]),
+			host: zod.string(),
+			port: zod
+				.number()
+				.min(createDatasourceBodyDsnPortMinOne)
+				.max(createDatasourceBodyDsnPortMaxOne),
+			user: zod.string(),
+			password: zod.union([
+				zod.object({
+					type: zod
+						.literal("revealed")
+						.default(createDatasourceBodyDsnPasswordTypeDefaultTwo),
+					value: zod.string(),
+				}),
+				zod.object({
+					type: zod
+						.literal("hidden")
+						.default(createDatasourceBodyDsnPasswordTypeDefaultThree),
+				}),
+			]),
+			dbname: zod.string(),
+			search_path: zod.union([zod.string(), zod.null()]),
+		}),
 	]),
-});
-
-export const createDatasourceResponseIdMax = 64;
-
-export const createDatasourceResponse = zod.object({
-	id: zod.string().max(createDatasourceResponseIdMax),
-});
-
-/**
- * @summary Update Datasource
- */
-export const updateDatasourceParams = zod.object({
-	datasource_id: zod.string(),
 });
 
 export const updateDatasourceBodyNameMaxOne = 100;
@@ -1410,540 +198,91 @@ export const updateDatasourceBody = zod.object({
 	dsn: zod
 		.union([
 			zod.union([
-				zod
-					.object({
-						type: zod.enum(["api_only"]),
-					})
-					.describe(
-						"ApiOnlyDsn describes a datasource where data is included in Evidential API requests.",
-					),
-				zod
-					.object({
-						type: zod.enum(["postgres"]),
-						host: zod.string(),
-						port: zod
-							.number()
-							.min(updateDatasourceBodyDsnPortMin)
-							.max(updateDatasourceBodyDsnPortMax),
-						user: zod.string(),
-						password: zod
-							.union([
-								zod
-									.object({
-										type: zod
-											.literal("revealed")
-											.default(updateDatasourceBodyDsnPasswordTypeDefault),
-										value: zod.string(),
-									})
-									.describe("RevealedStr contains a credential."),
-								zod
-									.object({
-										type: zod
-											.literal("hidden")
-											.default(updateDatasourceBodyDsnPasswordTypeDefaultOne),
-									})
-									.describe(
-										"Hidden represents a credential that is intentionally omitted.",
-									),
-							])
-							.describe(
-								"This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-							),
-						dbname: zod.string(),
-						sslmode: zod.enum([
-							"disable",
-							"require",
-							"verify-ca",
-							"verify-full",
-						]),
-						search_path: zod.union([zod.string(), zod.null()]),
-					})
-					.describe(
-						"PostgresDsn describes a connection to a Postgres-compatible database.",
-					),
-				zod
-					.object({
-						type: zod.enum(["bigquery"]),
-						project_id: zod
-							.string()
-							.min(updateDatasourceBodyDsnProjectIdMin)
-							.max(updateDatasourceBodyDsnProjectIdMax)
-							.regex(updateDatasourceBodyDsnProjectIdRegExp)
-							.describe("The Google Cloud Project ID containing the dataset."),
-						dataset_id: zod
-							.string()
-							.min(1)
-							.max(updateDatasourceBodyDsnDatasetIdMax)
-							.regex(updateDatasourceBodyDsnDatasetIdRegExp)
-							.describe("The dataset name."),
-						credentials: zod
-							.union([
-								zod
-									.object({
-										type: zod
-											.literal("serviceaccountinfo")
-											.default(updateDatasourceBodyDsnCredentialsTypeDefault),
-										content: zod
-											.string()
-											.min(updateDatasourceBodyDsnCredentialsContentMin)
-											.max(updateDatasourceBodyDsnCredentialsContentMax)
-											.describe(
-												"The service account info in the canonical JSON form. Required fields: type, project_id, private_key_id, private_key, client_email.",
-											),
-									})
-									.describe(
-										"Describes a Google Cloud Platform service account.",
-									),
-								zod
-									.object({
-										type: zod
-											.literal("hidden")
-											.default(
-												updateDatasourceBodyDsnCredentialsTypeDefaultOne,
-											),
-									})
-									.describe(
-										"Hidden represents a credential that is intentionally omitted.",
-									),
-							])
-							.describe(
-								"This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-							),
-					})
-					.describe("BqDsn describes a connection to a BigQuery database."),
-				zod
-					.object({
-						type: zod.enum(["redshift"]),
-						host: zod.string(),
-						port: zod
-							.number()
-							.min(updateDatasourceBodyDsnPortMinOne)
-							.max(updateDatasourceBodyDsnPortMaxOne),
-						user: zod.string(),
-						password: zod
-							.union([
-								zod
-									.object({
-										type: zod
-											.literal("revealed")
-											.default(updateDatasourceBodyDsnPasswordTypeDefaultTwo),
-										value: zod.string(),
-									})
-									.describe("RevealedStr contains a credential."),
-								zod
-									.object({
-										type: zod
-											.literal("hidden")
-											.default(updateDatasourceBodyDsnPasswordTypeDefaultThree),
-									})
-									.describe(
-										"Hidden represents a credential that is intentionally omitted.",
-									),
-							])
-							.describe(
-								"This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-							),
-						dbname: zod.string(),
-						search_path: zod.union([zod.string(), zod.null()]),
-					})
-					.describe(
-						"RedshiftDsn describes a connection to a Redshift database.",
-					),
+				zod.object({
+					type: zod.enum(["api_only"]),
+				}),
+				zod.object({
+					type: zod.enum(["postgres"]),
+					host: zod.string(),
+					port: zod
+						.number()
+						.min(updateDatasourceBodyDsnPortMin)
+						.max(updateDatasourceBodyDsnPortMax),
+					user: zod.string(),
+					password: zod.union([
+						zod.object({
+							type: zod
+								.literal("revealed")
+								.default(updateDatasourceBodyDsnPasswordTypeDefault),
+							value: zod.string(),
+						}),
+						zod.object({
+							type: zod
+								.literal("hidden")
+								.default(updateDatasourceBodyDsnPasswordTypeDefaultOne),
+						}),
+					]),
+					dbname: zod.string(),
+					sslmode: zod.enum(["disable", "require", "verify-ca", "verify-full"]),
+					search_path: zod.union([zod.string(), zod.null()]),
+				}),
+				zod.object({
+					type: zod.enum(["bigquery"]),
+					project_id: zod
+						.string()
+						.min(updateDatasourceBodyDsnProjectIdMin)
+						.max(updateDatasourceBodyDsnProjectIdMax)
+						.regex(updateDatasourceBodyDsnProjectIdRegExp),
+					dataset_id: zod
+						.string()
+						.min(1)
+						.max(updateDatasourceBodyDsnDatasetIdMax)
+						.regex(updateDatasourceBodyDsnDatasetIdRegExp),
+					credentials: zod.union([
+						zod.object({
+							type: zod
+								.literal("serviceaccountinfo")
+								.default(updateDatasourceBodyDsnCredentialsTypeDefault),
+							content: zod
+								.string()
+								.min(updateDatasourceBodyDsnCredentialsContentMin)
+								.max(updateDatasourceBodyDsnCredentialsContentMax),
+						}),
+						zod.object({
+							type: zod
+								.literal("hidden")
+								.default(updateDatasourceBodyDsnCredentialsTypeDefaultOne),
+						}),
+					]),
+				}),
+				zod.object({
+					type: zod.enum(["redshift"]),
+					host: zod.string(),
+					port: zod
+						.number()
+						.min(updateDatasourceBodyDsnPortMinOne)
+						.max(updateDatasourceBodyDsnPortMaxOne),
+					user: zod.string(),
+					password: zod.union([
+						zod.object({
+							type: zod
+								.literal("revealed")
+								.default(updateDatasourceBodyDsnPasswordTypeDefaultTwo),
+							value: zod.string(),
+						}),
+						zod.object({
+							type: zod
+								.literal("hidden")
+								.default(updateDatasourceBodyDsnPasswordTypeDefaultThree),
+						}),
+					]),
+					dbname: zod.string(),
+					search_path: zod.union([zod.string(), zod.null()]),
+				}),
 			]),
 			zod.null(),
 		])
 		.optional(),
-});
-
-/**
- * Returns detailed information about a specific datasource.
- * @summary Get Datasource
- */
-export const getDatasourceParams = zod.object({
-	datasource_id: zod.string(),
-});
-
-export const getDatasourceResponseIdMax = 64;
-
-export const getDatasourceResponseNameMax = 100;
-
-export const getDatasourceResponseDsnPortMin = 1024;
-export const getDatasourceResponseDsnPortMax = 65535;
-
-export const getDatasourceResponseDsnPasswordTypeDefault = "revealed";
-export const getDatasourceResponseDsnPasswordTypeDefaultOne = "hidden";
-export const getDatasourceResponseDsnProjectIdMin = 6;
-export const getDatasourceResponseDsnProjectIdMax = 30;
-
-export const getDatasourceResponseDsnProjectIdRegExp = new RegExp(
-	"^[a-z0-9-]+$",
-);
-export const getDatasourceResponseDsnDatasetIdMax = 1024;
-
-export const getDatasourceResponseDsnDatasetIdRegExp = new RegExp(
-	"^[a-zA-Z0-9_]+$",
-);
-export const getDatasourceResponseDsnCredentialsTypeDefault =
-	"serviceaccountinfo";
-export const getDatasourceResponseDsnCredentialsContentMin = 4;
-export const getDatasourceResponseDsnCredentialsContentMax = 8000;
-
-export const getDatasourceResponseDsnCredentialsTypeDefaultOne = "hidden";
-export const getDatasourceResponseDsnPortMinOne = 1024;
-export const getDatasourceResponseDsnPortMaxOne = 65535;
-
-export const getDatasourceResponseDsnPasswordTypeDefaultTwo = "revealed";
-export const getDatasourceResponseDsnPasswordTypeDefaultThree = "hidden";
-export const getDatasourceResponseOrganizationIdMax = 64;
-
-export const getDatasourceResponseOrganizationNameMax = 100;
-
-export const getDatasourceResponse = zod.object({
-	id: zod.string().max(getDatasourceResponseIdMax),
-	name: zod.string().max(getDatasourceResponseNameMax),
-	dsn: zod.union([
-		zod
-			.object({
-				type: zod.enum(["api_only"]),
-			})
-			.describe(
-				"ApiOnlyDsn describes a datasource where data is included in Evidential API requests.",
-			),
-		zod
-			.object({
-				type: zod.enum(["postgres"]),
-				host: zod.string(),
-				port: zod
-					.number()
-					.min(getDatasourceResponseDsnPortMin)
-					.max(getDatasourceResponseDsnPortMax),
-				user: zod.string(),
-				password: zod
-					.union([
-						zod
-							.object({
-								type: zod
-									.literal("revealed")
-									.default(getDatasourceResponseDsnPasswordTypeDefault),
-								value: zod.string(),
-							})
-							.describe("RevealedStr contains a credential."),
-						zod
-							.object({
-								type: zod
-									.literal("hidden")
-									.default(getDatasourceResponseDsnPasswordTypeDefaultOne),
-							})
-							.describe(
-								"Hidden represents a credential that is intentionally omitted.",
-							),
-					])
-					.describe(
-						"This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-					),
-				dbname: zod.string(),
-				sslmode: zod.enum(["disable", "require", "verify-ca", "verify-full"]),
-				search_path: zod.union([zod.string(), zod.null()]),
-			})
-			.describe(
-				"PostgresDsn describes a connection to a Postgres-compatible database.",
-			),
-		zod
-			.object({
-				type: zod.enum(["bigquery"]),
-				project_id: zod
-					.string()
-					.min(getDatasourceResponseDsnProjectIdMin)
-					.max(getDatasourceResponseDsnProjectIdMax)
-					.regex(getDatasourceResponseDsnProjectIdRegExp)
-					.describe("The Google Cloud Project ID containing the dataset."),
-				dataset_id: zod
-					.string()
-					.min(1)
-					.max(getDatasourceResponseDsnDatasetIdMax)
-					.regex(getDatasourceResponseDsnDatasetIdRegExp)
-					.describe("The dataset name."),
-				credentials: zod
-					.union([
-						zod
-							.object({
-								type: zod
-									.literal("serviceaccountinfo")
-									.default(getDatasourceResponseDsnCredentialsTypeDefault),
-								content: zod
-									.string()
-									.min(getDatasourceResponseDsnCredentialsContentMin)
-									.max(getDatasourceResponseDsnCredentialsContentMax)
-									.describe(
-										"The service account info in the canonical JSON form. Required fields: type, project_id, private_key_id, private_key, client_email.",
-									),
-							})
-							.describe("Describes a Google Cloud Platform service account."),
-						zod
-							.object({
-								type: zod
-									.literal("hidden")
-									.default(getDatasourceResponseDsnCredentialsTypeDefaultOne),
-							})
-							.describe(
-								"Hidden represents a credential that is intentionally omitted.",
-							),
-					])
-					.describe(
-						"This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-					),
-			})
-			.describe("BqDsn describes a connection to a BigQuery database."),
-		zod
-			.object({
-				type: zod.enum(["redshift"]),
-				host: zod.string(),
-				port: zod
-					.number()
-					.min(getDatasourceResponseDsnPortMinOne)
-					.max(getDatasourceResponseDsnPortMaxOne),
-				user: zod.string(),
-				password: zod
-					.union([
-						zod
-							.object({
-								type: zod
-									.literal("revealed")
-									.default(getDatasourceResponseDsnPasswordTypeDefaultTwo),
-								value: zod.string(),
-							})
-							.describe("RevealedStr contains a credential."),
-						zod
-							.object({
-								type: zod
-									.literal("hidden")
-									.default(getDatasourceResponseDsnPasswordTypeDefaultThree),
-							})
-							.describe(
-								"Hidden represents a credential that is intentionally omitted.",
-							),
-					])
-					.describe(
-						"This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.",
-					),
-				dbname: zod.string(),
-				search_path: zod.union([zod.string(), zod.null()]),
-			})
-			.describe("RedshiftDsn describes a connection to a Redshift database."),
-	]),
-	organization_id: zod.string().max(getDatasourceResponseOrganizationIdMax),
-	organization_name: zod.string().max(getDatasourceResponseOrganizationNameMax),
-});
-
-/**
- * Verifies connectivity to a datasource and returns a list of readable tables.
- * @summary Inspect Datasource
- */
-export const inspectDatasourceParams = zod.object({
-	datasource_id: zod.string(),
-});
-
-export const inspectDatasourceQueryRefreshDefault = false;
-
-export const inspectDatasourceQueryParams = zod.object({
-	refresh: zod.boolean().optional().describe("Refresh the cache."),
-});
-
-export const inspectDatasourceResponse = zod.object({
-	tables: zod.array(zod.string()),
-});
-
-/**
- * Inspects a single table in a datasource and returns a summary of its fields.
- * @summary Inspect Table In Datasource
- */
-export const inspectTableInDatasourceParams = zod.object({
-	datasource_id: zod.string(),
-	table_name: zod.string(),
-});
-
-export const inspectTableInDatasourceQueryRefreshDefault = false;
-
-export const inspectTableInDatasourceQueryParams = zod.object({
-	refresh: zod.boolean().optional().describe("Refresh the cache."),
-});
-
-export const inspectTableInDatasourceResponseFieldsItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const inspectTableInDatasourceResponseFieldsItemDescriptionMax = 2000;
-
-export const inspectTableInDatasourceResponse = zod
-	.object({
-		primary_key_fields: zod
-			.array(zod.string())
-			.describe("Fields that are primary keys."),
-		detected_unique_id_fields: zod
-			.array(zod.string())
-			.describe("Fields that are possibly candidates for unique IDs."),
-		fields: zod
-			.array(
-				zod
-					.object({
-						field_name: zod
-							.string()
-							.regex(inspectTableInDatasourceResponseFieldsItemFieldNameRegExp),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						description: zod
-							.string()
-							.max(inspectTableInDatasourceResponseFieldsItemDescriptionMax),
-					})
-					.describe("Concise summary of fields in the table."),
-			)
-			.describe("Fields in the table."),
-	})
-	.describe("Describes a table in the datasource.");
-
-/**
- * Deletes a datasource.
-
-The user must be a member of the organization that owns the datasource.
- * @summary Delete Datasource
- */
-export const deleteDatasourceParams = zod.object({
-	organization_id: zod.string(),
-	datasource_id: zod.string(),
-});
-
-export const deleteDatasourceQueryAllowMissingDefault = false;
-
-export const deleteDatasourceQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-/**
- * @summary List Participant Types
- */
-export const listParticipantTypesParams = zod.object({
-	datasource_id: zod.string(),
-});
-
-export const listParticipantTypesResponseItemsItemFieldsItemDescriptionDefault =
-	"";
-export const listParticipantTypesResponseItemsItemFieldsItemIsUniqueIdDefault = false;
-export const listParticipantTypesResponseItemsItemFieldsItemIsStrataDefault = false;
-export const listParticipantTypesResponseItemsItemFieldsItemIsFilterDefault = false;
-export const listParticipantTypesResponseItemsItemFieldsItemIsMetricDefault = false;
-export const listParticipantTypesResponseItemsItemHiddenDefault = false;
-
-export const listParticipantTypesResponse = zod.object({
-	items: zod
-		.array(
-			zod
-				.object({
-					table_name: zod
-						.string()
-						.describe("Name of the table in the data warehouse"),
-					fields: zod
-						.array(
-							zod.object({
-								field_name: zod
-									.string()
-									.describe("Name of the field in the data source"),
-								data_type: zod
-									.enum([
-										"boolean",
-										"character varying",
-										"uuid",
-										"date",
-										"integer",
-										"double precision",
-										"numeric",
-										"timestamp without time zone",
-										"timestamp with time zone",
-										"bigint",
-										"jsonb",
-										"json",
-										"unknown",
-									])
-									.describe(
-										"Defines the supported data types for fields in the data source.",
-									),
-								description: zod
-									.string()
-									.optional()
-									.describe("Human-readable description of the field"),
-								is_unique_id: zod
-									.boolean()
-									.optional()
-									.describe("Whether this field uniquely identifies records"),
-								is_strata: zod
-									.boolean()
-									.optional()
-									.describe(
-										"Whether this field should be used for stratification",
-									),
-								is_filter: zod
-									.boolean()
-									.optional()
-									.describe("Whether this field can be used as a filter"),
-								is_metric: zod
-									.boolean()
-									.optional()
-									.describe("Whether this field can be used as a metric"),
-								extra: zod
-									.union([zod.record(zod.string(), zod.string()), zod.null()])
-									.optional(),
-							}),
-						)
-						.describe("List of fields available in this table"),
-					type: zod
-						.literal("schema")
-						.describe(
-							"Indicates that the schema is determined by an inline schema.",
-						),
-					participant_type: zod
-						.string()
-						.describe(
-							"The name of the set of participants defined by the filters. This name must be unique within a datasource when not hidden (i.e. not auto-generated).",
-						),
-					hidden: zod
-						.boolean()
-						.optional()
-						.describe(
-							"If true, this participant type is hidden from list_participant_types. Used for auto-generated participant types.",
-						),
-				})
-				.describe(
-					"Participants are a logical representation of a table in the data warehouse.\n\nParticipants are defined by a participant_type, table_name and a schema.",
-				),
-		)
-		.describe("List of participant type definitions."),
-	has_hidden: zod
-		.boolean()
-		.describe("True when the datasource has hidden participant types."),
-});
-
-/**
- * @summary Create Participant Type
- */
-export const createParticipantTypeParams = zod.object({
-	datasource_id: zod.string(),
 });
 
 export const createParticipantTypeBodyParticipantTypeMax = 100;
@@ -1959,607 +298,37 @@ export const createParticipantTypeBody = zod.object({
 	participant_type: zod
 		.string()
 		.max(createParticipantTypeBodyParticipantTypeMax),
-	schema_def: zod
-		.object({
-			table_name: zod
-				.string()
-				.describe("Name of the table in the data warehouse"),
-			fields: zod
-				.array(
-					zod.object({
-						field_name: zod
-							.string()
-							.describe("Name of the field in the data source"),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						description: zod
-							.string()
-							.optional()
-							.describe("Human-readable description of the field"),
-						is_unique_id: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field uniquely identifies records"),
-						is_strata: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field should be used for stratification"),
-						is_filter: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a filter"),
-						is_metric: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a metric"),
-						extra: zod
-							.union([zod.record(zod.string(), zod.string()), zod.null()])
-							.optional(),
-					}),
-				)
-				.describe("List of fields available in this table"),
-		})
-		.describe(
-			"Represents a single worksheet describing metadata about a type of Participant.",
+	schema_def: zod.object({
+		table_name: zod.string(),
+		fields: zod.array(
+			zod.object({
+				field_name: zod.string(),
+				data_type: zod.enum([
+					"boolean",
+					"character varying",
+					"uuid",
+					"date",
+					"integer",
+					"double precision",
+					"numeric",
+					"timestamp without time zone",
+					"timestamp with time zone",
+					"bigint",
+					"jsonb",
+					"json",
+					"unknown",
+				]),
+				description: zod.string().optional(),
+				is_unique_id: zod.boolean().optional(),
+				is_strata: zod.boolean().optional(),
+				is_filter: zod.boolean().optional(),
+				is_metric: zod.boolean().optional(),
+				extra: zod
+					.union([zod.record(zod.string(), zod.string()), zod.null()])
+					.optional(),
+			}),
 		),
-});
-
-export const createParticipantTypeResponseParticipantTypeMax = 100;
-
-export const createParticipantTypeResponseSchemaDefFieldsItemDescriptionDefault =
-	"";
-export const createParticipantTypeResponseSchemaDefFieldsItemIsUniqueIdDefault = false;
-export const createParticipantTypeResponseSchemaDefFieldsItemIsStrataDefault = false;
-export const createParticipantTypeResponseSchemaDefFieldsItemIsFilterDefault = false;
-export const createParticipantTypeResponseSchemaDefFieldsItemIsMetricDefault = false;
-
-export const createParticipantTypeResponse = zod.object({
-	participant_type: zod
-		.string()
-		.max(createParticipantTypeResponseParticipantTypeMax),
-	schema_def: zod
-		.object({
-			table_name: zod
-				.string()
-				.describe("Name of the table in the data warehouse"),
-			fields: zod
-				.array(
-					zod.object({
-						field_name: zod
-							.string()
-							.describe("Name of the field in the data source"),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						description: zod
-							.string()
-							.optional()
-							.describe("Human-readable description of the field"),
-						is_unique_id: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field uniquely identifies records"),
-						is_strata: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field should be used for stratification"),
-						is_filter: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a filter"),
-						is_metric: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a metric"),
-						extra: zod
-							.union([zod.record(zod.string(), zod.string()), zod.null()])
-							.optional(),
-					}),
-				)
-				.describe("List of fields available in this table"),
-		})
-		.describe(
-			"Represents a single worksheet describing metadata about a type of Participant.",
-		),
-});
-
-/**
- * Returns filter, strata, and metric field metadata for a participant type, including exemplars for
-filter fields.
- * @summary Inspect Participant Types
- */
-export const inspectParticipantTypesParams = zod.object({
-	datasource_id: zod.string(),
-	participant_id: zod.string(),
-});
-
-export const inspectParticipantTypesQueryRefreshDefault = false;
-export const inspectParticipantTypesQueryExpensiveDefault = false;
-
-export const inspectParticipantTypesQueryParams = zod.object({
-	refresh: zod.boolean().optional().describe("Refresh the cache."),
-	expensive: zod
-		.boolean()
-		.optional()
-		.describe("Whether to run expensive metadata queries."),
-});
-
-export const inspectParticipantTypesResponseFiltersItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const inspectParticipantTypesResponseFiltersItemRelationsMax = 20;
-
-export const inspectParticipantTypesResponseFiltersItemDescriptionMax = 2000;
-
-export const inspectParticipantTypesResponseFiltersItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const inspectParticipantTypesResponseFiltersItemRelationsMaxOne = 20;
-
-export const inspectParticipantTypesResponseFiltersItemDescriptionMaxOne = 2000;
-
-export const inspectParticipantTypesResponseMetricsItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const inspectParticipantTypesResponseMetricsItemDescriptionMax = 2000;
-
-export const inspectParticipantTypesResponseStrataItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const inspectParticipantTypesResponseStrataItemDescriptionMax = 2000;
-
-export const inspectParticipantTypesResponse = zod
-	.object({
-		filters: zod.array(
-			zod.union([
-				zod
-					.object({
-						field_name: zod
-							.string()
-							.regex(inspectParticipantTypesResponseFiltersItemFieldNameRegExp)
-							.describe("Name of the field."),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						relations: zod
-							.array(
-								zod
-									.enum(["includes", "excludes", "between"])
-									.describe(
-										"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-									),
-							)
-							.min(1)
-							.max(inspectParticipantTypesResponseFiltersItemRelationsMax),
-						description: zod
-							.string()
-							.max(inspectParticipantTypesResponseFiltersItemDescriptionMax),
-						min: zod
-							.union([
-								zod.string().datetime({}),
-								zod.string().date(),
-								zod.number(),
-								zod.number(),
-								zod.null(),
-							])
-							.describe("The minimum observed value."),
-						max: zod
-							.union([
-								zod.string().datetime({}),
-								zod.string().date(),
-								zod.number(),
-								zod.number(),
-								zod.null(),
-							])
-							.describe("The maximum observed value."),
-					})
-					.describe("Describes a numeric or date filter variable."),
-				zod
-					.object({
-						field_name: zod
-							.string()
-							.regex(
-								inspectParticipantTypesResponseFiltersItemFieldNameRegExpOne,
-							)
-							.describe("Name of the field."),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						relations: zod
-							.array(
-								zod
-									.enum(["includes", "excludes", "between"])
-									.describe(
-										"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-									),
-							)
-							.min(1)
-							.max(inspectParticipantTypesResponseFiltersItemRelationsMaxOne),
-						description: zod
-							.string()
-							.max(inspectParticipantTypesResponseFiltersItemDescriptionMaxOne),
-						distinct_values: zod
-							.union([zod.array(zod.string()), zod.null()])
-							.describe("Sorted list of unique values."),
-					})
-					.describe("Describes a discrete filter variable."),
-			]),
-		),
-		metrics: zod.array(
-			zod
-				.object({
-					field_name: zod
-						.string()
-						.regex(inspectParticipantTypesResponseMetricsItemFieldNameRegExp),
-					data_type: zod
-						.enum([
-							"boolean",
-							"character varying",
-							"uuid",
-							"date",
-							"integer",
-							"double precision",
-							"numeric",
-							"timestamp without time zone",
-							"timestamp with time zone",
-							"bigint",
-							"jsonb",
-							"json",
-							"unknown",
-						])
-						.describe(
-							"Defines the supported data types for fields in the data source.",
-						),
-					description: zod
-						.string()
-						.max(inspectParticipantTypesResponseMetricsItemDescriptionMax),
-				})
-				.describe("Describes a metric."),
-		),
-		strata: zod.array(
-			zod
-				.object({
-					data_type: zod
-						.enum([
-							"boolean",
-							"character varying",
-							"uuid",
-							"date",
-							"integer",
-							"double precision",
-							"numeric",
-							"timestamp without time zone",
-							"timestamp with time zone",
-							"bigint",
-							"jsonb",
-							"json",
-							"unknown",
-						])
-						.describe(
-							"Defines the supported data types for fields in the data source.",
-						),
-					field_name: zod
-						.string()
-						.regex(inspectParticipantTypesResponseStrataItemFieldNameRegExp),
-					description: zod
-						.string()
-						.max(inspectParticipantTypesResponseStrataItemDescriptionMax),
-				})
-				.describe("Describes a stratification variable."),
-		),
-	})
-	.describe(
-		"Describes a participant type's strata, metrics, and filters (including exemplar values).",
-	);
-
-/**
- * @summary Get Participant Type
- */
-export const getParticipantTypeParams = zod.object({
-	datasource_id: zod.string(),
-	participant_id: zod.string(),
-});
-
-export const getParticipantTypeResponseCurrentFieldsItemDescriptionDefault = "";
-export const getParticipantTypeResponseCurrentFieldsItemIsUniqueIdDefault = false;
-export const getParticipantTypeResponseCurrentFieldsItemIsStrataDefault = false;
-export const getParticipantTypeResponseCurrentFieldsItemIsFilterDefault = false;
-export const getParticipantTypeResponseCurrentFieldsItemIsMetricDefault = false;
-export const getParticipantTypeResponseCurrentHiddenDefault = false;
-export const getParticipantTypeResponseProposedFieldsItemDescriptionDefault =
-	"";
-export const getParticipantTypeResponseProposedFieldsItemIsUniqueIdDefault = false;
-export const getParticipantTypeResponseProposedFieldsItemIsStrataDefault = false;
-export const getParticipantTypeResponseProposedFieldsItemIsFilterDefault = false;
-export const getParticipantTypeResponseProposedFieldsItemIsMetricDefault = false;
-export const getParticipantTypeResponseProposedHiddenDefault = false;
-
-export const getParticipantTypeResponse = zod.object({
-	current: zod
-		.object({
-			table_name: zod
-				.string()
-				.describe("Name of the table in the data warehouse"),
-			fields: zod
-				.array(
-					zod.object({
-						field_name: zod
-							.string()
-							.describe("Name of the field in the data source"),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						description: zod
-							.string()
-							.optional()
-							.describe("Human-readable description of the field"),
-						is_unique_id: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field uniquely identifies records"),
-						is_strata: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field should be used for stratification"),
-						is_filter: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a filter"),
-						is_metric: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a metric"),
-						extra: zod
-							.union([zod.record(zod.string(), zod.string()), zod.null()])
-							.optional(),
-					}),
-				)
-				.describe("List of fields available in this table"),
-			type: zod
-				.literal("schema")
-				.describe(
-					"Indicates that the schema is determined by an inline schema.",
-				),
-			participant_type: zod
-				.string()
-				.describe(
-					"The name of the set of participants defined by the filters. This name must be unique within a datasource when not hidden (i.e. not auto-generated).",
-				),
-			hidden: zod
-				.boolean()
-				.optional()
-				.describe(
-					"If true, this participant type is hidden from list_participant_types. Used for auto-generated participant types.",
-				),
-		})
-		.describe(
-			"Participants are a logical representation of a table in the data warehouse.\n\nParticipants are defined by a participant_type, table_name and a schema.",
-		),
-	proposed: zod
-		.object({
-			table_name: zod
-				.string()
-				.describe("Name of the table in the data warehouse"),
-			fields: zod
-				.array(
-					zod.object({
-						field_name: zod
-							.string()
-							.describe("Name of the field in the data source"),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						description: zod
-							.string()
-							.optional()
-							.describe("Human-readable description of the field"),
-						is_unique_id: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field uniquely identifies records"),
-						is_strata: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field should be used for stratification"),
-						is_filter: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a filter"),
-						is_metric: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a metric"),
-						extra: zod
-							.union([zod.record(zod.string(), zod.string()), zod.null()])
-							.optional(),
-					}),
-				)
-				.describe("List of fields available in this table"),
-			type: zod
-				.literal("schema")
-				.describe(
-					"Indicates that the schema is determined by an inline schema.",
-				),
-			participant_type: zod
-				.string()
-				.describe(
-					"The name of the set of participants defined by the filters. This name must be unique within a datasource when not hidden (i.e. not auto-generated).",
-				),
-			hidden: zod
-				.boolean()
-				.optional()
-				.describe(
-					"If true, this participant type is hidden from list_participant_types. Used for auto-generated participant types.",
-				),
-		})
-		.describe(
-			"Participants are a logical representation of a table in the data warehouse.\n\nParticipants are defined by a participant_type, table_name and a schema.",
-		),
-	drift: zod
-		.object({
-			schema_diff: zod
-				.array(
-					zod.union([
-						zod.object({
-							type: zod.enum(["column_deleted"]),
-							table_name: zod.string(),
-							column_name: zod.string(),
-						}),
-						zod.object({
-							type: zod.enum(["column_changed_type"]),
-							table_name: zod.string(),
-							column_name: zod.string(),
-							old_type: zod
-								.enum([
-									"boolean",
-									"character varying",
-									"uuid",
-									"date",
-									"integer",
-									"double precision",
-									"numeric",
-									"timestamp without time zone",
-									"timestamp with time zone",
-									"bigint",
-									"jsonb",
-									"json",
-									"unknown",
-								])
-								.describe(
-									"Defines the supported data types for fields in the data source.",
-								),
-							new_type: zod
-								.enum([
-									"boolean",
-									"character varying",
-									"uuid",
-									"date",
-									"integer",
-									"double precision",
-									"numeric",
-									"timestamp without time zone",
-									"timestamp with time zone",
-									"bigint",
-									"jsonb",
-									"json",
-									"unknown",
-								])
-								.describe(
-									"Defines the supported data types for fields in the data source.",
-								),
-						}),
-						zod.object({
-							type: zod.enum(["table_deleted"]),
-							table_name: zod.string(),
-						}),
-					]),
-				)
-				.describe(
-					"List of individual changes detected that might break things.",
-				),
-		})
-		.describe("Describes differences between two participant types."),
-});
-
-/**
- * @summary Update Participant Type
- */
-export const updateParticipantTypeParams = zod.object({
-	datasource_id: zod.string(),
-	participant_id: zod.string(),
+	}),
 });
 
 export const updateParticipantTypeBodyParticipantTypeMaxOne = 100;
@@ -2590,48 +359,27 @@ export const updateParticipantTypeBody = zod.object({
 		.union([
 			zod.array(
 				zod.object({
-					field_name: zod
-						.string()
-						.describe("Name of the field in the data source"),
-					data_type: zod
-						.enum([
-							"boolean",
-							"character varying",
-							"uuid",
-							"date",
-							"integer",
-							"double precision",
-							"numeric",
-							"timestamp without time zone",
-							"timestamp with time zone",
-							"bigint",
-							"jsonb",
-							"json",
-							"unknown",
-						])
-						.describe(
-							"Defines the supported data types for fields in the data source.",
-						),
-					description: zod
-						.string()
-						.optional()
-						.describe("Human-readable description of the field"),
-					is_unique_id: zod
-						.boolean()
-						.optional()
-						.describe("Whether this field uniquely identifies records"),
-					is_strata: zod
-						.boolean()
-						.optional()
-						.describe("Whether this field should be used for stratification"),
-					is_filter: zod
-						.boolean()
-						.optional()
-						.describe("Whether this field can be used as a filter"),
-					is_metric: zod
-						.boolean()
-						.optional()
-						.describe("Whether this field can be used as a metric"),
+					field_name: zod.string(),
+					data_type: zod.enum([
+						"boolean",
+						"character varying",
+						"uuid",
+						"date",
+						"integer",
+						"double precision",
+						"numeric",
+						"timestamp without time zone",
+						"timestamp with time zone",
+						"bigint",
+						"jsonb",
+						"json",
+						"unknown",
+					]),
+					description: zod.string().optional(),
+					is_unique_id: zod.boolean().optional(),
+					is_strata: zod.boolean().optional(),
+					is_filter: zod.boolean().optional(),
+					is_metric: zod.boolean().optional(),
 					extra: zod
 						.union([zod.record(zod.string(), zod.string()), zod.null()])
 						.optional(),
@@ -2640,189 +388,6 @@ export const updateParticipantTypeBody = zod.object({
 			zod.null(),
 		])
 		.optional(),
-});
-
-export const updateParticipantTypeResponseParticipantTypeMax = 100;
-
-export const updateParticipantTypeResponseTableNameRegExpOne = new RegExp(
-	"^[a-zA-Z_][a-zA-Z0-9_]*$",
-);
-export const updateParticipantTypeResponseFieldsItemDescriptionDefault = "";
-export const updateParticipantTypeResponseFieldsItemIsUniqueIdDefault = false;
-export const updateParticipantTypeResponseFieldsItemIsStrataDefault = false;
-export const updateParticipantTypeResponseFieldsItemIsFilterDefault = false;
-export const updateParticipantTypeResponseFieldsItemIsMetricDefault = false;
-export const updateParticipantTypeResponseFieldsMaxOne = 150;
-
-export const updateParticipantTypeResponse = zod.object({
-	participant_type: zod
-		.string()
-		.max(updateParticipantTypeResponseParticipantTypeMax),
-	table_name: zod
-		.union([
-			zod.string().regex(updateParticipantTypeResponseTableNameRegExpOne),
-			zod.null(),
-		])
-		.optional(),
-	fields: zod
-		.union([
-			zod
-				.array(
-					zod.object({
-						field_name: zod
-							.string()
-							.describe("Name of the field in the data source"),
-						data_type: zod
-							.enum([
-								"boolean",
-								"character varying",
-								"uuid",
-								"date",
-								"integer",
-								"double precision",
-								"numeric",
-								"timestamp without time zone",
-								"timestamp with time zone",
-								"bigint",
-								"jsonb",
-								"json",
-								"unknown",
-							])
-							.describe(
-								"Defines the supported data types for fields in the data source.",
-							),
-						description: zod
-							.string()
-							.optional()
-							.describe("Human-readable description of the field"),
-						is_unique_id: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field uniquely identifies records"),
-						is_strata: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field should be used for stratification"),
-						is_filter: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a filter"),
-						is_metric: zod
-							.boolean()
-							.optional()
-							.describe("Whether this field can be used as a metric"),
-						extra: zod
-							.union([zod.record(zod.string(), zod.string()), zod.null()])
-							.optional(),
-					}),
-				)
-				.max(updateParticipantTypeResponseFieldsMaxOne),
-			zod.null(),
-		])
-		.optional(),
-});
-
-/**
- * @summary Delete Participant
- */
-export const deleteParticipantParams = zod.object({
-	datasource_id: zod.string(),
-	participant_id: zod.string(),
-});
-
-export const deleteParticipantQueryAllowMissingDefault = false;
-
-export const deleteParticipantQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-/**
- * Returns API keys that have access to the datasource.
- * @summary List Api Keys
- */
-export const listApiKeysParams = zod.object({
-	datasource_id: zod.string(),
-});
-
-export const listApiKeysResponseItemsItemIdMax = 64;
-
-export const listApiKeysResponseItemsItemDatasourceIdMax = 64;
-
-export const listApiKeysResponseItemsItemOrganizationIdMax = 64;
-
-export const listApiKeysResponseItemsItemOrganizationNameMax = 100;
-
-export const listApiKeysResponse = zod.object({
-	items: zod.array(
-		zod.object({
-			id: zod.string().max(listApiKeysResponseItemsItemIdMax),
-			datasource_id: zod
-				.string()
-				.max(listApiKeysResponseItemsItemDatasourceIdMax),
-			organization_id: zod
-				.string()
-				.max(listApiKeysResponseItemsItemOrganizationIdMax),
-			organization_name: zod
-				.string()
-				.max(listApiKeysResponseItemsItemOrganizationNameMax),
-		}),
-	),
-});
-
-/**
- * Creates an API key for the specified datasource.
-
-The user must belong to the organization that owns the requested datasource.
- * @summary Create Api Key
- */
-export const createApiKeyParams = zod.object({
-	datasource_id: zod.string(),
-});
-
-export const createApiKeyResponseIdMax = 64;
-
-export const createApiKeyResponse = zod.object({
-	id: zod.string().max(createApiKeyResponseIdMax),
-	datasource_id: zod.string(),
-	key: zod.string(),
-});
-
-/**
- * Deletes the specified API key.
- * @summary Delete Api Key
- */
-export const deleteApiKeyParams = zod.object({
-	datasource_id: zod.string(),
-	api_key_id: zod.string(),
-});
-
-export const deleteApiKeyQueryAllowMissingDefault = false;
-
-export const deleteApiKeyQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-/**
- * Creates a new experiment in the specified datasource.
- * @summary Create Experiment
- */
-export const createExperimentParams = zod.object({
-	datasource_id: zod.string(),
-});
-
-export const createExperimentQueryStratifyOnMetricsDefault = true;
-
-export const createExperimentQueryParams = zod.object({
-	stratify_on_metrics: zod
-		.boolean()
-		.default(createExperimentQueryStratifyOnMetricsDefault)
-		.describe("Whether to also stratify on metrics during assignment."),
 });
 
 export const createExperimentBodyDesignSpecExperimentNameMax = 100;
@@ -2953,873 +518,507 @@ export const createExperimentBodyDesignSpecContextsMaxFour = 150;
 
 export const createExperimentBodyPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const createExperimentBodyPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const createExperimentBodyPowerAnalysesAnalysesMax = 150;
 
 export const createExperimentBodyWebhooksDefault = [];
 
 export const createExperimentBody = zod.object({
-	design_spec: zod
-		.union([
-			zod
-				.union([
-					zod
-						.object({
-							experiment_type: zod.enum(["freq_preassigned"]),
-							experiment_name: zod
+	design_spec: zod.union([
+		zod.union([
+			zod.object({
+				experiment_type: zod.enum(["freq_preassigned"]),
+				experiment_name: zod
+					.string()
+					.max(createExperimentBodyDesignSpecExperimentNameMax),
+				description: zod
+					.string()
+					.max(createExperimentBodyDesignSpecDescriptionMax),
+				design_url: zod
+					.union([
+						zod
+							.string()
+							.url()
+							.min(1)
+							.max(createExperimentBodyDesignSpecDesignUrlMaxOne),
+						zod.null(),
+					])
+					.optional(),
+				start_date: zod.string().datetime({}),
+				end_date: zod.string().datetime({}),
+				arms: zod
+					.array(
+						zod.object({
+							arm_id: zod.union([zod.string(), zod.null()]).optional(),
+							arm_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecExperimentNameMax),
-							description: zod
-								.string()
-								.max(createExperimentBodyDesignSpecDescriptionMax),
-							design_url: zod
+								.max(createExperimentBodyDesignSpecArmsItemArmNameMax),
+							arm_description: zod
 								.union([
 									zod
 										.string()
-										.url()
-										.min(1)
-										.max(createExperimentBodyDesignSpecDesignUrlMaxOne),
+										.max(
+											createExperimentBodyDesignSpecArmsItemArmDescriptionMaxOne,
+										),
 									zod.null(),
 								])
-								.optional()
-								.describe(
-									"Optional URL to a more detailed experiment design doc.",
-								),
-							start_date: zod.string().datetime({}),
-							end_date: zod.string().datetime({}),
-							arms: zod
-								.array(
-									zod
-										.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
-												.string()
-												.max(createExperimentBodyDesignSpecArmsItemArmNameMax),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecArmsItemArmDescriptionMaxOne,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-										})
-										.describe("Describes an experiment treatment arm."),
-								)
-								.min(createExperimentBodyDesignSpecArmsMin)
-								.max(createExperimentBodyDesignSpecArmsMax),
-							table_name: zod
+								.optional(),
+							arm_weight: zod.union([zod.number(), zod.null()]).optional(),
+						}),
+					)
+					.min(createExperimentBodyDesignSpecArmsMin)
+					.max(createExperimentBodyDesignSpecArmsMax),
+				table_name: zod
+					.string()
+					.max(createExperimentBodyDesignSpecTableNameMax),
+				primary_key: zod
+					.string()
+					.regex(createExperimentBodyDesignSpecPrimaryKeyRegExp),
+				cluster_key: zod.union([zod.string(), zod.null()]).optional(),
+				strata: zod
+					.array(
+						zod.object({
+							field_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecTableNameMax)
-								.describe(
-									"Datasource table used to resolve participant field metadata.",
-								),
-							primary_key: zod
+								.regex(createExperimentBodyDesignSpecStrataItemFieldNameRegExp),
+						}),
+					)
+					.max(createExperimentBodyDesignSpecStrataMax),
+				metrics: zod
+					.array(
+						zod.object({
+							field_name: zod
 								.string()
-								.regex(createExperimentBodyDesignSpecPrimaryKeyRegExp)
-								.describe(
-									"Column name in table_name that uniquely identifies each participant.",
+								.regex(
+									createExperimentBodyDesignSpecMetricsItemFieldNameRegExp,
 								),
-							strata: zod
-								.array(
-									zod
-										.object({
-											field_name: zod
-												.string()
-												.regex(
-													createExperimentBodyDesignSpecStrataItemFieldNameRegExp,
-												),
-										})
-										.describe("Describes a variable used for stratification."),
-								)
-								.max(createExperimentBodyDesignSpecStrataMax)
-								.describe("Optional fields to use for stratified assignment."),
-							metrics: zod
-								.array(
-									zod
-										.object({
-											field_name: zod
-												.string()
-												.regex(
-													createExperimentBodyDesignSpecMetricsItemFieldNameRegExp,
-												),
-											metric_pct_change: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-												),
-											metric_target: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-												),
-										})
-										.describe(
-											"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-										),
-								)
-								.min(1)
-								.max(createExperimentBodyDesignSpecMetricsMax)
-								.describe("Primary and optional secondary metrics to target."),
-							filters: zod
-								.array(
-									zod
-										.object({
-											field_name: zod
-												.string()
-												.regex(
-													createExperimentBodyDesignSpecFiltersItemFieldNameRegExp,
-												),
-											relation: zod
-												.enum(["includes", "excludes", "between"])
-												.describe(
-													"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-												),
-											value: zod.union([
-												zod.array(zod.union([zod.number(), zod.null()])),
-												zod.array(zod.union([zod.number(), zod.null()])),
-												zod.array(zod.union([zod.string(), zod.null()])),
-												zod.array(zod.union([zod.boolean(), zod.null()])),
-											]),
-										})
-										.describe(
-											'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-										),
-								)
-								.max(createExperimentBodyDesignSpecFiltersMax)
-								.describe(
-									"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-								),
-							desired_n: zod
-								.union([
-									zod
-										.number()
-										.min(createExperimentBodyDesignSpecDesiredNMinOne),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-								),
-							power: zod
-								.number()
-								.min(createExperimentBodyDesignSpecPowerMin)
-								.max(createExperimentBodyDesignSpecPowerMax)
-								.default(createExperimentBodyDesignSpecPowerDefault)
-								.describe(
-									"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-								),
-							alpha: zod
-								.number()
-								.min(createExperimentBodyDesignSpecAlphaMin)
-								.max(createExperimentBodyDesignSpecAlphaMax)
-								.default(createExperimentBodyDesignSpecAlphaDefault)
-								.describe(
-									"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-								),
-							fstat_thresh: zod
-								.number()
-								.min(createExperimentBodyDesignSpecFstatThreshMin)
-								.max(createExperimentBodyDesignSpecFstatThreshMax)
-								.default(createExperimentBodyDesignSpecFstatThreshDefault)
-								.describe(
-									'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-								),
-						})
-						.describe(
-							"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
-						),
-					zod
-						.object({
-							experiment_type: zod.enum(["freq_online"]),
-							experiment_name: zod
+							metric_pct_change: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							metric_target: zod.union([zod.number(), zod.null()]).optional(),
+							icc: zod.union([zod.number(), zod.null()]).optional(),
+							avg_cluster_size: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							cv: zod.union([zod.number(), zod.null()]).optional(),
+						}),
+					)
+					.min(1)
+					.max(createExperimentBodyDesignSpecMetricsMax),
+				filters: zod
+					.array(
+						zod.object({
+							field_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecExperimentNameMaxOne),
-							description: zod
+								.regex(
+									createExperimentBodyDesignSpecFiltersItemFieldNameRegExp,
+								),
+							relation: zod.enum(["includes", "excludes", "between"]),
+							value: zod.union([
+								zod.array(zod.union([zod.number(), zod.null()])),
+								zod.array(zod.union([zod.number(), zod.null()])),
+								zod.array(zod.union([zod.string(), zod.null()])),
+								zod.array(zod.union([zod.boolean(), zod.null()])),
+							]),
+						}),
+					)
+					.max(createExperimentBodyDesignSpecFiltersMax),
+				desired_n: zod
+					.union([
+						zod.number().min(createExperimentBodyDesignSpecDesiredNMinOne),
+						zod.null(),
+					])
+					.optional(),
+				power: zod
+					.number()
+					.min(createExperimentBodyDesignSpecPowerMin)
+					.max(createExperimentBodyDesignSpecPowerMax)
+					.default(createExperimentBodyDesignSpecPowerDefault),
+				alpha: zod
+					.number()
+					.min(createExperimentBodyDesignSpecAlphaMin)
+					.max(createExperimentBodyDesignSpecAlphaMax)
+					.default(createExperimentBodyDesignSpecAlphaDefault),
+				fstat_thresh: zod
+					.number()
+					.min(createExperimentBodyDesignSpecFstatThreshMin)
+					.max(createExperimentBodyDesignSpecFstatThreshMax)
+					.default(createExperimentBodyDesignSpecFstatThreshDefault),
+			}),
+			zod.object({
+				experiment_type: zod.enum(["freq_online"]),
+				experiment_name: zod
+					.string()
+					.max(createExperimentBodyDesignSpecExperimentNameMaxOne),
+				description: zod
+					.string()
+					.max(createExperimentBodyDesignSpecDescriptionMaxOne),
+				design_url: zod
+					.union([
+						zod
+							.string()
+							.url()
+							.min(1)
+							.max(createExperimentBodyDesignSpecDesignUrlMaxFour),
+						zod.null(),
+					])
+					.optional(),
+				start_date: zod.string().datetime({}),
+				end_date: zod.string().datetime({}),
+				arms: zod
+					.array(
+						zod.object({
+							arm_id: zod.union([zod.string(), zod.null()]).optional(),
+							arm_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecDescriptionMaxOne),
-							design_url: zod
+								.max(createExperimentBodyDesignSpecArmsItemArmNameMaxOne),
+							arm_description: zod
 								.union([
 									zod
 										.string()
-										.url()
-										.min(1)
-										.max(createExperimentBodyDesignSpecDesignUrlMaxFour),
+										.max(
+											createExperimentBodyDesignSpecArmsItemArmDescriptionMaxFour,
+										),
 									zod.null(),
 								])
-								.optional()
-								.describe(
-									"Optional URL to a more detailed experiment design doc.",
-								),
-							start_date: zod.string().datetime({}),
-							end_date: zod.string().datetime({}),
-							arms: zod
-								.array(
-									zod
-										.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
-												.string()
-												.max(
-													createExperimentBodyDesignSpecArmsItemArmNameMaxOne,
-												),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecArmsItemArmDescriptionMaxFour,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-										})
-										.describe("Describes an experiment treatment arm."),
-								)
-								.min(createExperimentBodyDesignSpecArmsMinOne)
-								.max(createExperimentBodyDesignSpecArmsMaxOne),
-							table_name: zod
+								.optional(),
+							arm_weight: zod.union([zod.number(), zod.null()]).optional(),
+						}),
+					)
+					.min(createExperimentBodyDesignSpecArmsMinOne)
+					.max(createExperimentBodyDesignSpecArmsMaxOne),
+				table_name: zod
+					.string()
+					.max(createExperimentBodyDesignSpecTableNameMaxOne),
+				primary_key: zod
+					.string()
+					.regex(createExperimentBodyDesignSpecPrimaryKeyRegExpOne),
+				cluster_key: zod.union([zod.string(), zod.null()]).optional(),
+				strata: zod
+					.array(
+						zod.object({
+							field_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecTableNameMaxOne)
-								.describe(
-									"Datasource table used to resolve participant field metadata.",
+								.regex(
+									createExperimentBodyDesignSpecStrataItemFieldNameRegExpOne,
 								),
-							primary_key: zod
+						}),
+					)
+					.max(createExperimentBodyDesignSpecStrataMaxOne),
+				metrics: zod
+					.array(
+						zod.object({
+							field_name: zod
 								.string()
-								.regex(createExperimentBodyDesignSpecPrimaryKeyRegExpOne)
-								.describe(
-									"Column name in table_name that uniquely identifies each participant.",
+								.regex(
+									createExperimentBodyDesignSpecMetricsItemFieldNameRegExpOne,
 								),
-							strata: zod
-								.array(
-									zod
-										.object({
-											field_name: zod
-												.string()
-												.regex(
-													createExperimentBodyDesignSpecStrataItemFieldNameRegExpOne,
-												),
-										})
-										.describe("Describes a variable used for stratification."),
-								)
-								.max(createExperimentBodyDesignSpecStrataMaxOne)
-								.describe("Optional fields to use for stratified assignment."),
-							metrics: zod
-								.array(
-									zod
-										.object({
-											field_name: zod
-												.string()
-												.regex(
-													createExperimentBodyDesignSpecMetricsItemFieldNameRegExpOne,
-												),
-											metric_pct_change: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-												),
-											metric_target: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-												),
-										})
-										.describe(
-											"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-										),
-								)
-								.min(1)
-								.max(createExperimentBodyDesignSpecMetricsMaxOne)
-								.describe("Primary and optional secondary metrics to target."),
-							filters: zod
-								.array(
-									zod
-										.object({
-											field_name: zod
-												.string()
-												.regex(
-													createExperimentBodyDesignSpecFiltersItemFieldNameRegExpOne,
-												),
-											relation: zod
-												.enum(["includes", "excludes", "between"])
-												.describe(
-													"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-												),
-											value: zod.union([
-												zod.array(zod.union([zod.number(), zod.null()])),
-												zod.array(zod.union([zod.number(), zod.null()])),
-												zod.array(zod.union([zod.string(), zod.null()])),
-												zod.array(zod.union([zod.boolean(), zod.null()])),
-											]),
-										})
-										.describe(
-											'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-										),
-								)
-								.max(createExperimentBodyDesignSpecFiltersMaxOne)
-								.describe(
-									"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-								),
-							desired_n: zod
-								.union([
-									zod
-										.number()
-										.min(createExperimentBodyDesignSpecDesiredNMinFour),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-								),
-							power: zod
-								.number()
-								.min(createExperimentBodyDesignSpecPowerMinOne)
-								.max(createExperimentBodyDesignSpecPowerMaxOne)
-								.default(createExperimentBodyDesignSpecPowerDefaultOne)
-								.describe(
-									"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-								),
-							alpha: zod
-								.number()
-								.min(createExperimentBodyDesignSpecAlphaMinOne)
-								.max(createExperimentBodyDesignSpecAlphaMaxOne)
-								.default(createExperimentBodyDesignSpecAlphaDefaultOne)
-								.describe(
-									"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-								),
-							fstat_thresh: zod
-								.number()
-								.min(createExperimentBodyDesignSpecFstatThreshMinOne)
-								.max(createExperimentBodyDesignSpecFstatThreshMaxOne)
-								.default(createExperimentBodyDesignSpecFstatThreshDefaultOne)
-								.describe(
-									'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-								),
-						})
-						.describe(
-							"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-						),
-				])
-				.describe("The specific type of frequentist experiment design."),
-			zod
-				.union([
-					zod
-						.object({
-							experiment_type: zod.enum(["mab_online"]),
-							experiment_name: zod
+							metric_pct_change: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							metric_target: zod.union([zod.number(), zod.null()]).optional(),
+							icc: zod.union([zod.number(), zod.null()]).optional(),
+							avg_cluster_size: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							cv: zod.union([zod.number(), zod.null()]).optional(),
+						}),
+					)
+					.min(1)
+					.max(createExperimentBodyDesignSpecMetricsMaxOne),
+				filters: zod
+					.array(
+						zod.object({
+							field_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecExperimentNameMaxTwo),
-							description: zod
+								.regex(
+									createExperimentBodyDesignSpecFiltersItemFieldNameRegExpOne,
+								),
+							relation: zod.enum(["includes", "excludes", "between"]),
+							value: zod.union([
+								zod.array(zod.union([zod.number(), zod.null()])),
+								zod.array(zod.union([zod.number(), zod.null()])),
+								zod.array(zod.union([zod.string(), zod.null()])),
+								zod.array(zod.union([zod.boolean(), zod.null()])),
+							]),
+						}),
+					)
+					.max(createExperimentBodyDesignSpecFiltersMaxOne),
+				desired_n: zod
+					.union([
+						zod.number().min(createExperimentBodyDesignSpecDesiredNMinFour),
+						zod.null(),
+					])
+					.optional(),
+				power: zod
+					.number()
+					.min(createExperimentBodyDesignSpecPowerMinOne)
+					.max(createExperimentBodyDesignSpecPowerMaxOne)
+					.default(createExperimentBodyDesignSpecPowerDefaultOne),
+				alpha: zod
+					.number()
+					.min(createExperimentBodyDesignSpecAlphaMinOne)
+					.max(createExperimentBodyDesignSpecAlphaMaxOne)
+					.default(createExperimentBodyDesignSpecAlphaDefaultOne),
+				fstat_thresh: zod
+					.number()
+					.min(createExperimentBodyDesignSpecFstatThreshMinOne)
+					.max(createExperimentBodyDesignSpecFstatThreshMaxOne)
+					.default(createExperimentBodyDesignSpecFstatThreshDefaultOne),
+			}),
+		]),
+		zod.union([
+			zod.object({
+				experiment_type: zod.enum(["mab_online"]),
+				experiment_name: zod
+					.string()
+					.max(createExperimentBodyDesignSpecExperimentNameMaxTwo),
+				description: zod
+					.string()
+					.max(createExperimentBodyDesignSpecDescriptionMaxTwo),
+				design_url: zod
+					.union([
+						zod
+							.string()
+							.url()
+							.min(1)
+							.max(createExperimentBodyDesignSpecDesignUrlMaxSeven),
+						zod.null(),
+					])
+					.optional(),
+				start_date: zod.string().datetime({}),
+				end_date: zod.string().datetime({}),
+				arms: zod
+					.array(
+						zod.object({
+							arm_id: zod.union([zod.string(), zod.null()]).optional(),
+							arm_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecDescriptionMaxTwo),
-							design_url: zod
+								.max(createExperimentBodyDesignSpecArmsItemArmNameMaxTwo),
+							arm_description: zod
 								.union([
 									zod
 										.string()
-										.url()
-										.min(1)
-										.max(createExperimentBodyDesignSpecDesignUrlMaxSeven),
+										.max(
+											createExperimentBodyDesignSpecArmsItemArmDescriptionMaxSeven,
+										),
 									zod.null(),
 								])
-								.optional()
-								.describe(
-									"Optional URL to a more detailed experiment design doc.",
-								),
-							start_date: zod.string().datetime({}),
-							end_date: zod.string().datetime({}),
-							arms: zod
-								.array(
-									zod
-										.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
-												.string()
-												.max(
-													createExperimentBodyDesignSpecArmsItemArmNameMaxTwo,
-												),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecArmsItemArmDescriptionMaxSeven,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-											alpha_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial alpha parameter for Beta prior"),
-											beta_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial beta parameter for Beta prior"),
-											mu_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial mean parameter for Normal prior"),
-											sigma_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Initial standard deviation parameter for Normal prior",
-												),
-											alpha: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Updated alpha parameter for Beta prior"),
-											beta: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Updated beta parameter for Beta prior"),
-											mu: zod
-												.union([zod.array(zod.number()), zod.null()])
-												.optional()
-												.describe("Updated mean vector for Normal prior"),
-											covariance: zod
-												.union([zod.array(zod.array(zod.number())), zod.null()])
-												.optional()
-												.describe("Updated covariance matrix for Normal prior"),
-										})
-										.describe(
-											"Describes an experiment arm for bandit experiments.",
+								.optional(),
+							arm_weight: zod.union([zod.number(), zod.null()]).optional(),
+							alpha_init: zod.union([zod.number(), zod.null()]).optional(),
+							beta_init: zod.union([zod.number(), zod.null()]).optional(),
+							mu_init: zod.union([zod.number(), zod.null()]).optional(),
+							sigma_init: zod.union([zod.number(), zod.null()]).optional(),
+							alpha: zod.union([zod.number(), zod.null()]).optional(),
+							beta: zod.union([zod.number(), zod.null()]).optional(),
+							mu: zod.union([zod.array(zod.number()), zod.null()]).optional(),
+							covariance: zod
+								.union([zod.array(zod.array(zod.number())), zod.null()])
+								.optional(),
+						}),
+					)
+					.min(createExperimentBodyDesignSpecArmsMinTwo)
+					.max(createExperimentBodyDesignSpecArmsMaxTwo),
+				contexts: zod
+					.union([
+						zod
+							.array(
+								zod.object({
+									context_id: zod.union([zod.string(), zod.null()]).optional(),
+									context_name: zod
+										.string()
+										.max(
+											createExperimentBodyDesignSpecContextsItemContextNameMax,
 										),
-								)
-								.min(createExperimentBodyDesignSpecArmsMinTwo)
-								.max(createExperimentBodyDesignSpecArmsMaxTwo),
-							contexts: zod
-								.union([
-									zod
-										.array(
+									context_description: zod
+										.union([
 											zod
-												.object({
-													context_id: zod
-														.union([zod.string(), zod.null()])
-														.optional()
-														.describe(
-															"Unique identifier for the context, you should NOT set this when creating a new context.",
-														),
-													context_name: zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecContextsItemContextNameMax,
-														),
-													context_description: zod
-														.union([
-															zod
-																.string()
-																.max(
-																	createExperimentBodyDesignSpecContextsItemContextDescriptionMaxOne,
-																),
-															zod.null(),
-														])
-														.optional(),
-													value_type: zod
-														.enum(["binary", "real-valued"])
-														.optional()
-														.describe("Enum for the type of context."),
-												})
-												.describe(
-													"Pydantic model for context of the experiment.",
+												.string()
+												.max(
+													createExperimentBodyDesignSpecContextsItemContextDescriptionMaxOne,
 												),
-										)
-										.max(createExperimentBodyDesignSpecContextsMaxOne),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-								),
-							prior_type: zod
-								.enum(["beta", "normal"])
-								.optional()
-								.describe("Enum for the prior distribution of the arm."),
-							reward_type: zod
-								.enum(["binary", "real-valued"])
-								.optional()
-								.describe(
-									"Enum for the likelihood distribution of the reward.",
-								),
-						})
-						.describe(
-							"Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-						),
-					zod
-						.object({
-							experiment_type: zod.enum(["cmab_online"]),
-							experiment_name: zod
+											zod.null(),
+										])
+										.optional(),
+									value_type: zod.enum(["binary", "real-valued"]).optional(),
+								}),
+							)
+							.max(createExperimentBodyDesignSpecContextsMaxOne),
+						zod.null(),
+					])
+					.optional(),
+				prior_type: zod.enum(["beta", "normal"]).optional(),
+				reward_type: zod.enum(["binary", "real-valued"]).optional(),
+			}),
+			zod.object({
+				experiment_type: zod.enum(["cmab_online"]),
+				experiment_name: zod
+					.string()
+					.max(createExperimentBodyDesignSpecExperimentNameMaxThree),
+				description: zod
+					.string()
+					.max(createExperimentBodyDesignSpecDescriptionMaxThree),
+				design_url: zod
+					.union([
+						zod
+							.string()
+							.url()
+							.min(1)
+							.max(createExperimentBodyDesignSpecDesignUrlMaxOnezero),
+						zod.null(),
+					])
+					.optional(),
+				start_date: zod.string().datetime({}),
+				end_date: zod.string().datetime({}),
+				arms: zod
+					.array(
+						zod.object({
+							arm_id: zod.union([zod.string(), zod.null()]).optional(),
+							arm_name: zod
 								.string()
-								.max(createExperimentBodyDesignSpecExperimentNameMaxThree),
-							description: zod
-								.string()
-								.max(createExperimentBodyDesignSpecDescriptionMaxThree),
-							design_url: zod
+								.max(createExperimentBodyDesignSpecArmsItemArmNameMaxThree),
+							arm_description: zod
 								.union([
 									zod
 										.string()
-										.url()
-										.min(1)
-										.max(createExperimentBodyDesignSpecDesignUrlMaxOnezero),
+										.max(
+											createExperimentBodyDesignSpecArmsItemArmDescriptionMaxOnezero,
+										),
 									zod.null(),
 								])
-								.optional()
-								.describe(
-									"Optional URL to a more detailed experiment design doc.",
-								),
-							start_date: zod.string().datetime({}),
-							end_date: zod.string().datetime({}),
-							arms: zod
-								.array(
-									zod
-										.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
+								.optional(),
+							arm_weight: zod.union([zod.number(), zod.null()]).optional(),
+							alpha_init: zod.union([zod.number(), zod.null()]).optional(),
+							beta_init: zod.union([zod.number(), zod.null()]).optional(),
+							mu_init: zod.union([zod.number(), zod.null()]).optional(),
+							sigma_init: zod.union([zod.number(), zod.null()]).optional(),
+							alpha: zod.union([zod.number(), zod.null()]).optional(),
+							beta: zod.union([zod.number(), zod.null()]).optional(),
+							mu: zod.union([zod.array(zod.number()), zod.null()]).optional(),
+							covariance: zod
+								.union([zod.array(zod.array(zod.number())), zod.null()])
+								.optional(),
+						}),
+					)
+					.min(createExperimentBodyDesignSpecArmsMinThree)
+					.max(createExperimentBodyDesignSpecArmsMaxThree),
+				contexts: zod
+					.union([
+						zod
+							.array(
+								zod.object({
+									context_id: zod.union([zod.string(), zod.null()]).optional(),
+									context_name: zod
+										.string()
+										.max(
+											createExperimentBodyDesignSpecContextsItemContextNameMaxOne,
+										),
+									context_description: zod
+										.union([
+											zod
 												.string()
 												.max(
-													createExperimentBodyDesignSpecArmsItemArmNameMaxThree,
+													createExperimentBodyDesignSpecContextsItemContextDescriptionMaxFour,
 												),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecArmsItemArmDescriptionMaxOnezero,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-											alpha_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial alpha parameter for Beta prior"),
-											beta_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial beta parameter for Beta prior"),
-											mu_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Initial mean parameter for Normal prior"),
-											sigma_init: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Initial standard deviation parameter for Normal prior",
-												),
-											alpha: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Updated alpha parameter for Beta prior"),
-											beta: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe("Updated beta parameter for Beta prior"),
-											mu: zod
-												.union([zod.array(zod.number()), zod.null()])
-												.optional()
-												.describe("Updated mean vector for Normal prior"),
-											covariance: zod
-												.union([zod.array(zod.array(zod.number())), zod.null()])
-												.optional()
-												.describe("Updated covariance matrix for Normal prior"),
-										})
-										.describe(
-											"Describes an experiment arm for bandit experiments.",
-										),
-								)
-								.min(createExperimentBodyDesignSpecArmsMinThree)
-								.max(createExperimentBodyDesignSpecArmsMaxThree),
-							contexts: zod
-								.union([
-									zod
-										.array(
-											zod
-												.object({
-													context_id: zod
-														.union([zod.string(), zod.null()])
-														.optional()
-														.describe(
-															"Unique identifier for the context, you should NOT set this when creating a new context.",
-														),
-													context_name: zod
-														.string()
-														.max(
-															createExperimentBodyDesignSpecContextsItemContextNameMaxOne,
-														),
-													context_description: zod
-														.union([
-															zod
-																.string()
-																.max(
-																	createExperimentBodyDesignSpecContextsItemContextDescriptionMaxFour,
-																),
-															zod.null(),
-														])
-														.optional(),
-													value_type: zod
-														.enum(["binary", "real-valued"])
-														.optional()
-														.describe("Enum for the type of context."),
-												})
-												.describe(
-													"Pydantic model for context of the experiment.",
-												),
-										)
-										.max(createExperimentBodyDesignSpecContextsMaxFour),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-								),
-							prior_type: zod
-								.enum(["beta", "normal"])
-								.optional()
-								.describe("Enum for the prior distribution of the arm."),
-							reward_type: zod
-								.enum(["binary", "real-valued"])
-								.optional()
-								.describe(
-									"Enum for the likelihood distribution of the reward.",
-								),
-						})
-						.describe(
-							"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-						),
-				])
-				.describe("The specific type of bandit experiment design."),
-		])
-		.describe("The type of assignment and experiment design."),
+											zod.null(),
+										])
+										.optional(),
+									value_type: zod.enum(["binary", "real-valued"]).optional(),
+								}),
+							)
+							.max(createExperimentBodyDesignSpecContextsMaxFour),
+						zod.null(),
+					])
+					.optional(),
+				prior_type: zod.enum(["beta", "normal"]).optional(),
+				reward_type: zod.enum(["binary", "real-valued"]).optional(),
+			}),
+		]),
+	]),
 	power_analyses: zod
 		.union([
 			zod.object({
 				analyses: zod
 					.array(
-						zod
-							.object({
-								metric_spec: zod
-									.object({
-										field_name: zod
-											.string()
-											.regex(
-												createExperimentBodyPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp,
-											),
-										metric_pct_change: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Percent change target relative to the metric_baseline.",
-											),
-										metric_target: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Absolute target value = metric_baseline*(1 + metric_pct_change)",
-											),
-										metric_type: zod
+						zod.object({
+							metric_spec: zod.object({
+								field_name: zod
+									.string()
+									.regex(
+										createExperimentBodyPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp,
+									),
+								metric_pct_change: zod
+									.union([zod.number(), zod.null()])
+									.optional(),
+								metric_target: zod.union([zod.number(), zod.null()]).optional(),
+								icc: zod.union([zod.number(), zod.null()]).optional(),
+								avg_cluster_size: zod
+									.union([zod.number(), zod.null()])
+									.optional(),
+								cv: zod.union([zod.number(), zod.null()]).optional(),
+								metric_type: zod
+									.union([zod.enum(["binary", "numeric"]), zod.null()])
+									.optional(),
+								metric_baseline: zod
+									.union([zod.number(), zod.null()])
+									.optional(),
+								metric_stddev: zod.union([zod.number(), zod.null()]).optional(),
+								available_nonnull_n: zod
+									.union([zod.number(), zod.null()])
+									.optional(),
+								available_n: zod.union([zod.number(), zod.null()]).optional(),
+							}),
+							target_n: zod.union([zod.number(), zod.null()]).optional(),
+							sufficient_n: zod.union([zod.boolean(), zod.null()]).optional(),
+							target_possible: zod.union([zod.number(), zod.null()]).optional(),
+							pct_change_possible: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							pct_change_with_desired_n: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							msg: zod
+								.union([
+									zod.object({
+										type: zod.enum([
+											"sufficient",
+											"insufficient",
+											"no baseline",
+											"no available n",
+											"zero effect size",
+											"zero variation",
+										]),
+										msg: zod.string(),
+										source_msg: zod.string(),
+										values: zod
 											.union([
-												zod
-													.enum(["binary", "numeric"])
-													.describe("Classifies metrics by their value type."),
+												zod.record(
+													zod.string(),
+													zod.union([zod.number(), zod.number()]),
+												),
 												zod.null(),
 											])
-											.optional()
-											.describe("Inferred from dwh type."),
-										metric_baseline: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Mean of the tracked metric."),
-										metric_stddev: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0.",
-											),
-										available_nonnull_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"The number of participants meeting the filtering criteria with a *non-null* value for this metric.",
-											),
-										available_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-											),
-										icc: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Intracluster correlation coefficient for cluster-randomized designs.",
-											),
-										avg_cluster_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Average number of individuals per cluster."),
-										cv: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Coefficient of variation in cluster sizes (0 = equal sizes).",
-											),
-									})
-									.describe(
-										"Defines a metric to measure in an experiment with its baseline stats.",
-									),
-								target_n: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Minimum sample size needed to meet the design specs.",
-									),
-								sufficient_n: zod
-									.union([zod.boolean(), zod.null()])
-									.optional()
-									.describe(
-										"Whether or not there are enough available units to sample from to meet target_n.",
-									),
-								target_possible: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.",
-									),
-								pct_change_possible: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
-									),
-								pct_change_with_desired_n: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
-									),
-								msg: zod
-									.union([
-										zod
-											.object({
-												type: zod
-													.enum([
-														"sufficient",
-														"insufficient",
-														"no baseline",
-														"no available n",
-														"zero effect size",
-														"zero variation",
-													])
-													.describe(
-														"Classifies metric power analysis results.",
-													),
-												msg: zod
-													.string()
-													.describe(
-														"Main power analysis result stated in human-friendly English.",
-													),
-												source_msg: zod
-													.string()
-													.describe(
-														"Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages.",
-													),
-												values: zod
-													.union([
-														zod.record(
-															zod.string(),
-															zod.union([zod.number(), zod.number()]),
-														),
-														zod.null(),
-													])
-													.optional(),
-											})
-											.describe(
-												"Describes interpretation of power analysis results.",
-											),
-										zod.null(),
-									])
-									.optional()
-									.describe("Human friendly message about the above results."),
-								num_clusters_total: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Total number of clusters needed across all arms"),
-								clusters_per_arm: zod
-									.union([zod.array(zod.number()), zod.null()])
-									.optional()
-									.describe(
-										"Number of clusters needed for each arm (one entry per arm)",
-									),
-								n_per_arm: zod
-									.union([zod.array(zod.number()), zod.null()])
-									.optional()
-									.describe(
-										"Number of participants for each arm (one entry per arm)",
-									),
-								design_effect: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Design effect (DEFF) - clustering penalty multiplier",
-									),
-								effective_sample_size: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Effective sample size accounting for clustering (total_n / DEFF)",
-									),
-							})
-							.describe("Describes analysis results of a single metric."),
+											.optional(),
+										high_cluster_variation: zod.boolean().optional(),
+									}),
+									zod.null(),
+								])
+								.optional(),
+							num_clusters_total: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+							clusters_per_arm: zod
+								.union([zod.array(zod.number()), zod.null()])
+								.optional(),
+							n_per_arm: zod
+								.union([zod.array(zod.number()), zod.null()])
+								.optional(),
+							design_effect: zod.union([zod.number(), zod.null()]).optional(),
+							effective_sample_size: zod
+								.union([zod.number(), zod.null()])
+								.optional(),
+						}),
 					)
 					.max(createExperimentBodyPowerAnalysesAnalysesMax),
 			}),
@@ -3828,4594 +1027,24 @@ export const createExperimentBody = zod.object({
 		.optional(),
 	webhooks: zod
 		.array(zod.string())
-		.default(createExperimentBodyWebhooksDefault)
-		.describe(
-			"List of webhook IDs to associate with this experiment. When the experiment is committed, these webhooks will be triggered with experiment details. Must contain unique values.",
-		),
-});
-
-export const createExperimentResponseParticipantTypeDeprecatedMax = 100;
-
-export const createExperimentResponseDesignSpecExperimentNameMax = 100;
-
-export const createExperimentResponseDesignSpecDescriptionMax = 2000;
-
-export const createExperimentResponseDesignSpecDesignUrlMaxOne = 500;
-
-export const createExperimentResponseDesignSpecArmsItemArmNameMax = 100;
-
-export const createExperimentResponseDesignSpecArmsItemArmDescriptionMaxOne = 2000;
-
-export const createExperimentResponseDesignSpecArmsMin = 2;
-export const createExperimentResponseDesignSpecArmsMax = 20;
-
-export const createExperimentResponseDesignSpecTableNameMax = 100;
-
-export const createExperimentResponseDesignSpecPrimaryKeyRegExp = new RegExp(
-	"^[a-zA-Z_][a-zA-Z0-9_]*$",
-);
-export const createExperimentResponseDesignSpecStrataItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponseDesignSpecStrataMax = 150;
-
-export const createExperimentResponseDesignSpecMetricsItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponseDesignSpecMetricsMax = 150;
-
-export const createExperimentResponseDesignSpecFiltersItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponseDesignSpecFiltersMax = 20;
-
-export const createExperimentResponseDesignSpecDesiredNMinOne = 0;
-
-export const createExperimentResponseDesignSpecPowerDefault = 0.8;
-export const createExperimentResponseDesignSpecPowerMin = 0;
-export const createExperimentResponseDesignSpecPowerMax = 1;
-
-export const createExperimentResponseDesignSpecAlphaDefault = 0.05;
-export const createExperimentResponseDesignSpecAlphaMin = 0;
-export const createExperimentResponseDesignSpecAlphaMax = 1;
-
-export const createExperimentResponseDesignSpecFstatThreshDefault = 0.6;
-export const createExperimentResponseDesignSpecFstatThreshMin = 0;
-export const createExperimentResponseDesignSpecFstatThreshMax = 1;
-
-export const createExperimentResponseDesignSpecExperimentNameMaxOne = 100;
-
-export const createExperimentResponseDesignSpecDescriptionMaxOne = 2000;
-
-export const createExperimentResponseDesignSpecDesignUrlMaxFour = 500;
-
-export const createExperimentResponseDesignSpecArmsItemArmNameMaxOne = 100;
-
-export const createExperimentResponseDesignSpecArmsItemArmDescriptionMaxFour = 2000;
-
-export const createExperimentResponseDesignSpecArmsMinOne = 2;
-export const createExperimentResponseDesignSpecArmsMaxOne = 20;
-
-export const createExperimentResponseDesignSpecTableNameMaxOne = 100;
-
-export const createExperimentResponseDesignSpecPrimaryKeyRegExpOne = new RegExp(
-	"^[a-zA-Z_][a-zA-Z0-9_]*$",
-);
-export const createExperimentResponseDesignSpecStrataItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponseDesignSpecStrataMaxOne = 150;
-
-export const createExperimentResponseDesignSpecMetricsItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponseDesignSpecMetricsMaxOne = 150;
-
-export const createExperimentResponseDesignSpecFiltersItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponseDesignSpecFiltersMaxOne = 20;
-
-export const createExperimentResponseDesignSpecDesiredNMinFour = 0;
-
-export const createExperimentResponseDesignSpecPowerDefaultOne = 0.8;
-export const createExperimentResponseDesignSpecPowerMinOne = 0;
-export const createExperimentResponseDesignSpecPowerMaxOne = 1;
-
-export const createExperimentResponseDesignSpecAlphaDefaultOne = 0.05;
-export const createExperimentResponseDesignSpecAlphaMinOne = 0;
-export const createExperimentResponseDesignSpecAlphaMaxOne = 1;
-
-export const createExperimentResponseDesignSpecFstatThreshDefaultOne = 0.6;
-export const createExperimentResponseDesignSpecFstatThreshMinOne = 0;
-export const createExperimentResponseDesignSpecFstatThreshMaxOne = 1;
-
-export const createExperimentResponseDesignSpecExperimentNameMaxTwo = 100;
-
-export const createExperimentResponseDesignSpecDescriptionMaxTwo = 2000;
-
-export const createExperimentResponseDesignSpecDesignUrlMaxSeven = 500;
-
-export const createExperimentResponseDesignSpecArmsItemArmNameMaxTwo = 100;
-
-export const createExperimentResponseDesignSpecArmsItemArmDescriptionMaxSeven = 2000;
-
-export const createExperimentResponseDesignSpecArmsMinTwo = 2;
-export const createExperimentResponseDesignSpecArmsMaxTwo = 20;
-
-export const createExperimentResponseDesignSpecContextsItemContextNameMax = 100;
-
-export const createExperimentResponseDesignSpecContextsItemContextDescriptionMaxOne = 2000;
-
-export const createExperimentResponseDesignSpecContextsMaxOne = 150;
-
-export const createExperimentResponseDesignSpecExperimentNameMaxThree = 100;
-
-export const createExperimentResponseDesignSpecDescriptionMaxThree = 2000;
-
-export const createExperimentResponseDesignSpecDesignUrlMaxOnezero = 500;
-
-export const createExperimentResponseDesignSpecArmsItemArmNameMaxThree = 100;
-
-export const createExperimentResponseDesignSpecArmsItemArmDescriptionMaxOnezero = 2000;
-
-export const createExperimentResponseDesignSpecArmsMinThree = 2;
-export const createExperimentResponseDesignSpecArmsMaxThree = 20;
-
-export const createExperimentResponseDesignSpecContextsItemContextNameMaxOne = 100;
-
-export const createExperimentResponseDesignSpecContextsItemContextDescriptionMaxFour = 2000;
-
-export const createExperimentResponseDesignSpecContextsMaxFour = 150;
-
-export const createExperimentResponsePowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const createExperimentResponsePowerAnalysesAnalysesMax = 150;
-
-export const createExperimentResponseAssignSummaryArmSizesItemArmArmNameMax = 100;
-
-export const createExperimentResponseAssignSummaryArmSizesItemArmArmDescriptionMaxOne = 2000;
-
-export const createExperimentResponseAssignSummaryArmSizesItemSizeDefault = 0;
-export const createExperimentResponseAssignSummaryArmSizesMaxOne = 20;
-
-export const createExperimentResponseWebhooksDefault = [];
-export const createExperimentResponseDecisionDefault = "";
-
-export const createExperimentResponse = zod
-	.object({
-		experiment_id: zod
-			.string()
-			.describe("Server-generated ID of the experiment."),
-		datasource_id: zod.string(),
-		participant_type_deprecated: zod
-			.string()
-			.max(createExperimentResponseParticipantTypeDeprecatedMax)
-			.describe(
-				"(legacy experiments) Persisted participant-type name for backwards compatibility. New experiments will have this set to the empty string.",
-			),
-		state: zod
-			.enum(["designing", "assigned", "abandoned", "committed", "aborted"])
-			.describe(
-				"Experiment lifecycle states.\n\nnote: [starting state], [[terminal state]]\n[DESIGNING]->[ASSIGNED]->{[[ABANDONED]], COMMITTED}->[[ABORTED]]",
-			),
-		stopped_assignments_at: zod
-			.union([zod.string().datetime({}), zod.null()])
-			.describe(
-				"The date and time assignments were stopped. Null if assignments are still allowed to be made.",
-			),
-		stopped_assignments_reason: zod
-			.union([
-				zod
-					.enum(["preassigned", "end_date", "manual", "target_n"])
-					.describe("The reason assignments were stopped."),
-				zod.null(),
-			])
-			.describe(
-				"The reason assignments were stopped. Null if assignments are still allowed to be made.",
-			),
-		design_spec: zod
-			.union([
-				zod
-					.union([
-						zod
-							.object({
-								experiment_type: zod.enum(["freq_preassigned"]),
-								experiment_name: zod
-									.string()
-									.max(createExperimentResponseDesignSpecExperimentNameMax),
-								description: zod
-									.string()
-									.max(createExperimentResponseDesignSpecDescriptionMax),
-								design_url: zod
-									.union([
-										zod
-											.string()
-											.url()
-											.min(1)
-											.max(createExperimentResponseDesignSpecDesignUrlMaxOne),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional URL to a more detailed experiment design doc.",
-									),
-								start_date: zod.string().datetime({}),
-								end_date: zod.string().datetime({}),
-								arms: zod
-									.array(
-										zod
-											.object({
-												arm_id: zod
-													.union([zod.string(), zod.null()])
-													.optional()
-													.describe(
-														"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-													),
-												arm_name: zod
-													.string()
-													.max(
-														createExperimentResponseDesignSpecArmsItemArmNameMax,
-													),
-												arm_description: zod
-													.union([
-														zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecArmsItemArmDescriptionMaxOne,
-															),
-														zod.null(),
-													])
-													.optional(),
-												arm_weight: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-													),
-											})
-											.describe("Describes an experiment treatment arm."),
-									)
-									.min(createExperimentResponseDesignSpecArmsMin)
-									.max(createExperimentResponseDesignSpecArmsMax),
-								table_name: zod
-									.string()
-									.max(createExperimentResponseDesignSpecTableNameMax)
-									.describe(
-										"Datasource table used to resolve participant field metadata.",
-									),
-								primary_key: zod
-									.string()
-									.regex(createExperimentResponseDesignSpecPrimaryKeyRegExp)
-									.describe(
-										"Column name in table_name that uniquely identifies each participant.",
-									),
-								strata: zod
-									.array(
-										zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														createExperimentResponseDesignSpecStrataItemFieldNameRegExp,
-													),
-											})
-											.describe(
-												"Describes a variable used for stratification.",
-											),
-									)
-									.max(createExperimentResponseDesignSpecStrataMax)
-									.describe(
-										"Optional fields to use for stratified assignment.",
-									),
-								metrics: zod
-									.array(
-										zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														createExperimentResponseDesignSpecMetricsItemFieldNameRegExp,
-													),
-												metric_pct_change: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-													),
-												metric_target: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-													),
-											})
-											.describe(
-												"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-											),
-									)
-									.min(1)
-									.max(createExperimentResponseDesignSpecMetricsMax)
-									.describe(
-										"Primary and optional secondary metrics to target.",
-									),
-								filters: zod
-									.array(
-										zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														createExperimentResponseDesignSpecFiltersItemFieldNameRegExp,
-													),
-												relation: zod
-													.enum(["includes", "excludes", "between"])
-													.describe(
-														"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-													),
-												value: zod.union([
-													zod.array(zod.union([zod.number(), zod.null()])),
-													zod.array(zod.union([zod.number(), zod.null()])),
-													zod.array(zod.union([zod.string(), zod.null()])),
-													zod.array(zod.union([zod.boolean(), zod.null()])),
-												]),
-											})
-											.describe(
-												'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-											),
-									)
-									.max(createExperimentResponseDesignSpecFiltersMax)
-									.describe(
-										"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-									),
-								desired_n: zod
-									.union([
-										zod
-											.number()
-											.min(createExperimentResponseDesignSpecDesiredNMinOne),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-									),
-								power: zod
-									.number()
-									.min(createExperimentResponseDesignSpecPowerMin)
-									.max(createExperimentResponseDesignSpecPowerMax)
-									.default(createExperimentResponseDesignSpecPowerDefault)
-									.describe(
-										"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-									),
-								alpha: zod
-									.number()
-									.min(createExperimentResponseDesignSpecAlphaMin)
-									.max(createExperimentResponseDesignSpecAlphaMax)
-									.default(createExperimentResponseDesignSpecAlphaDefault)
-									.describe(
-										"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-									),
-								fstat_thresh: zod
-									.number()
-									.min(createExperimentResponseDesignSpecFstatThreshMin)
-									.max(createExperimentResponseDesignSpecFstatThreshMax)
-									.default(createExperimentResponseDesignSpecFstatThreshDefault)
-									.describe(
-										'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-									),
-							})
-							.describe(
-								"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
-							),
-						zod
-							.object({
-								experiment_type: zod.enum(["freq_online"]),
-								experiment_name: zod
-									.string()
-									.max(createExperimentResponseDesignSpecExperimentNameMaxOne),
-								description: zod
-									.string()
-									.max(createExperimentResponseDesignSpecDescriptionMaxOne),
-								design_url: zod
-									.union([
-										zod
-											.string()
-											.url()
-											.min(1)
-											.max(createExperimentResponseDesignSpecDesignUrlMaxFour),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional URL to a more detailed experiment design doc.",
-									),
-								start_date: zod.string().datetime({}),
-								end_date: zod.string().datetime({}),
-								arms: zod
-									.array(
-										zod
-											.object({
-												arm_id: zod
-													.union([zod.string(), zod.null()])
-													.optional()
-													.describe(
-														"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-													),
-												arm_name: zod
-													.string()
-													.max(
-														createExperimentResponseDesignSpecArmsItemArmNameMaxOne,
-													),
-												arm_description: zod
-													.union([
-														zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecArmsItemArmDescriptionMaxFour,
-															),
-														zod.null(),
-													])
-													.optional(),
-												arm_weight: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-													),
-											})
-											.describe("Describes an experiment treatment arm."),
-									)
-									.min(createExperimentResponseDesignSpecArmsMinOne)
-									.max(createExperimentResponseDesignSpecArmsMaxOne),
-								table_name: zod
-									.string()
-									.max(createExperimentResponseDesignSpecTableNameMaxOne)
-									.describe(
-										"Datasource table used to resolve participant field metadata.",
-									),
-								primary_key: zod
-									.string()
-									.regex(createExperimentResponseDesignSpecPrimaryKeyRegExpOne)
-									.describe(
-										"Column name in table_name that uniquely identifies each participant.",
-									),
-								strata: zod
-									.array(
-										zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														createExperimentResponseDesignSpecStrataItemFieldNameRegExpOne,
-													),
-											})
-											.describe(
-												"Describes a variable used for stratification.",
-											),
-									)
-									.max(createExperimentResponseDesignSpecStrataMaxOne)
-									.describe(
-										"Optional fields to use for stratified assignment.",
-									),
-								metrics: zod
-									.array(
-										zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														createExperimentResponseDesignSpecMetricsItemFieldNameRegExpOne,
-													),
-												metric_pct_change: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-													),
-												metric_target: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-													),
-											})
-											.describe(
-												"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-											),
-									)
-									.min(1)
-									.max(createExperimentResponseDesignSpecMetricsMaxOne)
-									.describe(
-										"Primary and optional secondary metrics to target.",
-									),
-								filters: zod
-									.array(
-										zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														createExperimentResponseDesignSpecFiltersItemFieldNameRegExpOne,
-													),
-												relation: zod
-													.enum(["includes", "excludes", "between"])
-													.describe(
-														"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-													),
-												value: zod.union([
-													zod.array(zod.union([zod.number(), zod.null()])),
-													zod.array(zod.union([zod.number(), zod.null()])),
-													zod.array(zod.union([zod.string(), zod.null()])),
-													zod.array(zod.union([zod.boolean(), zod.null()])),
-												]),
-											})
-											.describe(
-												'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-											),
-									)
-									.max(createExperimentResponseDesignSpecFiltersMaxOne)
-									.describe(
-										"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-									),
-								desired_n: zod
-									.union([
-										zod
-											.number()
-											.min(createExperimentResponseDesignSpecDesiredNMinFour),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-									),
-								power: zod
-									.number()
-									.min(createExperimentResponseDesignSpecPowerMinOne)
-									.max(createExperimentResponseDesignSpecPowerMaxOne)
-									.default(createExperimentResponseDesignSpecPowerDefaultOne)
-									.describe(
-										"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-									),
-								alpha: zod
-									.number()
-									.min(createExperimentResponseDesignSpecAlphaMinOne)
-									.max(createExperimentResponseDesignSpecAlphaMaxOne)
-									.default(createExperimentResponseDesignSpecAlphaDefaultOne)
-									.describe(
-										"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-									),
-								fstat_thresh: zod
-									.number()
-									.min(createExperimentResponseDesignSpecFstatThreshMinOne)
-									.max(createExperimentResponseDesignSpecFstatThreshMaxOne)
-									.default(
-										createExperimentResponseDesignSpecFstatThreshDefaultOne,
-									)
-									.describe(
-										'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-									),
-							})
-							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-							),
-					])
-					.describe("The specific type of frequentist experiment design."),
-				zod
-					.union([
-						zod
-							.object({
-								experiment_type: zod.enum(["mab_online"]),
-								experiment_name: zod
-									.string()
-									.max(createExperimentResponseDesignSpecExperimentNameMaxTwo),
-								description: zod
-									.string()
-									.max(createExperimentResponseDesignSpecDescriptionMaxTwo),
-								design_url: zod
-									.union([
-										zod
-											.string()
-											.url()
-											.min(1)
-											.max(createExperimentResponseDesignSpecDesignUrlMaxSeven),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional URL to a more detailed experiment design doc.",
-									),
-								start_date: zod.string().datetime({}),
-								end_date: zod.string().datetime({}),
-								arms: zod
-									.array(
-										zod
-											.object({
-												arm_id: zod
-													.union([zod.string(), zod.null()])
-													.optional()
-													.describe(
-														"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-													),
-												arm_name: zod
-													.string()
-													.max(
-														createExperimentResponseDesignSpecArmsItemArmNameMaxTwo,
-													),
-												arm_description: zod
-													.union([
-														zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecArmsItemArmDescriptionMaxSeven,
-															),
-														zod.null(),
-													])
-													.optional(),
-												arm_weight: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-													),
-												alpha_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial alpha parameter for Beta prior"),
-												beta_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial beta parameter for Beta prior"),
-												mu_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial mean parameter for Normal prior"),
-												sigma_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Initial standard deviation parameter for Normal prior",
-													),
-												alpha: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Updated alpha parameter for Beta prior"),
-												beta: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Updated beta parameter for Beta prior"),
-												mu: zod
-													.union([zod.array(zod.number()), zod.null()])
-													.optional()
-													.describe("Updated mean vector for Normal prior"),
-												covariance: zod
-													.union([
-														zod.array(zod.array(zod.number())),
-														zod.null(),
-													])
-													.optional()
-													.describe(
-														"Updated covariance matrix for Normal prior",
-													),
-											})
-											.describe(
-												"Describes an experiment arm for bandit experiments.",
-											),
-									)
-									.min(createExperimentResponseDesignSpecArmsMinTwo)
-									.max(createExperimentResponseDesignSpecArmsMaxTwo),
-								contexts: zod
-									.union([
-										zod
-											.array(
-												zod
-													.object({
-														context_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"Unique identifier for the context, you should NOT set this when creating a new context.",
-															),
-														context_name: zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecContextsItemContextNameMax,
-															),
-														context_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		createExperimentResponseDesignSpecContextsItemContextDescriptionMaxOne,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														value_type: zod
-															.enum(["binary", "real-valued"])
-															.optional()
-															.describe("Enum for the type of context."),
-													})
-													.describe(
-														"Pydantic model for context of the experiment.",
-													),
-											)
-											.max(createExperimentResponseDesignSpecContextsMaxOne),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-									),
-								prior_type: zod
-									.enum(["beta", "normal"])
-									.optional()
-									.describe("Enum for the prior distribution of the arm."),
-								reward_type: zod
-									.enum(["binary", "real-valued"])
-									.optional()
-									.describe(
-										"Enum for the likelihood distribution of the reward.",
-									),
-							})
-							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-							),
-						zod
-							.object({
-								experiment_type: zod.enum(["cmab_online"]),
-								experiment_name: zod
-									.string()
-									.max(
-										createExperimentResponseDesignSpecExperimentNameMaxThree,
-									),
-								description: zod
-									.string()
-									.max(createExperimentResponseDesignSpecDescriptionMaxThree),
-								design_url: zod
-									.union([
-										zod
-											.string()
-											.url()
-											.min(1)
-											.max(
-												createExperimentResponseDesignSpecDesignUrlMaxOnezero,
-											),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional URL to a more detailed experiment design doc.",
-									),
-								start_date: zod.string().datetime({}),
-								end_date: zod.string().datetime({}),
-								arms: zod
-									.array(
-										zod
-											.object({
-												arm_id: zod
-													.union([zod.string(), zod.null()])
-													.optional()
-													.describe(
-														"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-													),
-												arm_name: zod
-													.string()
-													.max(
-														createExperimentResponseDesignSpecArmsItemArmNameMaxThree,
-													),
-												arm_description: zod
-													.union([
-														zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecArmsItemArmDescriptionMaxOnezero,
-															),
-														zod.null(),
-													])
-													.optional(),
-												arm_weight: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-													),
-												alpha_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial alpha parameter for Beta prior"),
-												beta_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial beta parameter for Beta prior"),
-												mu_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Initial mean parameter for Normal prior"),
-												sigma_init: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Initial standard deviation parameter for Normal prior",
-													),
-												alpha: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Updated alpha parameter for Beta prior"),
-												beta: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Updated beta parameter for Beta prior"),
-												mu: zod
-													.union([zod.array(zod.number()), zod.null()])
-													.optional()
-													.describe("Updated mean vector for Normal prior"),
-												covariance: zod
-													.union([
-														zod.array(zod.array(zod.number())),
-														zod.null(),
-													])
-													.optional()
-													.describe(
-														"Updated covariance matrix for Normal prior",
-													),
-											})
-											.describe(
-												"Describes an experiment arm for bandit experiments.",
-											),
-									)
-									.min(createExperimentResponseDesignSpecArmsMinThree)
-									.max(createExperimentResponseDesignSpecArmsMaxThree),
-								contexts: zod
-									.union([
-										zod
-											.array(
-												zod
-													.object({
-														context_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"Unique identifier for the context, you should NOT set this when creating a new context.",
-															),
-														context_name: zod
-															.string()
-															.max(
-																createExperimentResponseDesignSpecContextsItemContextNameMaxOne,
-															),
-														context_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		createExperimentResponseDesignSpecContextsItemContextDescriptionMaxFour,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														value_type: zod
-															.enum(["binary", "real-valued"])
-															.optional()
-															.describe("Enum for the type of context."),
-													})
-													.describe(
-														"Pydantic model for context of the experiment.",
-													),
-											)
-											.max(createExperimentResponseDesignSpecContextsMaxFour),
-										zod.null(),
-									])
-									.optional()
-									.describe(
-										"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-									),
-								prior_type: zod
-									.enum(["beta", "normal"])
-									.optional()
-									.describe("Enum for the prior distribution of the arm."),
-								reward_type: zod
-									.enum(["binary", "real-valued"])
-									.optional()
-									.describe(
-										"Enum for the likelihood distribution of the reward.",
-									),
-							})
-							.describe(
-								"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-							),
-					])
-					.describe("The specific type of bandit experiment design."),
-			])
-			.describe("The type of assignment and experiment design."),
-		power_analyses: zod.union([
-			zod.object({
-				analyses: zod
-					.array(
-						zod
-							.object({
-								metric_spec: zod
-									.object({
-										field_name: zod
-											.string()
-											.regex(
-												createExperimentResponsePowerAnalysesAnalysesItemMetricSpecFieldNameRegExp,
-											),
-										metric_pct_change: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Percent change target relative to the metric_baseline.",
-											),
-										metric_target: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Absolute target value = metric_baseline*(1 + metric_pct_change)",
-											),
-										metric_type: zod
-											.union([
-												zod
-													.enum(["binary", "numeric"])
-													.describe("Classifies metrics by their value type."),
-												zod.null(),
-											])
-											.optional()
-											.describe("Inferred from dwh type."),
-										metric_baseline: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Mean of the tracked metric."),
-										metric_stddev: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0.",
-											),
-										available_nonnull_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"The number of participants meeting the filtering criteria with a *non-null* value for this metric.",
-											),
-										available_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-											),
-										icc: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Intracluster correlation coefficient for cluster-randomized designs.",
-											),
-										avg_cluster_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Average number of individuals per cluster."),
-										cv: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Coefficient of variation in cluster sizes (0 = equal sizes).",
-											),
-									})
-									.describe(
-										"Defines a metric to measure in an experiment with its baseline stats.",
-									),
-								target_n: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Minimum sample size needed to meet the design specs.",
-									),
-								sufficient_n: zod
-									.union([zod.boolean(), zod.null()])
-									.optional()
-									.describe(
-										"Whether or not there are enough available units to sample from to meet target_n.",
-									),
-								target_possible: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.",
-									),
-								pct_change_possible: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
-									),
-								pct_change_with_desired_n: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
-									),
-								msg: zod
-									.union([
-										zod
-											.object({
-												type: zod
-													.enum([
-														"sufficient",
-														"insufficient",
-														"no baseline",
-														"no available n",
-														"zero effect size",
-														"zero variation",
-													])
-													.describe(
-														"Classifies metric power analysis results.",
-													),
-												msg: zod
-													.string()
-													.describe(
-														"Main power analysis result stated in human-friendly English.",
-													),
-												source_msg: zod
-													.string()
-													.describe(
-														"Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages.",
-													),
-												values: zod
-													.union([
-														zod.record(
-															zod.string(),
-															zod.union([zod.number(), zod.number()]),
-														),
-														zod.null(),
-													])
-													.optional(),
-											})
-											.describe(
-												"Describes interpretation of power analysis results.",
-											),
-										zod.null(),
-									])
-									.optional()
-									.describe("Human friendly message about the above results."),
-								num_clusters_total: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Total number of clusters needed across all arms"),
-								clusters_per_arm: zod
-									.union([zod.array(zod.number()), zod.null()])
-									.optional()
-									.describe(
-										"Number of clusters needed for each arm (one entry per arm)",
-									),
-								n_per_arm: zod
-									.union([zod.array(zod.number()), zod.null()])
-									.optional()
-									.describe(
-										"Number of participants for each arm (one entry per arm)",
-									),
-								design_effect: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Design effect (DEFF) - clustering penalty multiplier",
-									),
-								effective_sample_size: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Effective sample size accounting for clustering (total_n / DEFF)",
-									),
-							})
-							.describe("Describes analysis results of a single metric."),
-					)
-					.max(createExperimentResponsePowerAnalysesAnalysesMax),
-			}),
-			zod.null(),
-		]),
-		assign_summary: zod.union([
-			zod
-				.object({
-					balance_check: zod
-						.union([
-							zod
-								.object({
-									f_statistic: zod
-										.number()
-										.describe(
-											"F-statistic testing the overall significance of the model predicting treatment assignment.",
-										),
-									numerator_df: zod
-										.number()
-										.describe(
-											"The numerator degrees of freedom for the f-statistic related to number of dependent variables.",
-										),
-									denominator_df: zod
-										.number()
-										.describe(
-											"Denominator degrees of freedom related to the number of observations.",
-										),
-									p_value: zod
-										.number()
-										.describe(
-											"Probability of observing these data if strata do not predict treatment assignment, i.e. our randomization is balanced.",
-										),
-									balance_ok: zod
-										.boolean()
-										.describe(
-											"Whether the p-value for our observed f_statistic is greater than the f-stat threshold specified in our design specification. (See DesignSpec.fstat_thresh)",
-										),
-								})
-								.describe(
-									"Describes balance test results for treatment assignment.",
-								),
-							zod.null(),
-						])
-						.optional()
-						.describe(
-							"Balance test results if available. 'online' experiments do not have balance checks.",
-						),
-					sample_size: zod
-						.number()
-						.describe("The number of participants across all arms in total."),
-					arm_sizes: zod
-						.union([
-							zod
-								.array(
-									zod
-										.object({
-											arm: zod
-												.object({
-													arm_id: zod
-														.union([zod.string(), zod.null()])
-														.optional()
-														.describe(
-															"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-														),
-													arm_name: zod
-														.string()
-														.max(
-															createExperimentResponseAssignSummaryArmSizesItemArmArmNameMax,
-														),
-													arm_description: zod
-														.union([
-															zod
-																.string()
-																.max(
-																	createExperimentResponseAssignSummaryArmSizesItemArmArmDescriptionMaxOne,
-																),
-															zod.null(),
-														])
-														.optional(),
-													arm_weight: zod
-														.union([zod.number(), zod.null()])
-														.optional()
-														.describe(
-															"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-														),
-												})
-												.describe("Describes an experiment treatment arm."),
-											size: zod.number().optional(),
-										})
-										.describe(
-											"Describes the number of participants assigned to each arm.",
-										),
-								)
-								.max(createExperimentResponseAssignSummaryArmSizesMaxOne),
-							zod.null(),
-						])
-						.optional()
-						.describe("For each arm, the number of participants assigned."),
-				})
-				.describe("Key pieces of an AssignResponse without the assignments."),
-			zod.null(),
-		]),
-		webhooks: zod
-			.array(zod.string())
-			.default(createExperimentResponseWebhooksDefault)
-			.describe(
-				"List of webhook IDs associated with this experiment. These webhooks are triggered when the experiment is committed.",
-			),
-		decision: zod
-			.string()
-			.optional()
-			.describe(
-				"Record any decision(s) made because of this experiment. Will you launch it, and if so when? Regardless of positive or negative results, how do any learnings inform next steps or future hypotheses?",
-			),
-		impact: zod
-			.enum(["high", "medium", "low", "negative", "unclear", ""])
-			.optional(),
-	})
-	.describe(
-		"Same as the request but with ids filled for the experiment and arms, and summary info on the assignment.",
-	);
-
-/**
- * For preassigned experiments, and online experiments (except contextual bandits),
-    returns an analysis of the experiment's performance, given datasource and experiment ID.
- * @summary Analyze Experiment
- */
-export const analyzeExperimentParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-export const analyzeExperimentQueryParams = zod.object({
-	baseline_arm_id: zod
-		.union([zod.string(), zod.null()])
-		.optional()
-		.describe(
-			"UUID of the baseline arm. If None, the first design spec arm is used.",
-		),
-});
-
-export const analyzeExperimentResponseMetricAnalysesItemMetricFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const analyzeExperimentResponseMetricAnalysesItemArmAnalysesItemArmNameMax = 100;
-
-export const analyzeExperimentResponseMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const analyzeExperimentResponseMetricAnalysesItemArmAnalysesItemNumMissingValuesMin =
-	-1;
-
-export const analyzeExperimentResponseArmAnalysesItemArmNameMax = 100;
-
-export const analyzeExperimentResponseArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const analyzeExperimentResponse = zod
-	.union([
-		zod
-			.object({
-				type: zod.enum(["freq"]),
-				experiment_id: zod.string().describe("ID of the experiment."),
-				metric_analyses: zod
-					.array(
-						zod
-							.object({
-								metric_name: zod.string(),
-								metric: zod
-									.object({
-										field_name: zod
-											.string()
-											.regex(
-												analyzeExperimentResponseMetricAnalysesItemMetricFieldNameRegExp,
-											),
-										metric_pct_change: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-											),
-										metric_target: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-											),
-									})
-									.describe(
-										"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-									),
-								arm_analyses: zod
-									.array(
-										zod.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
-												.string()
-												.max(
-													analyzeExperimentResponseMetricAnalysesItemArmAnalysesItemArmNameMax,
-												),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															analyzeExperimentResponseMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-											estimate: zod
-												.number()
-												.describe(
-													"The estimated treatment effect relative to the baseline arm.",
-												),
-											p_value: zod
-												.union([zod.number(), zod.null()])
-												.describe(
-													"The p-value indicating statistical significance of the treatment effect. Value may be None if the t-stat is not available, e.g. due to inability to calculate the standard error.",
-												),
-											t_stat: zod
-												.union([zod.number(), zod.null()])
-												.describe(
-													"The t-statistic from the statistical test. If the value is actually NaN, e.g. due to inability to calculate the standard error, we return None.",
-												),
-											std_error: zod
-												.union([zod.number(), zod.null()])
-												.describe(
-													"The standard error of the treatment effect estimate.",
-												),
-											ci_lower: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval lower bound for the regression coefficient estimate.",
-												),
-											ci_upper: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval upper bound for the regression coefficient estimate.",
-												),
-											mean_ci_lower: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval lower bound for the arm's mean.",
-												),
-											mean_ci_upper: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval upper bound for the arm's mean.",
-												),
-											num_missing_values: zod
-												.number()
-												.min(
-													analyzeExperimentResponseMetricAnalysesItemArmAnalysesItemNumMissingValuesMin,
-												)
-												.describe(
-													"The number of participants assigned to this arm with missing values (NaNs) for this metric. These rows are excluded from the analysis. -1 indicates arm analysis not available due to all assignments missing outcomes for this metric.",
-												),
-											is_baseline: zod
-												.boolean()
-												.describe(
-													"Whether this arm is the baseline/control arm for comparison.",
-												),
-										}),
-									)
-									.describe(
-										"The results of the analysis for each arm (coefficient) for this specific metric.",
-									),
-							})
-							.describe(
-								"Describes the change in a single metric for each arm of an experiment.",
-							),
-					)
-					.describe(
-						"Contains one analysis per metric targeted by the experiment.",
-					),
-				num_participants: zod
-					.number()
-					.describe(
-						"The number of participants assigned to the experiment pulled from the dwh across all arms. Metric outcomes are not guaranteed to be present for all participants.",
-					),
-				num_missing_participants: zod
-					.union([zod.number(), zod.null()])
-					.optional()
-					.describe(
-						"The number of participants assigned to the experiment across all arms that are not found in the data warehouse when pulling metrics.",
-					),
-				created_at: zod
-					.string()
-					.datetime({})
-					.describe("The date and time the experiment analysis was created."),
-			})
-			.describe(
-				"Describes the change if any in metrics targeted by an experiment.",
-			),
-		zod
-			.object({
-				type: zod.enum(["bandit"]),
-				experiment_id: zod.string().describe("ID of the experiment."),
-				arm_analyses: zod
-					.array(
-						zod
-							.object({
-								arm_id: zod
-									.union([zod.string(), zod.null()])
-									.optional()
-									.describe(
-										"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-									),
-								arm_name: zod
-									.string()
-									.max(analyzeExperimentResponseArmAnalysesItemArmNameMax),
-								arm_description: zod
-									.union([
-										zod
-											.string()
-											.max(
-												analyzeExperimentResponseArmAnalysesItemArmDescriptionMaxOne,
-											),
-										zod.null(),
-									])
-									.optional(),
-								arm_weight: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-									),
-								alpha_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Initial alpha parameter for Beta prior"),
-								beta_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Initial beta parameter for Beta prior"),
-								mu_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Initial mean parameter for Normal prior"),
-								sigma_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Initial standard deviation parameter for Normal prior",
-									),
-								alpha: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Updated alpha parameter for Beta prior"),
-								beta: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Updated beta parameter for Beta prior"),
-								mu: zod
-									.union([zod.array(zod.number()), zod.null()])
-									.optional()
-									.describe("Updated mean vector for Normal prior"),
-								covariance: zod
-									.union([zod.array(zod.array(zod.number())), zod.null()])
-									.optional()
-									.describe("Updated covariance matrix for Normal prior"),
-								prior_pred_mean: zod
-									.number()
-									.describe("Prior predictive mean for this arm."),
-								prior_pred_stdev: zod
-									.number()
-									.describe(
-										"Prior predictive standard deviation for this arm.",
-									),
-								prior_pred_ci_upper: zod
-									.number()
-									.describe(
-										"Prior predictive upper bound of 95% confidence interval for this arm.",
-									),
-								prior_pred_ci_lower: zod
-									.number()
-									.describe(
-										"Prior predictive lower bound of 95% confidence interval for this arm.",
-									),
-								post_pred_mean: zod
-									.number()
-									.describe("Posterior predictive mean for this arm."),
-								post_pred_stdev: zod
-									.number()
-									.describe(
-										"Posterior predictive standard deviation for this arm.",
-									),
-								post_pred_ci_upper: zod
-									.number()
-									.describe(
-										"Posterior predictive upper bound of 95% confidence interval for this arm.",
-									),
-								post_pred_ci_lower: zod
-									.number()
-									.describe(
-										"Posterior predictive lower bound of 95% confidence interval for this arm.",
-									),
-							})
-							.describe(
-								"Describes an experiment arm analysis for bandit experiments.",
-							),
-					)
-					.describe(
-						"Contains one analysis per metric targeted by the experiment.",
-					),
-				n_outcomes: zod
-					.number()
-					.describe("The number of outcomes observed for this experiment."),
-				created_at: zod
-					.string()
-					.datetime({})
-					.describe("The date and time the experiment analysis was created."),
-				contexts: zod
-					.union([zod.array(zod.number()), zod.null()])
-					.optional()
-					.describe("The context values used for the analysis, if applicable."),
-			})
-			.describe("Describes changes in arms for a bandit experiment"),
-	])
-	.describe("The type of experiment analysis response.");
-
-/**
- * For contextual bandit experiments, returns an analysis of the experiment's performance,
-    given datasource and experiment ID and context values as input.
- * @summary Analyze Cmab Experiment
- */
-export const analyzeCmabExperimentParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
+		.default(createExperimentBodyWebhooksDefault),
 });
 
 export const analyzeCmabExperimentBodyTypeDefault = "cmab_assignment";
 
-export const analyzeCmabExperimentBody = zod
-	.object({
-		type: zod
-			.literal("cmab_assignment")
-			.default(analyzeCmabExperimentBodyTypeDefault),
-		context_inputs: zod
-			.union([
-				zod.array(
-					zod
-						.object({
-							context_id: zod
-								.string()
-								.describe("Unique identifier for the context."),
-							context_value: zod.number().describe("Value of the context"),
-						})
-						.describe("Pydantic model for a context input"),
-				),
-				zod.null(),
-			])
-			.describe(
-				"\n            List of context values for the assignment.\n            Must include exactly the same number contexts defined in the experiment.\n            The values are matched to the experiment's contexts by context_id, not by position in the list.\n            Each context_id must correspond to one of the IDs of the contexts defined in the experiment.\n            Can be None, when simply retrieving pre-existing assignments; must have valid inputs otherwise.\n            ",
-			),
-	})
-	.describe(
-		'Request model for creating a new CMAB assignment or a CMAB experiment analysis.\n\nWhen submitting context values for a CMAB experiment, the following rules apply:\n1. Each context_input must reference a valid context_id from the experiment\'s defined contexts\n2. The order of context_inputs does not need to match the order of contexts in the experiment\n3. You must provide values for all contexts defined in the experiment\n4. Number of input context values must match the number of contexts defined in the experiment\n5. The context value input can be None, but only in the case of retrieving a pre-existing assignment.\n\nExample:\n    If an experiment defines contexts with IDs ["ctx_1", "ctx_2"], your request must include\n    both of these context_ids in the context_inputs list, but they can be in any order.',
-	);
-
-export const analyzeCmabExperimentResponseMetricAnalysesItemMetricFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const analyzeCmabExperimentResponseMetricAnalysesItemArmAnalysesItemArmNameMax = 100;
-
-export const analyzeCmabExperimentResponseMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const analyzeCmabExperimentResponseMetricAnalysesItemArmAnalysesItemNumMissingValuesMin =
-	-1;
-
-export const analyzeCmabExperimentResponseArmAnalysesItemArmNameMax = 100;
-
-export const analyzeCmabExperimentResponseArmAnalysesItemArmDescriptionMaxOne = 2000;
-
-export const analyzeCmabExperimentResponse = zod
-	.union([
-		zod
-			.object({
-				type: zod.enum(["freq"]),
-				experiment_id: zod.string().describe("ID of the experiment."),
-				metric_analyses: zod
-					.array(
-						zod
-							.object({
-								metric_name: zod.string(),
-								metric: zod
-									.object({
-										field_name: zod
-											.string()
-											.regex(
-												analyzeCmabExperimentResponseMetricAnalysesItemMetricFieldNameRegExp,
-											),
-										metric_pct_change: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-											),
-										metric_target: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-											),
-									})
-									.describe(
-										"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-									),
-								arm_analyses: zod
-									.array(
-										zod.object({
-											arm_id: zod
-												.union([zod.string(), zod.null()])
-												.optional()
-												.describe(
-													"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-												),
-											arm_name: zod
-												.string()
-												.max(
-													analyzeCmabExperimentResponseMetricAnalysesItemArmAnalysesItemArmNameMax,
-												),
-											arm_description: zod
-												.union([
-													zod
-														.string()
-														.max(
-															analyzeCmabExperimentResponseMetricAnalysesItemArmAnalysesItemArmDescriptionMaxOne,
-														),
-													zod.null(),
-												])
-												.optional(),
-											arm_weight: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-												),
-											estimate: zod
-												.number()
-												.describe(
-													"The estimated treatment effect relative to the baseline arm.",
-												),
-											p_value: zod
-												.union([zod.number(), zod.null()])
-												.describe(
-													"The p-value indicating statistical significance of the treatment effect. Value may be None if the t-stat is not available, e.g. due to inability to calculate the standard error.",
-												),
-											t_stat: zod
-												.union([zod.number(), zod.null()])
-												.describe(
-													"The t-statistic from the statistical test. If the value is actually NaN, e.g. due to inability to calculate the standard error, we return None.",
-												),
-											std_error: zod
-												.union([zod.number(), zod.null()])
-												.describe(
-													"The standard error of the treatment effect estimate.",
-												),
-											ci_lower: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval lower bound for the regression coefficient estimate.",
-												),
-											ci_upper: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval upper bound for the regression coefficient estimate.",
-												),
-											mean_ci_lower: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval lower bound for the arm's mean.",
-												),
-											mean_ci_upper: zod
-												.union([zod.number(), zod.null()])
-												.optional()
-												.describe(
-													"Confidence interval upper bound for the arm's mean.",
-												),
-											num_missing_values: zod
-												.number()
-												.min(
-													analyzeCmabExperimentResponseMetricAnalysesItemArmAnalysesItemNumMissingValuesMin,
-												)
-												.describe(
-													"The number of participants assigned to this arm with missing values (NaNs) for this metric. These rows are excluded from the analysis. -1 indicates arm analysis not available due to all assignments missing outcomes for this metric.",
-												),
-											is_baseline: zod
-												.boolean()
-												.describe(
-													"Whether this arm is the baseline/control arm for comparison.",
-												),
-										}),
-									)
-									.describe(
-										"The results of the analysis for each arm (coefficient) for this specific metric.",
-									),
-							})
-							.describe(
-								"Describes the change in a single metric for each arm of an experiment.",
-							),
-					)
-					.describe(
-						"Contains one analysis per metric targeted by the experiment.",
-					),
-				num_participants: zod
-					.number()
-					.describe(
-						"The number of participants assigned to the experiment pulled from the dwh across all arms. Metric outcomes are not guaranteed to be present for all participants.",
-					),
-				num_missing_participants: zod
-					.union([zod.number(), zod.null()])
-					.optional()
-					.describe(
-						"The number of participants assigned to the experiment across all arms that are not found in the data warehouse when pulling metrics.",
-					),
-				created_at: zod
-					.string()
-					.datetime({})
-					.describe("The date and time the experiment analysis was created."),
-			})
-			.describe(
-				"Describes the change if any in metrics targeted by an experiment.",
-			),
-		zod
-			.object({
-				type: zod.enum(["bandit"]),
-				experiment_id: zod.string().describe("ID of the experiment."),
-				arm_analyses: zod
-					.array(
-						zod
-							.object({
-								arm_id: zod
-									.union([zod.string(), zod.null()])
-									.optional()
-									.describe(
-										"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-									),
-								arm_name: zod
-									.string()
-									.max(analyzeCmabExperimentResponseArmAnalysesItemArmNameMax),
-								arm_description: zod
-									.union([
-										zod
-											.string()
-											.max(
-												analyzeCmabExperimentResponseArmAnalysesItemArmDescriptionMaxOne,
-											),
-										zod.null(),
-									])
-									.optional(),
-								arm_weight: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-									),
-								alpha_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Initial alpha parameter for Beta prior"),
-								beta_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Initial beta parameter for Beta prior"),
-								mu_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Initial mean parameter for Normal prior"),
-								sigma_init: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe(
-										"Initial standard deviation parameter for Normal prior",
-									),
-								alpha: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Updated alpha parameter for Beta prior"),
-								beta: zod
-									.union([zod.number(), zod.null()])
-									.optional()
-									.describe("Updated beta parameter for Beta prior"),
-								mu: zod
-									.union([zod.array(zod.number()), zod.null()])
-									.optional()
-									.describe("Updated mean vector for Normal prior"),
-								covariance: zod
-									.union([zod.array(zod.array(zod.number())), zod.null()])
-									.optional()
-									.describe("Updated covariance matrix for Normal prior"),
-								prior_pred_mean: zod
-									.number()
-									.describe("Prior predictive mean for this arm."),
-								prior_pred_stdev: zod
-									.number()
-									.describe(
-										"Prior predictive standard deviation for this arm.",
-									),
-								prior_pred_ci_upper: zod
-									.number()
-									.describe(
-										"Prior predictive upper bound of 95% confidence interval for this arm.",
-									),
-								prior_pred_ci_lower: zod
-									.number()
-									.describe(
-										"Prior predictive lower bound of 95% confidence interval for this arm.",
-									),
-								post_pred_mean: zod
-									.number()
-									.describe("Posterior predictive mean for this arm."),
-								post_pred_stdev: zod
-									.number()
-									.describe(
-										"Posterior predictive standard deviation for this arm.",
-									),
-								post_pred_ci_upper: zod
-									.number()
-									.describe(
-										"Posterior predictive upper bound of 95% confidence interval for this arm.",
-									),
-								post_pred_ci_lower: zod
-									.number()
-									.describe(
-										"Posterior predictive lower bound of 95% confidence interval for this arm.",
-									),
-							})
-							.describe(
-								"Describes an experiment arm analysis for bandit experiments.",
-							),
-					)
-					.describe(
-						"Contains one analysis per metric targeted by the experiment.",
-					),
-				n_outcomes: zod
-					.number()
-					.describe("The number of outcomes observed for this experiment."),
-				created_at: zod
-					.string()
-					.datetime({})
-					.describe("The date and time the experiment analysis was created."),
-				contexts: zod
-					.union([zod.array(zod.number()), zod.null()])
-					.optional()
-					.describe("The context values used for the analysis, if applicable."),
-			})
-			.describe("Describes changes in arms for a bandit experiment"),
-	])
-	.describe("The type of experiment analysis response.");
-
-/**
- * @summary Commit Experiment
- */
-export const commitExperimentParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-/**
- * @summary Abandon Experiment
- */
-export const abandonExperimentParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-/**
- * Returns a list of experiments in the organization.
- * @summary List Organization Experiments
- */
-export const listOrganizationExperimentsParams = zod.object({
-	organization_id: zod.string(),
-});
-
-export const listOrganizationExperimentsResponseItemsItemParticipantTypeDeprecatedMax = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMax = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMax = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxOne = 500;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMax = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxOne = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMin = 2;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMax = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecTableNameMax = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPrimaryKeyRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecStrataItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecStrataMax = 150;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecMetricsItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecMetricsMax = 150;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMax = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOne = 0;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefault = 0.8;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMin = 0;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMax = 1;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecAlphaDefault = 0.05;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMin = 0;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMax = 1;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshDefault = 0.6;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMin = 0;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMax = 1;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxOne = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxOne = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxFour = 500;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxOne = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxFour = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinOne = 2;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxOne = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecTableNameMaxOne = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPrimaryKeyRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecStrataItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecStrataMaxOne = 150;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecMetricsItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecMetricsMaxOne = 150;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMaxOne = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinFour = 0;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefaultOne = 0.8;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMinOne = 0;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecPowerMaxOne = 1;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecAlphaDefaultOne = 0.05;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMinOne = 0;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMaxOne = 1;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshDefaultOne = 0.6;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMinOne = 0;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMaxOne = 1;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxTwo = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxTwo = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxSeven = 500;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxTwo = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxSeven = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinTwo = 2;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxTwo = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextNameMax = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxOne = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxOne = 150;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxThree = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxThree = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxOnezero = 500;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxThree = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxOnezero = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinThree = 2;
-export const listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxThree = 20;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextNameMaxOne = 100;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxFour = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxFour = 150;
-
-export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesMax = 150;
-
-export const listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemArmArmNameMax = 100;
-
-export const listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemArmArmDescriptionMaxOne = 2000;
-
-export const listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemSizeDefault = 0;
-export const listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesMaxOne = 20;
-
-export const listOrganizationExperimentsResponseItemsItemWebhooksDefault = [];
-export const listOrganizationExperimentsResponseItemsItemDecisionDefault = "";
-
-export const listOrganizationExperimentsResponse = zod.object({
-	items: zod.array(
-		zod
-			.object({
-				experiment_id: zod
-					.string()
-					.describe("Server-generated ID of the experiment."),
-				datasource_id: zod.string(),
-				participant_type_deprecated: zod
-					.string()
-					.max(
-						listOrganizationExperimentsResponseItemsItemParticipantTypeDeprecatedMax,
-					)
-					.describe(
-						"(legacy experiments) Persisted participant-type name for backwards compatibility. New experiments will have this set to the empty string.",
-					),
-				state: zod
-					.enum(["designing", "assigned", "abandoned", "committed", "aborted"])
-					.describe(
-						"Experiment lifecycle states.\n\nnote: [starting state], [[terminal state]]\n[DESIGNING]->[ASSIGNED]->{[[ABANDONED]], COMMITTED}->[[ABORTED]]",
-					),
-				stopped_assignments_at: zod
-					.union([zod.string().datetime({}), zod.null()])
-					.describe(
-						"The date and time assignments were stopped. Null if assignments are still allowed to be made.",
-					),
-				stopped_assignments_reason: zod
-					.union([
-						zod
-							.enum(["preassigned", "end_date", "manual", "target_n"])
-							.describe("The reason assignments were stopped."),
-						zod.null(),
-					])
-					.describe(
-						"The reason assignments were stopped. Null if assignments are still allowed to be made.",
-					),
-				design_spec: zod
-					.union([
-						zod
-							.union([
-								zod
-									.object({
-										experiment_type: zod.enum(["freq_preassigned"]),
-										experiment_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMax,
-											),
-										description: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMax,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxOne,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMax,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxOne,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-													})
-													.describe("Describes an experiment treatment arm."),
-											)
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMin,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMax,
-											),
-										table_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecTableNameMax,
-											)
-											.describe(
-												"Datasource table used to resolve participant field metadata.",
-											),
-										primary_key: zod
-											.string()
-											.regex(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPrimaryKeyRegExp,
-											)
-											.describe(
-												"Column name in table_name that uniquely identifies each participant.",
-											),
-										strata: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																listOrganizationExperimentsResponseItemsItemDesignSpecStrataItemFieldNameRegExp,
-															),
-													})
-													.describe(
-														"Describes a variable used for stratification.",
-													),
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecStrataMax,
-											)
-											.describe(
-												"Optional fields to use for stratified assignment.",
-											),
-										metrics: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																listOrganizationExperimentsResponseItemsItemDesignSpecMetricsItemFieldNameRegExp,
-															),
-														metric_pct_change: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-															),
-														metric_target: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-															),
-													})
-													.describe(
-														"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-													),
-											)
-											.min(1)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecMetricsMax,
-											)
-											.describe(
-												"Primary and optional secondary metrics to target.",
-											),
-										filters: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFieldNameRegExp,
-															),
-														relation: zod
-															.enum(["includes", "excludes", "between"])
-															.describe(
-																"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-															),
-														value: zod.union([
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.string(), zod.null()])),
-															zod.array(zod.union([zod.boolean(), zod.null()])),
-														]),
-													})
-													.describe(
-														'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-													),
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMax,
-											)
-											.describe(
-												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-											),
-										desired_n: zod
-											.union([
-												zod
-													.number()
-													.min(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinOne,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-											),
-										power: zod
-											.number()
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPowerMin,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPowerMax,
-											)
-											.default(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefault,
-											)
-											.describe(
-												"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-											),
-										alpha: zod
-											.number()
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMin,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMax,
-											)
-											.default(
-												listOrganizationExperimentsResponseItemsItemDesignSpecAlphaDefault,
-											)
-											.describe(
-												"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-											),
-										fstat_thresh: zod
-											.number()
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMin,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMax,
-											)
-											.default(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshDefault,
-											)
-											.describe(
-												'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-											),
-									})
-									.describe(
-										"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
-									),
-								zod
-									.object({
-										experiment_type: zod.enum(["freq_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxOne,
-											),
-										description: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxOne,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxFour,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxOne,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxFour,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-													})
-													.describe("Describes an experiment treatment arm."),
-											)
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinOne,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxOne,
-											),
-										table_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecTableNameMaxOne,
-											)
-											.describe(
-												"Datasource table used to resolve participant field metadata.",
-											),
-										primary_key: zod
-											.string()
-											.regex(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPrimaryKeyRegExpOne,
-											)
-											.describe(
-												"Column name in table_name that uniquely identifies each participant.",
-											),
-										strata: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																listOrganizationExperimentsResponseItemsItemDesignSpecStrataItemFieldNameRegExpOne,
-															),
-													})
-													.describe(
-														"Describes a variable used for stratification.",
-													),
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecStrataMaxOne,
-											)
-											.describe(
-												"Optional fields to use for stratified assignment.",
-											),
-										metrics: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																listOrganizationExperimentsResponseItemsItemDesignSpecMetricsItemFieldNameRegExpOne,
-															),
-														metric_pct_change: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-															),
-														metric_target: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-															),
-													})
-													.describe(
-														"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-													),
-											)
-											.min(1)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecMetricsMaxOne,
-											)
-											.describe(
-												"Primary and optional secondary metrics to target.",
-											),
-										filters: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																listOrganizationExperimentsResponseItemsItemDesignSpecFiltersItemFieldNameRegExpOne,
-															),
-														relation: zod
-															.enum(["includes", "excludes", "between"])
-															.describe(
-																"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-															),
-														value: zod.union([
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.string(), zod.null()])),
-															zod.array(zod.union([zod.boolean(), zod.null()])),
-														]),
-													})
-													.describe(
-														'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-													),
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFiltersMaxOne,
-											)
-											.describe(
-												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-											),
-										desired_n: zod
-											.union([
-												zod
-													.number()
-													.min(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesiredNMinFour,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-											),
-										power: zod
-											.number()
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPowerMinOne,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPowerMaxOne,
-											)
-											.default(
-												listOrganizationExperimentsResponseItemsItemDesignSpecPowerDefaultOne,
-											)
-											.describe(
-												"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-											),
-										alpha: zod
-											.number()
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMinOne,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecAlphaMaxOne,
-											)
-											.default(
-												listOrganizationExperimentsResponseItemsItemDesignSpecAlphaDefaultOne,
-											)
-											.describe(
-												"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-											),
-										fstat_thresh: zod
-											.number()
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMinOne,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshMaxOne,
-											)
-											.default(
-												listOrganizationExperimentsResponseItemsItemDesignSpecFstatThreshDefaultOne,
-											)
-											.describe(
-												'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
-							])
-							.describe("The specific type of frequentist experiment design."),
-						zod
-							.union([
-								zod
-									.object({
-										experiment_type: zod.enum(["mab_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxTwo,
-											),
-										description: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxTwo,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxSeven,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxTwo,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxSeven,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-														alpha_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial alpha parameter for Beta prior",
-															),
-														beta_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial beta parameter for Beta prior",
-															),
-														mu_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial mean parameter for Normal prior",
-															),
-														sigma_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial standard deviation parameter for Normal prior",
-															),
-														alpha: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated alpha parameter for Beta prior",
-															),
-														beta: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated beta parameter for Beta prior",
-															),
-														mu: zod
-															.union([zod.array(zod.number()), zod.null()])
-															.optional()
-															.describe("Updated mean vector for Normal prior"),
-														covariance: zod
-															.union([
-																zod.array(zod.array(zod.number())),
-																zod.null(),
-															])
-															.optional()
-															.describe(
-																"Updated covariance matrix for Normal prior",
-															),
-													})
-													.describe(
-														"Describes an experiment arm for bandit experiments.",
-													),
-											)
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinTwo,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxTwo,
-											),
-										contexts: zod
-											.union([
-												zod
-													.array(
-														zod
-															.object({
-																context_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Unique identifier for the context, you should NOT set this when creating a new context.",
-																	),
-																context_name: zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextNameMax,
-																	),
-																context_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxOne,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																value_type: zod
-																	.enum(["binary", "real-valued"])
-																	.optional()
-																	.describe("Enum for the type of context."),
-															})
-															.describe(
-																"Pydantic model for context of the experiment.",
-															),
-													)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxOne,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-											),
-										prior_type: zod
-											.enum(["beta", "normal"])
-											.optional()
-											.describe("Enum for the prior distribution of the arm."),
-										reward_type: zod
-											.enum(["binary", "real-valued"])
-											.optional()
-											.describe(
-												"Enum for the likelihood distribution of the reward.",
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
-								zod
-									.object({
-										experiment_type: zod.enum(["cmab_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecExperimentNameMaxThree,
-											),
-										description: zod
-											.string()
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecDescriptionMaxThree,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecDesignUrlMaxOnezero,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmNameMaxThree,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecArmsItemArmDescriptionMaxOnezero,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-														alpha_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial alpha parameter for Beta prior",
-															),
-														beta_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial beta parameter for Beta prior",
-															),
-														mu_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial mean parameter for Normal prior",
-															),
-														sigma_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial standard deviation parameter for Normal prior",
-															),
-														alpha: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated alpha parameter for Beta prior",
-															),
-														beta: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated beta parameter for Beta prior",
-															),
-														mu: zod
-															.union([zod.array(zod.number()), zod.null()])
-															.optional()
-															.describe("Updated mean vector for Normal prior"),
-														covariance: zod
-															.union([
-																zod.array(zod.array(zod.number())),
-																zod.null(),
-															])
-															.optional()
-															.describe(
-																"Updated covariance matrix for Normal prior",
-															),
-													})
-													.describe(
-														"Describes an experiment arm for bandit experiments.",
-													),
-											)
-											.min(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMinThree,
-											)
-											.max(
-												listOrganizationExperimentsResponseItemsItemDesignSpecArmsMaxThree,
-											),
-										contexts: zod
-											.union([
-												zod
-													.array(
-														zod
-															.object({
-																context_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Unique identifier for the context, you should NOT set this when creating a new context.",
-																	),
-																context_name: zod
-																	.string()
-																	.max(
-																		listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextNameMaxOne,
-																	),
-																context_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				listOrganizationExperimentsResponseItemsItemDesignSpecContextsItemContextDescriptionMaxFour,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																value_type: zod
-																	.enum(["binary", "real-valued"])
-																	.optional()
-																	.describe("Enum for the type of context."),
-															})
-															.describe(
-																"Pydantic model for context of the experiment.",
-															),
-													)
-													.max(
-														listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxFour,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-											),
-										prior_type: zod
-											.enum(["beta", "normal"])
-											.optional()
-											.describe("Enum for the prior distribution of the arm."),
-										reward_type: zod
-											.enum(["binary", "real-valued"])
-											.optional()
-											.describe(
-												"Enum for the likelihood distribution of the reward.",
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
-							])
-							.describe("The specific type of bandit experiment design."),
-					])
-					.describe("The type of assignment and experiment design."),
-				power_analyses: zod.union([
-					zod.object({
-						analyses: zod
-							.array(
-								zod
-									.object({
-										metric_spec: zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp,
-													),
-												metric_pct_change: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Percent change target relative to the metric_baseline.",
-													),
-												metric_target: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Absolute target value = metric_baseline*(1 + metric_pct_change)",
-													),
-												metric_type: zod
-													.union([
-														zod
-															.enum(["binary", "numeric"])
-															.describe(
-																"Classifies metrics by their value type.",
-															),
-														zod.null(),
-													])
-													.optional()
-													.describe("Inferred from dwh type."),
-												metric_baseline: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Mean of the tracked metric."),
-												metric_stddev: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0.",
-													),
-												available_nonnull_n: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"The number of participants meeting the filtering criteria with a *non-null* value for this metric.",
-													),
-												available_n: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-													),
-												icc: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Intracluster correlation coefficient for cluster-randomized designs.",
-													),
-												avg_cluster_size: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Average number of individuals per cluster.",
-													),
-												cv: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Coefficient of variation in cluster sizes (0 = equal sizes).",
-													),
-											})
-											.describe(
-												"Defines a metric to measure in an experiment with its baseline stats.",
-											),
-										target_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Minimum sample size needed to meet the design specs.",
-											),
-										sufficient_n: zod
-											.union([zod.boolean(), zod.null()])
-											.optional()
-											.describe(
-												"Whether or not there are enough available units to sample from to meet target_n.",
-											),
-										target_possible: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.",
-											),
-										pct_change_possible: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
-											),
-										pct_change_with_desired_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
-											),
-										msg: zod
-											.union([
-												zod
-													.object({
-														type: zod
-															.enum([
-																"sufficient",
-																"insufficient",
-																"no baseline",
-																"no available n",
-																"zero effect size",
-																"zero variation",
-															])
-															.describe(
-																"Classifies metric power analysis results.",
-															),
-														msg: zod
-															.string()
-															.describe(
-																"Main power analysis result stated in human-friendly English.",
-															),
-														source_msg: zod
-															.string()
-															.describe(
-																"Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages.",
-															),
-														values: zod
-															.union([
-																zod.record(
-																	zod.string(),
-																	zod.union([zod.number(), zod.number()]),
-																),
-																zod.null(),
-															])
-															.optional(),
-													})
-													.describe(
-														"Describes interpretation of power analysis results.",
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Human friendly message about the above results.",
-											),
-										num_clusters_total: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Total number of clusters needed across all arms",
-											),
-										clusters_per_arm: zod
-											.union([zod.array(zod.number()), zod.null()])
-											.optional()
-											.describe(
-												"Number of clusters needed for each arm (one entry per arm)",
-											),
-										n_per_arm: zod
-											.union([zod.array(zod.number()), zod.null()])
-											.optional()
-											.describe(
-												"Number of participants for each arm (one entry per arm)",
-											),
-										design_effect: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Design effect (DEFF) - clustering penalty multiplier",
-											),
-										effective_sample_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Effective sample size accounting for clustering (total_n / DEFF)",
-											),
-									})
-									.describe("Describes analysis results of a single metric."),
-							)
-							.max(
-								listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesMax,
-							),
-					}),
-					zod.null(),
-				]),
-				assign_summary: zod.union([
-					zod
-						.object({
-							balance_check: zod
-								.union([
-									zod
-										.object({
-											f_statistic: zod
-												.number()
-												.describe(
-													"F-statistic testing the overall significance of the model predicting treatment assignment.",
-												),
-											numerator_df: zod
-												.number()
-												.describe(
-													"The numerator degrees of freedom for the f-statistic related to number of dependent variables.",
-												),
-											denominator_df: zod
-												.number()
-												.describe(
-													"Denominator degrees of freedom related to the number of observations.",
-												),
-											p_value: zod
-												.number()
-												.describe(
-													"Probability of observing these data if strata do not predict treatment assignment, i.e. our randomization is balanced.",
-												),
-											balance_ok: zod
-												.boolean()
-												.describe(
-													"Whether the p-value for our observed f_statistic is greater than the f-stat threshold specified in our design specification. (See DesignSpec.fstat_thresh)",
-												),
-										})
-										.describe(
-											"Describes balance test results for treatment assignment.",
-										),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Balance test results if available. 'online' experiments do not have balance checks.",
-								),
-							sample_size: zod
-								.number()
-								.describe(
-									"The number of participants across all arms in total.",
-								),
-							arm_sizes: zod
-								.union([
-									zod
-										.array(
-											zod
-												.object({
-													arm: zod
-														.object({
-															arm_id: zod
-																.union([zod.string(), zod.null()])
-																.optional()
-																.describe(
-																	"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-																),
-															arm_name: zod
-																.string()
-																.max(
-																	listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemArmArmNameMax,
-																),
-															arm_description: zod
-																.union([
-																	zod
-																		.string()
-																		.max(
-																			listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemArmArmDescriptionMaxOne,
-																		),
-																	zod.null(),
-																])
-																.optional(),
-															arm_weight: zod
-																.union([zod.number(), zod.null()])
-																.optional()
-																.describe(
-																	"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-																),
-														})
-														.describe("Describes an experiment treatment arm."),
-													size: zod.number().optional(),
-												})
-												.describe(
-													"Describes the number of participants assigned to each arm.",
-												),
-										)
-										.max(
-											listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesMaxOne,
-										),
-									zod.null(),
-								])
-								.optional()
-								.describe("For each arm, the number of participants assigned."),
-						})
-						.describe(
-							"Key pieces of an AssignResponse without the assignments.",
-						),
-					zod.null(),
-				]),
-				webhooks: zod
-					.array(zod.string())
-					.default(listOrganizationExperimentsResponseItemsItemWebhooksDefault)
-					.describe(
-						"List of webhook IDs associated with this experiment. These webhooks are triggered when the experiment is committed.",
-					),
-				decision: zod
-					.string()
-					.optional()
-					.describe(
-						"Record any decision(s) made because of this experiment. Will you launch it, and if so when? Regardless of positive or negative results, how do any learnings inform next steps or future hypotheses?",
-					),
-				impact: zod
-					.enum(["high", "medium", "low", "negative", "unclear", ""])
-					.optional(),
-			})
-			.describe("Representation of our stored Experiment information."),
-	),
-});
-
-/**
- * Returns the experiment with the specified ID.
- * @summary Get Experiment For Ui
- */
-export const getExperimentForUiParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-export const getExperimentForUiResponseConfigParticipantTypeDeprecatedMax = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecExperimentNameMax = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecDescriptionMax = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecDesignUrlMaxOne = 500;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMax = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxOne = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsMin = 2;
-export const getExperimentForUiResponseConfigDesignSpecArmsMax = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecTableNameMax = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecPrimaryKeyRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecStrataItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecStrataMax = 150;
-
-export const getExperimentForUiResponseConfigDesignSpecMetricsItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecMetricsMax = 150;
-
-export const getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecFiltersMax = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecDesiredNMinOne = 0;
-
-export const getExperimentForUiResponseConfigDesignSpecPowerDefault = 0.8;
-export const getExperimentForUiResponseConfigDesignSpecPowerMin = 0;
-export const getExperimentForUiResponseConfigDesignSpecPowerMax = 1;
-
-export const getExperimentForUiResponseConfigDesignSpecAlphaDefault = 0.05;
-export const getExperimentForUiResponseConfigDesignSpecAlphaMin = 0;
-export const getExperimentForUiResponseConfigDesignSpecAlphaMax = 1;
-
-export const getExperimentForUiResponseConfigDesignSpecFstatThreshDefault = 0.6;
-export const getExperimentForUiResponseConfigDesignSpecFstatThreshMin = 0;
-export const getExperimentForUiResponseConfigDesignSpecFstatThreshMax = 1;
-
-export const getExperimentForUiResponseConfigDesignSpecExperimentNameMaxOne = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecDescriptionMaxOne = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecDesignUrlMaxFour = 500;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxOne = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxFour = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsMinOne = 2;
-export const getExperimentForUiResponseConfigDesignSpecArmsMaxOne = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecTableNameMaxOne = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecPrimaryKeyRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecStrataItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecStrataMaxOne = 150;
-
-export const getExperimentForUiResponseConfigDesignSpecMetricsItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecMetricsMaxOne = 150;
-
-export const getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegExpOne =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigDesignSpecFiltersMaxOne = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecDesiredNMinFour = 0;
-
-export const getExperimentForUiResponseConfigDesignSpecPowerDefaultOne = 0.8;
-export const getExperimentForUiResponseConfigDesignSpecPowerMinOne = 0;
-export const getExperimentForUiResponseConfigDesignSpecPowerMaxOne = 1;
-
-export const getExperimentForUiResponseConfigDesignSpecAlphaDefaultOne = 0.05;
-export const getExperimentForUiResponseConfigDesignSpecAlphaMinOne = 0;
-export const getExperimentForUiResponseConfigDesignSpecAlphaMaxOne = 1;
-
-export const getExperimentForUiResponseConfigDesignSpecFstatThreshDefaultOne = 0.6;
-export const getExperimentForUiResponseConfigDesignSpecFstatThreshMinOne = 0;
-export const getExperimentForUiResponseConfigDesignSpecFstatThreshMaxOne = 1;
-
-export const getExperimentForUiResponseConfigDesignSpecExperimentNameMaxTwo = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecDescriptionMaxTwo = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecDesignUrlMaxSeven = 500;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxTwo = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxSeven = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsMinTwo = 2;
-export const getExperimentForUiResponseConfigDesignSpecArmsMaxTwo = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMax = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxOne = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsMaxOne = 150;
-
-export const getExperimentForUiResponseConfigDesignSpecExperimentNameMaxThree = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecDescriptionMaxThree = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecDesignUrlMaxOnezero = 500;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxThree = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxOnezero = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecArmsMinThree = 2;
-export const getExperimentForUiResponseConfigDesignSpecArmsMaxThree = 20;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMaxOne = 100;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxFour = 2000;
-
-export const getExperimentForUiResponseConfigDesignSpecContextsMaxFour = 150;
-
-export const getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const getExperimentForUiResponseConfigPowerAnalysesAnalysesMax = 150;
-
-export const getExperimentForUiResponseConfigAssignSummaryArmSizesItemArmArmNameMax = 100;
-
-export const getExperimentForUiResponseConfigAssignSummaryArmSizesItemArmArmDescriptionMaxOne = 2000;
-
-export const getExperimentForUiResponseConfigAssignSummaryArmSizesItemSizeDefault = 0;
-export const getExperimentForUiResponseConfigAssignSummaryArmSizesMaxOne = 20;
-
-export const getExperimentForUiResponseConfigWebhooksDefault = [];
-export const getExperimentForUiResponseConfigDecisionDefault = "";
-export const getExperimentForUiResponseParticipantTypeFieldsItemDescriptionDefault =
-	"";
-export const getExperimentForUiResponseParticipantTypeFieldsItemIsUniqueIdDefault = false;
-export const getExperimentForUiResponseParticipantTypeFieldsItemIsStrataDefault = false;
-export const getExperimentForUiResponseParticipantTypeFieldsItemIsFilterDefault = false;
-export const getExperimentForUiResponseParticipantTypeFieldsItemIsMetricDefault = false;
-export const getExperimentForUiResponseParticipantTypeHiddenDefault = false;
-
-export const getExperimentForUiResponse = zod
-	.object({
-		config: zod
-			.object({
-				experiment_id: zod
-					.string()
-					.describe("Server-generated ID of the experiment."),
-				datasource_id: zod.string(),
-				participant_type_deprecated: zod
-					.string()
-					.max(getExperimentForUiResponseConfigParticipantTypeDeprecatedMax)
-					.describe(
-						"(legacy experiments) Persisted participant-type name for backwards compatibility. New experiments will have this set to the empty string.",
-					),
-				state: zod
-					.enum(["designing", "assigned", "abandoned", "committed", "aborted"])
-					.describe(
-						"Experiment lifecycle states.\n\nnote: [starting state], [[terminal state]]\n[DESIGNING]->[ASSIGNED]->{[[ABANDONED]], COMMITTED}->[[ABORTED]]",
-					),
-				stopped_assignments_at: zod
-					.union([zod.string().datetime({}), zod.null()])
-					.describe(
-						"The date and time assignments were stopped. Null if assignments are still allowed to be made.",
-					),
-				stopped_assignments_reason: zod
-					.union([
-						zod
-							.enum(["preassigned", "end_date", "manual", "target_n"])
-							.describe("The reason assignments were stopped."),
-						zod.null(),
-					])
-					.describe(
-						"The reason assignments were stopped. Null if assignments are still allowed to be made.",
-					),
-				design_spec: zod
-					.union([
-						zod
-							.union([
-								zod
-									.object({
-										experiment_type: zod.enum(["freq_preassigned"]),
-										experiment_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecExperimentNameMax,
-											),
-										description: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecDescriptionMax,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecDesignUrlMaxOne,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMax,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxOne,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-													})
-													.describe("Describes an experiment treatment arm."),
-											)
-											.min(getExperimentForUiResponseConfigDesignSpecArmsMin)
-											.max(getExperimentForUiResponseConfigDesignSpecArmsMax),
-										table_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecTableNameMax,
-											)
-											.describe(
-												"Datasource table used to resolve participant field metadata.",
-											),
-										primary_key: zod
-											.string()
-											.regex(
-												getExperimentForUiResponseConfigDesignSpecPrimaryKeyRegExp,
-											)
-											.describe(
-												"Column name in table_name that uniquely identifies each participant.",
-											),
-										strata: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																getExperimentForUiResponseConfigDesignSpecStrataItemFieldNameRegExp,
-															),
-													})
-													.describe(
-														"Describes a variable used for stratification.",
-													),
-											)
-											.max(getExperimentForUiResponseConfigDesignSpecStrataMax)
-											.describe(
-												"Optional fields to use for stratified assignment.",
-											),
-										metrics: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																getExperimentForUiResponseConfigDesignSpecMetricsItemFieldNameRegExp,
-															),
-														metric_pct_change: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-															),
-														metric_target: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-															),
-													})
-													.describe(
-														"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-													),
-											)
-											.min(1)
-											.max(getExperimentForUiResponseConfigDesignSpecMetricsMax)
-											.describe(
-												"Primary and optional secondary metrics to target.",
-											),
-										filters: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegExp,
-															),
-														relation: zod
-															.enum(["includes", "excludes", "between"])
-															.describe(
-																"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-															),
-														value: zod.union([
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.string(), zod.null()])),
-															zod.array(zod.union([zod.boolean(), zod.null()])),
-														]),
-													})
-													.describe(
-														'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-													),
-											)
-											.max(getExperimentForUiResponseConfigDesignSpecFiltersMax)
-											.describe(
-												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-											),
-										desired_n: zod
-											.union([
-												zod
-													.number()
-													.min(
-														getExperimentForUiResponseConfigDesignSpecDesiredNMinOne,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-											),
-										power: zod
-											.number()
-											.min(getExperimentForUiResponseConfigDesignSpecPowerMin)
-											.max(getExperimentForUiResponseConfigDesignSpecPowerMax)
-											.default(
-												getExperimentForUiResponseConfigDesignSpecPowerDefault,
-											)
-											.describe(
-												"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-											),
-										alpha: zod
-											.number()
-											.min(getExperimentForUiResponseConfigDesignSpecAlphaMin)
-											.max(getExperimentForUiResponseConfigDesignSpecAlphaMax)
-											.default(
-												getExperimentForUiResponseConfigDesignSpecAlphaDefault,
-											)
-											.describe(
-												"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-											),
-										fstat_thresh: zod
-											.number()
-											.min(
-												getExperimentForUiResponseConfigDesignSpecFstatThreshMin,
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecFstatThreshMax,
-											)
-											.default(
-												getExperimentForUiResponseConfigDesignSpecFstatThreshDefault,
-											)
-											.describe(
-												'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-											),
-									})
-									.describe(
-										"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
-									),
-								zod
-									.object({
-										experiment_type: zod.enum(["freq_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecExperimentNameMaxOne,
-											),
-										description: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecDescriptionMaxOne,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecDesignUrlMaxFour,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxOne,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxFour,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-													})
-													.describe("Describes an experiment treatment arm."),
-											)
-											.min(getExperimentForUiResponseConfigDesignSpecArmsMinOne)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecArmsMaxOne,
-											),
-										table_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecTableNameMaxOne,
-											)
-											.describe(
-												"Datasource table used to resolve participant field metadata.",
-											),
-										primary_key: zod
-											.string()
-											.regex(
-												getExperimentForUiResponseConfigDesignSpecPrimaryKeyRegExpOne,
-											)
-											.describe(
-												"Column name in table_name that uniquely identifies each participant.",
-											),
-										strata: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																getExperimentForUiResponseConfigDesignSpecStrataItemFieldNameRegExpOne,
-															),
-													})
-													.describe(
-														"Describes a variable used for stratification.",
-													),
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecStrataMaxOne,
-											)
-											.describe(
-												"Optional fields to use for stratified assignment.",
-											),
-										metrics: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																getExperimentForUiResponseConfigDesignSpecMetricsItemFieldNameRegExpOne,
-															),
-														metric_pct_change: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-															),
-														metric_target: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-															),
-													})
-													.describe(
-														"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-													),
-											)
-											.min(1)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecMetricsMaxOne,
-											)
-											.describe(
-												"Primary and optional secondary metrics to target.",
-											),
-										filters: zod
-											.array(
-												zod
-													.object({
-														field_name: zod
-															.string()
-															.regex(
-																getExperimentForUiResponseConfigDesignSpecFiltersItemFieldNameRegExpOne,
-															),
-														relation: zod
-															.enum(["includes", "excludes", "between"])
-															.describe(
-																"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-															),
-														value: zod.union([
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.number(), zod.null()])),
-															zod.array(zod.union([zod.string(), zod.null()])),
-															zod.array(zod.union([zod.boolean(), zod.null()])),
-														]),
-													})
-													.describe(
-														'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-													),
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecFiltersMaxOne,
-											)
-											.describe(
-												"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-											),
-										desired_n: zod
-											.union([
-												zod
-													.number()
-													.min(
-														getExperimentForUiResponseConfigDesignSpecDesiredNMinFour,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-											),
-										power: zod
-											.number()
-											.min(
-												getExperimentForUiResponseConfigDesignSpecPowerMinOne,
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecPowerMaxOne,
-											)
-											.default(
-												getExperimentForUiResponseConfigDesignSpecPowerDefaultOne,
-											)
-											.describe(
-												"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-											),
-										alpha: zod
-											.number()
-											.min(
-												getExperimentForUiResponseConfigDesignSpecAlphaMinOne,
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecAlphaMaxOne,
-											)
-											.default(
-												getExperimentForUiResponseConfigDesignSpecAlphaDefaultOne,
-											)
-											.describe(
-												"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-											),
-										fstat_thresh: zod
-											.number()
-											.min(
-												getExperimentForUiResponseConfigDesignSpecFstatThreshMinOne,
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecFstatThreshMaxOne,
-											)
-											.default(
-												getExperimentForUiResponseConfigDesignSpecFstatThreshDefaultOne,
-											)
-											.describe(
-												'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
-							])
-							.describe("The specific type of frequentist experiment design."),
-						zod
-							.union([
-								zod
-									.object({
-										experiment_type: zod.enum(["mab_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecExperimentNameMaxTwo,
-											),
-										description: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecDescriptionMaxTwo,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecDesignUrlMaxSeven,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxTwo,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxSeven,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-														alpha_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial alpha parameter for Beta prior",
-															),
-														beta_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial beta parameter for Beta prior",
-															),
-														mu_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial mean parameter for Normal prior",
-															),
-														sigma_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial standard deviation parameter for Normal prior",
-															),
-														alpha: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated alpha parameter for Beta prior",
-															),
-														beta: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated beta parameter for Beta prior",
-															),
-														mu: zod
-															.union([zod.array(zod.number()), zod.null()])
-															.optional()
-															.describe("Updated mean vector for Normal prior"),
-														covariance: zod
-															.union([
-																zod.array(zod.array(zod.number())),
-																zod.null(),
-															])
-															.optional()
-															.describe(
-																"Updated covariance matrix for Normal prior",
-															),
-													})
-													.describe(
-														"Describes an experiment arm for bandit experiments.",
-													),
-											)
-											.min(getExperimentForUiResponseConfigDesignSpecArmsMinTwo)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecArmsMaxTwo,
-											),
-										contexts: zod
-											.union([
-												zod
-													.array(
-														zod
-															.object({
-																context_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Unique identifier for the context, you should NOT set this when creating a new context.",
-																	),
-																context_name: zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMax,
-																	),
-																context_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxOne,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																value_type: zod
-																	.enum(["binary", "real-valued"])
-																	.optional()
-																	.describe("Enum for the type of context."),
-															})
-															.describe(
-																"Pydantic model for context of the experiment.",
-															),
-													)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecContextsMaxOne,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-											),
-										prior_type: zod
-											.enum(["beta", "normal"])
-											.optional()
-											.describe("Enum for the prior distribution of the arm."),
-										reward_type: zod
-											.enum(["binary", "real-valued"])
-											.optional()
-											.describe(
-												"Enum for the likelihood distribution of the reward.",
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
-								zod
-									.object({
-										experiment_type: zod.enum(["cmab_online"]),
-										experiment_name: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecExperimentNameMaxThree,
-											),
-										description: zod
-											.string()
-											.max(
-												getExperimentForUiResponseConfigDesignSpecDescriptionMaxThree,
-											),
-										design_url: zod
-											.union([
-												zod
-													.string()
-													.url()
-													.min(1)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecDesignUrlMaxOnezero,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional URL to a more detailed experiment design doc.",
-											),
-										start_date: zod.string().datetime({}),
-										end_date: zod.string().datetime({}),
-										arms: zod
-											.array(
-												zod
-													.object({
-														arm_id: zod
-															.union([zod.string(), zod.null()])
-															.optional()
-															.describe(
-																"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-															),
-														arm_name: zod
-															.string()
-															.max(
-																getExperimentForUiResponseConfigDesignSpecArmsItemArmNameMaxThree,
-															),
-														arm_description: zod
-															.union([
-																zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecArmsItemArmDescriptionMaxOnezero,
-																	),
-																zod.null(),
-															])
-															.optional(),
-														arm_weight: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-															),
-														alpha_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial alpha parameter for Beta prior",
-															),
-														beta_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial beta parameter for Beta prior",
-															),
-														mu_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial mean parameter for Normal prior",
-															),
-														sigma_init: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Initial standard deviation parameter for Normal prior",
-															),
-														alpha: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated alpha parameter for Beta prior",
-															),
-														beta: zod
-															.union([zod.number(), zod.null()])
-															.optional()
-															.describe(
-																"Updated beta parameter for Beta prior",
-															),
-														mu: zod
-															.union([zod.array(zod.number()), zod.null()])
-															.optional()
-															.describe("Updated mean vector for Normal prior"),
-														covariance: zod
-															.union([
-																zod.array(zod.array(zod.number())),
-																zod.null(),
-															])
-															.optional()
-															.describe(
-																"Updated covariance matrix for Normal prior",
-															),
-													})
-													.describe(
-														"Describes an experiment arm for bandit experiments.",
-													),
-											)
-											.min(
-												getExperimentForUiResponseConfigDesignSpecArmsMinThree,
-											)
-											.max(
-												getExperimentForUiResponseConfigDesignSpecArmsMaxThree,
-											),
-										contexts: zod
-											.union([
-												zod
-													.array(
-														zod
-															.object({
-																context_id: zod
-																	.union([zod.string(), zod.null()])
-																	.optional()
-																	.describe(
-																		"Unique identifier for the context, you should NOT set this when creating a new context.",
-																	),
-																context_name: zod
-																	.string()
-																	.max(
-																		getExperimentForUiResponseConfigDesignSpecContextsItemContextNameMaxOne,
-																	),
-																context_description: zod
-																	.union([
-																		zod
-																			.string()
-																			.max(
-																				getExperimentForUiResponseConfigDesignSpecContextsItemContextDescriptionMaxFour,
-																			),
-																		zod.null(),
-																	])
-																	.optional(),
-																value_type: zod
-																	.enum(["binary", "real-valued"])
-																	.optional()
-																	.describe("Enum for the type of context."),
-															})
-															.describe(
-																"Pydantic model for context of the experiment.",
-															),
-													)
-													.max(
-														getExperimentForUiResponseConfigDesignSpecContextsMaxFour,
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.",
-											),
-										prior_type: zod
-											.enum(["beta", "normal"])
-											.optional()
-											.describe("Enum for the prior distribution of the arm."),
-										reward_type: zod
-											.enum(["binary", "real-valued"])
-											.optional()
-											.describe(
-												"Enum for the likelihood distribution of the reward.",
-											),
-									})
-									.describe(
-										"Use this type to randomly assign participants into arms during live experiment execution with\ncontextual MAB experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-									),
-							])
-							.describe("The specific type of bandit experiment design."),
-					])
-					.describe("The type of assignment and experiment design."),
-				power_analyses: zod.union([
-					zod.object({
-						analyses: zod
-							.array(
-								zod
-									.object({
-										metric_spec: zod
-											.object({
-												field_name: zod
-													.string()
-													.regex(
-														getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp,
-													),
-												metric_pct_change: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Percent change target relative to the metric_baseline.",
-													),
-												metric_target: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Absolute target value = metric_baseline*(1 + metric_pct_change)",
-													),
-												metric_type: zod
-													.union([
-														zod
-															.enum(["binary", "numeric"])
-															.describe(
-																"Classifies metrics by their value type.",
-															),
-														zod.null(),
-													])
-													.optional()
-													.describe("Inferred from dwh type."),
-												metric_baseline: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe("Mean of the tracked metric."),
-												metric_stddev: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0.",
-													),
-												available_nonnull_n: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"The number of participants meeting the filtering criteria with a *non-null* value for this metric.",
-													),
-												available_n: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-													),
-												icc: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Intracluster correlation coefficient for cluster-randomized designs.",
-													),
-												avg_cluster_size: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Average number of individuals per cluster.",
-													),
-												cv: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Coefficient of variation in cluster sizes (0 = equal sizes).",
-													),
-											})
-											.describe(
-												"Defines a metric to measure in an experiment with its baseline stats.",
-											),
-										target_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Minimum sample size needed to meet the design specs.",
-											),
-										sufficient_n: zod
-											.union([zod.boolean(), zod.null()])
-											.optional()
-											.describe(
-												"Whether or not there are enough available units to sample from to meet target_n.",
-											),
-										target_possible: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.",
-											),
-										pct_change_possible: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
-											),
-										pct_change_with_desired_n: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
-											),
-										msg: zod
-											.union([
-												zod
-													.object({
-														type: zod
-															.enum([
-																"sufficient",
-																"insufficient",
-																"no baseline",
-																"no available n",
-																"zero effect size",
-																"zero variation",
-															])
-															.describe(
-																"Classifies metric power analysis results.",
-															),
-														msg: zod
-															.string()
-															.describe(
-																"Main power analysis result stated in human-friendly English.",
-															),
-														source_msg: zod
-															.string()
-															.describe(
-																"Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages.",
-															),
-														values: zod
-															.union([
-																zod.record(
-																	zod.string(),
-																	zod.union([zod.number(), zod.number()]),
-																),
-																zod.null(),
-															])
-															.optional(),
-													})
-													.describe(
-														"Describes interpretation of power analysis results.",
-													),
-												zod.null(),
-											])
-											.optional()
-											.describe(
-												"Human friendly message about the above results.",
-											),
-										num_clusters_total: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Total number of clusters needed across all arms",
-											),
-										clusters_per_arm: zod
-											.union([zod.array(zod.number()), zod.null()])
-											.optional()
-											.describe(
-												"Number of clusters needed for each arm (one entry per arm)",
-											),
-										n_per_arm: zod
-											.union([zod.array(zod.number()), zod.null()])
-											.optional()
-											.describe(
-												"Number of participants for each arm (one entry per arm)",
-											),
-										design_effect: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Design effect (DEFF) - clustering penalty multiplier",
-											),
-										effective_sample_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Effective sample size accounting for clustering (total_n / DEFF)",
-											),
-									})
-									.describe("Describes analysis results of a single metric."),
-							)
-							.max(getExperimentForUiResponseConfigPowerAnalysesAnalysesMax),
-					}),
-					zod.null(),
-				]),
-				assign_summary: zod.union([
-					zod
-						.object({
-							balance_check: zod
-								.union([
-									zod
-										.object({
-											f_statistic: zod
-												.number()
-												.describe(
-													"F-statistic testing the overall significance of the model predicting treatment assignment.",
-												),
-											numerator_df: zod
-												.number()
-												.describe(
-													"The numerator degrees of freedom for the f-statistic related to number of dependent variables.",
-												),
-											denominator_df: zod
-												.number()
-												.describe(
-													"Denominator degrees of freedom related to the number of observations.",
-												),
-											p_value: zod
-												.number()
-												.describe(
-													"Probability of observing these data if strata do not predict treatment assignment, i.e. our randomization is balanced.",
-												),
-											balance_ok: zod
-												.boolean()
-												.describe(
-													"Whether the p-value for our observed f_statistic is greater than the f-stat threshold specified in our design specification. (See DesignSpec.fstat_thresh)",
-												),
-										})
-										.describe(
-											"Describes balance test results for treatment assignment.",
-										),
-									zod.null(),
-								])
-								.optional()
-								.describe(
-									"Balance test results if available. 'online' experiments do not have balance checks.",
-								),
-							sample_size: zod
-								.number()
-								.describe(
-									"The number of participants across all arms in total.",
-								),
-							arm_sizes: zod
-								.union([
-									zod
-										.array(
-											zod
-												.object({
-													arm: zod
-														.object({
-															arm_id: zod
-																.union([zod.string(), zod.null()])
-																.optional()
-																.describe(
-																	"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-																),
-															arm_name: zod
-																.string()
-																.max(
-																	getExperimentForUiResponseConfigAssignSummaryArmSizesItemArmArmNameMax,
-																),
-															arm_description: zod
-																.union([
-																	zod
-																		.string()
-																		.max(
-																			getExperimentForUiResponseConfigAssignSummaryArmSizesItemArmArmDescriptionMaxOne,
-																		),
-																	zod.null(),
-																])
-																.optional(),
-															arm_weight: zod
-																.union([zod.number(), zod.null()])
-																.optional()
-																.describe(
-																	"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-																),
-														})
-														.describe("Describes an experiment treatment arm."),
-													size: zod.number().optional(),
-												})
-												.describe(
-													"Describes the number of participants assigned to each arm.",
-												),
-										)
-										.max(
-											getExperimentForUiResponseConfigAssignSummaryArmSizesMaxOne,
-										),
-									zod.null(),
-								])
-								.optional()
-								.describe("For each arm, the number of participants assigned."),
-						})
-						.describe(
-							"Key pieces of an AssignResponse without the assignments.",
-						),
-					zod.null(),
-				]),
-				webhooks: zod
-					.array(zod.string())
-					.default(getExperimentForUiResponseConfigWebhooksDefault)
-					.describe(
-						"List of webhook IDs associated with this experiment. These webhooks are triggered when the experiment is committed.",
-					),
-				decision: zod
-					.string()
-					.optional()
-					.describe(
-						"Record any decision(s) made because of this experiment. Will you launch it, and if so when? Regardless of positive or negative results, how do any learnings inform next steps or future hypotheses?",
-					),
-				impact: zod
-					.enum(["high", "medium", "low", "negative", "unclear", ""])
-					.optional(),
-			})
-			.describe("Representation of our stored Experiment information."),
-		participant_type: zod
-			.union([
-				zod
-					.object({
-						table_name: zod
-							.string()
-							.describe("Name of the table in the data warehouse"),
-						fields: zod
-							.array(
-								zod.object({
-									field_name: zod
-										.string()
-										.describe("Name of the field in the data source"),
-									data_type: zod
-										.enum([
-											"boolean",
-											"character varying",
-											"uuid",
-											"date",
-											"integer",
-											"double precision",
-											"numeric",
-											"timestamp without time zone",
-											"timestamp with time zone",
-											"bigint",
-											"jsonb",
-											"json",
-											"unknown",
-										])
-										.describe(
-											"Defines the supported data types for fields in the data source.",
-										),
-									description: zod
-										.string()
-										.optional()
-										.describe("Human-readable description of the field"),
-									is_unique_id: zod
-										.boolean()
-										.optional()
-										.describe("Whether this field uniquely identifies records"),
-									is_strata: zod
-										.boolean()
-										.optional()
-										.describe(
-											"Whether this field should be used for stratification",
-										),
-									is_filter: zod
-										.boolean()
-										.optional()
-										.describe("Whether this field can be used as a filter"),
-									is_metric: zod
-										.boolean()
-										.optional()
-										.describe("Whether this field can be used as a metric"),
-									extra: zod
-										.union([zod.record(zod.string(), zod.string()), zod.null()])
-										.optional(),
-								}),
-							)
-							.describe("List of fields available in this table"),
-						type: zod
-							.literal("schema")
-							.describe(
-								"Indicates that the schema is determined by an inline schema.",
-							),
-						participant_type: zod
-							.string()
-							.describe(
-								"The name of the set of participants defined by the filters. This name must be unique within a datasource when not hidden (i.e. not auto-generated).",
-							),
-						hidden: zod
-							.boolean()
-							.optional()
-							.describe(
-								"If true, this participant type is hidden from list_participant_types. Used for auto-generated participant types.",
-							),
-					})
-					.describe(
-						"Participants are a logical representation of a table in the data warehouse.\n\nParticipants are defined by a participant_type, table_name and a schema.",
-					),
-				zod.null(),
-			])
-			.describe(
-				"If available, the Participant Type information for this experiment. This field is null for experiments that only use an 'API Only' datasource.",
-			),
-	})
-	.describe("Experiment configuration and participant type information.");
-
-/**
- * @summary Update Experiment
- */
-export const updateExperimentParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
+export const analyzeCmabExperimentBody = zod.object({
+	type: zod
+		.literal("cmab_assignment")
+		.default(analyzeCmabExperimentBodyTypeDefault),
+	context_inputs: zod.union([
+		zod.array(
+			zod.object({
+				context_id: zod.string(),
+				context_value: zod.number(),
+			}),
+		),
+		zod.null(),
+	]),
 });
 
 export const updateExperimentBodyNameMaxOne = 100;
@@ -8424,117 +1053,46 @@ export const updateExperimentBodyDescriptionMaxOne = 2000;
 
 export const updateExperimentBodyDesignUrlMaxOne = 500;
 
-export const updateExperimentBody = zod
-	.object({
-		name: zod
-			.union([zod.string().max(updateExperimentBodyNameMaxOne), zod.null()])
-			.optional(),
-		description: zod
-			.union([
-				zod.string().max(updateExperimentBodyDescriptionMaxOne),
-				zod.null(),
-			])
-			.optional(),
-		design_url: zod
-			.union([
-				zod.string().max(updateExperimentBodyDesignUrlMaxOne),
-				zod.null(),
-			])
-			.optional(),
-		start_date: zod.union([zod.string().datetime({}), zod.null()]).optional(),
-		end_date: zod.union([zod.string().datetime({}), zod.null()]).optional(),
-		impact: zod
-			.union([
-				zod.enum(["high", "medium", "low", "negative", "unclear", ""]),
-				zod.null(),
-			])
-			.optional(),
-		decision: zod.union([zod.string(), zod.null()]).optional(),
-	})
-	.describe(
-		"Defines the subset of fields that can be updated for an experiment after creation.",
-	);
-
-/**
- * Deletes the experiment with the specified ID.
- * @summary Delete Experiment
- */
-export const deleteExperimentParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
+export const updateExperimentBody = zod.object({
+	name: zod
+		.union([zod.string().max(updateExperimentBodyNameMaxOne), zod.null()])
+		.optional(),
+	description: zod
+		.union([
+			zod.string().max(updateExperimentBodyDescriptionMaxOne),
+			zod.null(),
+		])
+		.optional(),
+	design_url: zod
+		.union([zod.string().max(updateExperimentBodyDesignUrlMaxOne), zod.null()])
+		.optional(),
+	start_date: zod.union([zod.string().datetime({}), zod.null()]).optional(),
+	end_date: zod.union([zod.string().datetime({}), zod.null()]).optional(),
+	impact: zod
+		.union([
+			zod.enum(["high", "medium", "low", "negative", "unclear", ""]),
+			zod.null(),
+		])
+		.optional(),
+	decision: zod.union([zod.string(), zod.null()]).optional(),
 });
 
-export const deleteExperimentQueryAllowMissingDefault = false;
-
-export const deleteExperimentQueryParams = zod.object({
-	allow_missing: zod
-		.boolean()
-		.optional()
-		.describe("If true, return a 204 even if the resource does not exist."),
-});
-
-/**
- * @summary Export experiment assignments as CSV file; BalanceCheck not included. csv header form: participant_id,arm_id,arm_name,strata_name1,strata_name2,...
- */
-export const getExperimentAssignmentsAsCsvForUiParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-/**
- * Deletes specific data associated with an experiment.
- * @summary Delete Experiment Data
- */
-export const deleteExperimentDataParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-});
-
-export const deleteExperimentDataBody = zod
-	.object({
-		assignments: zod
-			.union([zod.boolean(), zod.null()])
-			.optional()
-			.describe("Delete related participant assignments."),
-		snapshots: zod
-			.union([zod.boolean(), zod.null()])
-			.optional()
-			.describe("Delete related snapshots."),
-	})
-	.describe("Request to delete specific data associated with an experiment.");
-
-/**
- * @summary Update Arm
- */
-export const updateArmParams = zod.object({
-	datasource_id: zod.string(),
-	experiment_id: zod.string(),
-	arm_id: zod.string(),
+export const deleteExperimentDataBody = zod.object({
+	assignments: zod.union([zod.boolean(), zod.null()]).optional(),
+	snapshots: zod.union([zod.boolean(), zod.null()]).optional(),
 });
 
 export const updateArmBodyNameMaxOne = 100;
 
 export const updateArmBodyDescriptionMaxOne = 2000;
 
-export const updateArmBody = zod
-	.object({
-		name: zod
-			.union([zod.string().max(updateArmBodyNameMaxOne), zod.null()])
-			.optional(),
-		description: zod
-			.union([zod.string().max(updateArmBodyDescriptionMaxOne), zod.null()])
-			.optional(),
-	})
-	.describe(
-		"Defines the subset of fields that can be updated for an Arm after creation.",
-	);
-
-/**
- * Performs a power check for the specified datasource.
- * @summary Power Check
- */
-export const powerCheckParams = zod.object({
-	datasource_id: zod.string(),
+export const updateArmBody = zod.object({
+	name: zod
+		.union([zod.string().max(updateArmBodyNameMaxOne), zod.null()])
+		.optional(),
+	description: zod
+		.union([zod.string().max(updateArmBodyDescriptionMaxOne), zod.null()])
+		.optional(),
 });
 
 export const powerCheckBodyDesignSpecExperimentNameMax = 100;
@@ -8632,532 +1190,214 @@ export const powerCheckBodyDesignSpecFstatThreshMinOne = 0;
 export const powerCheckBodyDesignSpecFstatThreshMaxOne = 1;
 
 export const powerCheckBody = zod.object({
-	design_spec: zod
-		.union([
-			zod
-				.object({
-					experiment_type: zod.enum(["freq_preassigned"]),
-					experiment_name: zod
+	design_spec: zod.union([
+		zod.object({
+			experiment_type: zod.enum(["freq_preassigned"]),
+			experiment_name: zod
+				.string()
+				.max(powerCheckBodyDesignSpecExperimentNameMax),
+			description: zod.string().max(powerCheckBodyDesignSpecDescriptionMax),
+			design_url: zod
+				.union([
+					zod
 						.string()
-						.max(powerCheckBodyDesignSpecExperimentNameMax),
-					description: zod.string().max(powerCheckBodyDesignSpecDescriptionMax),
-					design_url: zod
-						.union([
-							zod
-								.string()
-								.url()
-								.min(1)
-								.max(powerCheckBodyDesignSpecDesignUrlMaxOne),
-							zod.null(),
-						])
-						.optional()
-						.describe("Optional URL to a more detailed experiment design doc."),
-					start_date: zod.string().datetime({}),
-					end_date: zod.string().datetime({}),
-					arms: zod
-						.array(
-							zod
-								.object({
-									arm_id: zod
-										.union([zod.string(), zod.null()])
-										.optional()
-										.describe(
-											"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-										),
-									arm_name: zod
-										.string()
-										.max(powerCheckBodyDesignSpecArmsItemArmNameMax),
-									arm_description: zod
-										.union([
-											zod
-												.string()
-												.max(
-													powerCheckBodyDesignSpecArmsItemArmDescriptionMaxOne,
-												),
-											zod.null(),
-										])
-										.optional(),
-									arm_weight: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-										),
-								})
-								.describe("Describes an experiment treatment arm."),
-						)
-						.min(powerCheckBodyDesignSpecArmsMin)
-						.max(powerCheckBodyDesignSpecArmsMax),
-					table_name: zod
-						.string()
-						.max(powerCheckBodyDesignSpecTableNameMax)
-						.describe(
-							"Datasource table used to resolve participant field metadata.",
-						),
-					primary_key: zod
-						.string()
-						.regex(powerCheckBodyDesignSpecPrimaryKeyRegExp)
-						.describe(
-							"Column name in table_name that uniquely identifies each participant.",
-						),
-					strata: zod
-						.array(
-							zod
-								.object({
-									field_name: zod
-										.string()
-										.regex(powerCheckBodyDesignSpecStrataItemFieldNameRegExp),
-								})
-								.describe("Describes a variable used for stratification."),
-						)
-						.max(powerCheckBodyDesignSpecStrataMax)
-						.describe("Optional fields to use for stratified assignment."),
-					metrics: zod
-						.array(
-							zod
-								.object({
-									field_name: zod
-										.string()
-										.regex(powerCheckBodyDesignSpecMetricsItemFieldNameRegExp),
-									metric_pct_change: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-										),
-									metric_target: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-										),
-								})
-								.describe(
-									"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-								),
-						)
+						.url()
 						.min(1)
-						.max(powerCheckBodyDesignSpecMetricsMax)
-						.describe("Primary and optional secondary metrics to target."),
-					filters: zod
-						.array(
-							zod
-								.object({
-									field_name: zod
-										.string()
-										.regex(powerCheckBodyDesignSpecFiltersItemFieldNameRegExp),
-									relation: zod
-										.enum(["includes", "excludes", "between"])
-										.describe(
-											"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-										),
-									value: zod.union([
-										zod.array(zod.union([zod.number(), zod.null()])),
-										zod.array(zod.union([zod.number(), zod.null()])),
-										zod.array(zod.union([zod.string(), zod.null()])),
-										zod.array(zod.union([zod.boolean(), zod.null()])),
-									]),
-								})
-								.describe(
-									'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-								),
-						)
-						.max(powerCheckBodyDesignSpecFiltersMax)
-						.describe(
-							"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-						),
-					desired_n: zod
-						.union([
-							zod.number().min(powerCheckBodyDesignSpecDesiredNMinOne),
-							zod.null(),
-						])
-						.optional()
-						.describe(
-							"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-						),
-					power: zod
-						.number()
-						.min(powerCheckBodyDesignSpecPowerMin)
-						.max(powerCheckBodyDesignSpecPowerMax)
-						.default(powerCheckBodyDesignSpecPowerDefault)
-						.describe(
-							"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-						),
-					alpha: zod
-						.number()
-						.min(powerCheckBodyDesignSpecAlphaMin)
-						.max(powerCheckBodyDesignSpecAlphaMax)
-						.default(powerCheckBodyDesignSpecAlphaDefault)
-						.describe(
-							"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-						),
-					fstat_thresh: zod
-						.number()
-						.min(powerCheckBodyDesignSpecFstatThreshMin)
-						.max(powerCheckBodyDesignSpecFstatThreshMax)
-						.default(powerCheckBodyDesignSpecFstatThreshDefault)
-						.describe(
-							'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-						),
-				})
-				.describe(
-					"Use this type to randomly select and assign from existing participants at design time with\nfrequentist A/B experiments.",
-				),
-			zod
-				.object({
-					experiment_type: zod.enum(["freq_online"]),
-					experiment_name: zod
+						.max(powerCheckBodyDesignSpecDesignUrlMaxOne),
+					zod.null(),
+				])
+				.optional(),
+			start_date: zod.string().datetime({}),
+			end_date: zod.string().datetime({}),
+			arms: zod
+				.array(
+					zod.object({
+						arm_id: zod.union([zod.string(), zod.null()]).optional(),
+						arm_name: zod
+							.string()
+							.max(powerCheckBodyDesignSpecArmsItemArmNameMax),
+						arm_description: zod
+							.union([
+								zod
+									.string()
+									.max(powerCheckBodyDesignSpecArmsItemArmDescriptionMaxOne),
+								zod.null(),
+							])
+							.optional(),
+						arm_weight: zod.union([zod.number(), zod.null()]).optional(),
+					}),
+				)
+				.min(powerCheckBodyDesignSpecArmsMin)
+				.max(powerCheckBodyDesignSpecArmsMax),
+			table_name: zod.string().max(powerCheckBodyDesignSpecTableNameMax),
+			primary_key: zod.string().regex(powerCheckBodyDesignSpecPrimaryKeyRegExp),
+			cluster_key: zod.union([zod.string(), zod.null()]).optional(),
+			strata: zod
+				.array(
+					zod.object({
+						field_name: zod
+							.string()
+							.regex(powerCheckBodyDesignSpecStrataItemFieldNameRegExp),
+					}),
+				)
+				.max(powerCheckBodyDesignSpecStrataMax),
+			metrics: zod
+				.array(
+					zod.object({
+						field_name: zod
+							.string()
+							.regex(powerCheckBodyDesignSpecMetricsItemFieldNameRegExp),
+						metric_pct_change: zod.union([zod.number(), zod.null()]).optional(),
+						metric_target: zod.union([zod.number(), zod.null()]).optional(),
+						icc: zod.union([zod.number(), zod.null()]).optional(),
+						avg_cluster_size: zod.union([zod.number(), zod.null()]).optional(),
+						cv: zod.union([zod.number(), zod.null()]).optional(),
+					}),
+				)
+				.min(1)
+				.max(powerCheckBodyDesignSpecMetricsMax),
+			filters: zod
+				.array(
+					zod.object({
+						field_name: zod
+							.string()
+							.regex(powerCheckBodyDesignSpecFiltersItemFieldNameRegExp),
+						relation: zod.enum(["includes", "excludes", "between"]),
+						value: zod.union([
+							zod.array(zod.union([zod.number(), zod.null()])),
+							zod.array(zod.union([zod.number(), zod.null()])),
+							zod.array(zod.union([zod.string(), zod.null()])),
+							zod.array(zod.union([zod.boolean(), zod.null()])),
+						]),
+					}),
+				)
+				.max(powerCheckBodyDesignSpecFiltersMax),
+			desired_n: zod
+				.union([
+					zod.number().min(powerCheckBodyDesignSpecDesiredNMinOne),
+					zod.null(),
+				])
+				.optional(),
+			power: zod
+				.number()
+				.min(powerCheckBodyDesignSpecPowerMin)
+				.max(powerCheckBodyDesignSpecPowerMax)
+				.default(powerCheckBodyDesignSpecPowerDefault),
+			alpha: zod
+				.number()
+				.min(powerCheckBodyDesignSpecAlphaMin)
+				.max(powerCheckBodyDesignSpecAlphaMax)
+				.default(powerCheckBodyDesignSpecAlphaDefault),
+			fstat_thresh: zod
+				.number()
+				.min(powerCheckBodyDesignSpecFstatThreshMin)
+				.max(powerCheckBodyDesignSpecFstatThreshMax)
+				.default(powerCheckBodyDesignSpecFstatThreshDefault),
+		}),
+		zod.object({
+			experiment_type: zod.enum(["freq_online"]),
+			experiment_name: zod
+				.string()
+				.max(powerCheckBodyDesignSpecExperimentNameMaxOne),
+			description: zod.string().max(powerCheckBodyDesignSpecDescriptionMaxOne),
+			design_url: zod
+				.union([
+					zod
 						.string()
-						.max(powerCheckBodyDesignSpecExperimentNameMaxOne),
-					description: zod
-						.string()
-						.max(powerCheckBodyDesignSpecDescriptionMaxOne),
-					design_url: zod
-						.union([
-							zod
-								.string()
-								.url()
-								.min(1)
-								.max(powerCheckBodyDesignSpecDesignUrlMaxFour),
-							zod.null(),
-						])
-						.optional()
-						.describe("Optional URL to a more detailed experiment design doc."),
-					start_date: zod.string().datetime({}),
-					end_date: zod.string().datetime({}),
-					arms: zod
-						.array(
-							zod
-								.object({
-									arm_id: zod
-										.union([zod.string(), zod.null()])
-										.optional()
-										.describe(
-											"ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.",
-										),
-									arm_name: zod
-										.string()
-										.max(powerCheckBodyDesignSpecArmsItemArmNameMaxOne),
-									arm_description: zod
-										.union([
-											zod
-												.string()
-												.max(
-													powerCheckBodyDesignSpecArmsItemArmDescriptionMaxFour,
-												),
-											zod.null(),
-										])
-										.optional(),
-									arm_weight: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.",
-										),
-								})
-								.describe("Describes an experiment treatment arm."),
-						)
-						.min(powerCheckBodyDesignSpecArmsMinOne)
-						.max(powerCheckBodyDesignSpecArmsMaxOne),
-					table_name: zod
-						.string()
-						.max(powerCheckBodyDesignSpecTableNameMaxOne)
-						.describe(
-							"Datasource table used to resolve participant field metadata.",
-						),
-					primary_key: zod
-						.string()
-						.regex(powerCheckBodyDesignSpecPrimaryKeyRegExpOne)
-						.describe(
-							"Column name in table_name that uniquely identifies each participant.",
-						),
-					strata: zod
-						.array(
-							zod
-								.object({
-									field_name: zod
-										.string()
-										.regex(
-											powerCheckBodyDesignSpecStrataItemFieldNameRegExpOne,
-										),
-								})
-								.describe("Describes a variable used for stratification."),
-						)
-						.max(powerCheckBodyDesignSpecStrataMaxOne)
-						.describe("Optional fields to use for stratified assignment."),
-					metrics: zod
-						.array(
-							zod
-								.object({
-									field_name: zod
-										.string()
-										.regex(
-											powerCheckBodyDesignSpecMetricsItemFieldNameRegExpOne,
-										),
-									metric_pct_change: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.",
-										),
-									metric_target: zod
-										.union([zod.number(), zod.null()])
-										.optional()
-										.describe(
-											"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
-										),
-								})
-								.describe(
-									"Defines a request to look up baseline stats for a metric to measure in an experiment.",
-								),
-						)
+						.url()
 						.min(1)
-						.max(powerCheckBodyDesignSpecMetricsMaxOne)
-						.describe("Primary and optional secondary metrics to target."),
-					filters: zod
-						.array(
-							zod
-								.object({
-									field_name: zod
-										.string()
-										.regex(
-											powerCheckBodyDesignSpecFiltersItemFieldNameRegExpOne,
-										),
-									relation: zod
-										.enum(["includes", "excludes", "between"])
-										.describe(
-											"Defines operators for filtering values.\n\nINCLUDES matches when the value matches any of the provided values, including null if explicitly\nspecified. This is equivalent to NOT(EXCLUDES(values)).\n\nEXCLUDES matches when the value does not match any of the provided values, including null if\nexplicitly specified. If null is not explicitly excluded, we include nulls in the result.\n\nBETWEEN matches when the value is between the two provided values (inclusive).",
-										),
-									value: zod.union([
-										zod.array(zod.union([zod.number(), zod.null()])),
-										zod.array(zod.union([zod.number(), zod.null()])),
-										zod.array(zod.union([zod.string(), zod.null()])),
-										zod.array(zod.union([zod.boolean(), zod.null()])),
-									]),
-								})
-								.describe(
-									'Defines criteria for filtering rows by value.\n\n## Examples\n\n| Relation | Value             | logical Result                                    |\n|----------|-------------------|---------------------------------------------------|\n| INCLUDES | [None]            | Match when `x IS NULL`                            |\n| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |\n| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |\n| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |\n| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |\n| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |\n| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |\n| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |\n| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |\n| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |\n| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |\n| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |\n\nString comparisons are case-sensitive.\n\n## Special Handling for BETWEEN support of including NULL\n\nWhen the relation is BETWEEN, we allow for up to 3 values to support the special case of\nincluding null in addition to the values in the between range via an OR IS NULL clause, as\nindicated by a 3rd value of None. Any other 3rd value is invalid.\n\n## Handling of DATE, DATETIME and TIMESTAMP values\n\nDATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.\n\nValues must be expressed as ISO8601 datetime strings compatible with Python\'s datetime.fromisoformat()\n(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).\n\nIf a timezone is provided, it must be UTC.',
-								),
-						)
-						.max(powerCheckBodyDesignSpecFiltersMaxOne)
-						.describe(
-							"Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.",
-						),
-					desired_n: zod
-						.union([
-							zod.number().min(powerCheckBodyDesignSpecDesiredNMinFour),
-							zod.null(),
-						])
-						.optional()
-						.describe(
-							"Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size. ",
-						),
-					power: zod
-						.number()
-						.min(powerCheckBodyDesignSpecPowerMinOne)
-						.max(powerCheckBodyDesignSpecPowerMaxOne)
-						.default(powerCheckBodyDesignSpecPowerDefaultOne)
-						.describe(
-							"The chance of detecting a real non-null effect, i.e. 1 - false negative rate.",
-						),
-					alpha: zod
-						.number()
-						.min(powerCheckBodyDesignSpecAlphaMinOne)
-						.max(powerCheckBodyDesignSpecAlphaMaxOne)
-						.default(powerCheckBodyDesignSpecAlphaDefaultOne)
-						.describe(
-							"The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.",
-						),
-					fstat_thresh: zod
-						.number()
-						.min(powerCheckBodyDesignSpecFstatThreshMinOne)
-						.max(powerCheckBodyDesignSpecFstatThreshMaxOne)
-						.default(powerCheckBodyDesignSpecFstatThreshDefaultOne)
-						.describe(
-							'Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".',
-						),
-				})
-				.describe(
-					"Use this type to randomly assign participants into arms during live experiment execution with\nfrequentist A/B experiments.\n\nFor example, you may wish to experiment on new users. Assignments are issued via API request.",
-				),
-		])
-		.describe("The specific type of frequentist experiment design."),
-});
-
-export const powerCheckResponseAnalysesItemMetricSpecFieldNameRegExp =
-	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
-export const powerCheckResponseAnalysesMax = 150;
-
-export const powerCheckResponse = zod.object({
-	analyses: zod
-		.array(
-			zod
-				.object({
-					metric_spec: zod
-						.object({
-							field_name: zod
-								.string()
-								.regex(powerCheckResponseAnalysesItemMetricSpecFieldNameRegExp),
-							metric_pct_change: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Percent change target relative to the metric_baseline.",
-								),
-							metric_target: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Absolute target value = metric_baseline*(1 + metric_pct_change)",
-								),
-							metric_type: zod
-								.union([
-									zod
-										.enum(["binary", "numeric"])
-										.describe("Classifies metrics by their value type."),
-									zod.null(),
-								])
-								.optional()
-								.describe("Inferred from dwh type."),
-							metric_baseline: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe("Mean of the tracked metric."),
-							metric_stddev: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0.",
-								),
-							available_nonnull_n: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"The number of participants meeting the filtering criteria with a *non-null* value for this metric.",
-								),
-							available_n: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-								),
-							icc: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Intracluster correlation coefficient for cluster-randomized designs.",
-								),
-							avg_cluster_size: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe("Average number of individuals per cluster."),
-							cv: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Coefficient of variation in cluster sizes (0 = equal sizes).",
-								),
-						})
-						.describe(
-							"Defines a metric to measure in an experiment with its baseline stats.",
-						),
-					target_n: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe("Minimum sample size needed to meet the design specs."),
-					sufficient_n: zod
-						.union([zod.boolean(), zod.null()])
-						.optional()
-						.describe(
-							"Whether or not there are enough available units to sample from to meet target_n.",
-						),
-					target_possible: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe(
-							"If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.",
-						),
-					pct_change_possible: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe(
-							"If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.",
-						),
-					pct_change_with_desired_n: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe(
-							"The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).",
-						),
-					msg: zod
-						.union([
-							zod
-								.object({
-									type: zod
-										.enum([
-											"sufficient",
-											"insufficient",
-											"no baseline",
-											"no available n",
-											"zero effect size",
-											"zero variation",
-										])
-										.describe("Classifies metric power analysis results."),
-									msg: zod
-										.string()
-										.describe(
-											"Main power analysis result stated in human-friendly English.",
-										),
-									source_msg: zod
-										.string()
-										.describe(
-											"Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages.",
-										),
-									values: zod
-										.union([
-											zod.record(
-												zod.string(),
-												zod.union([zod.number(), zod.number()]),
-											),
-											zod.null(),
-										])
-										.optional(),
-								})
-								.describe(
-									"Describes interpretation of power analysis results.",
-								),
-							zod.null(),
-						])
-						.optional()
-						.describe("Human friendly message about the above results."),
-					num_clusters_total: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe("Total number of clusters needed across all arms"),
-					clusters_per_arm: zod
-						.union([zod.array(zod.number()), zod.null()])
-						.optional()
-						.describe(
-							"Number of clusters needed for each arm (one entry per arm)",
-						),
-					n_per_arm: zod
-						.union([zod.array(zod.number()), zod.null()])
-						.optional()
-						.describe(
-							"Number of participants for each arm (one entry per arm)",
-						),
-					design_effect: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe("Design effect (DEFF) - clustering penalty multiplier"),
-					effective_sample_size: zod
-						.union([zod.number(), zod.null()])
-						.optional()
-						.describe(
-							"Effective sample size accounting for clustering (total_n / DEFF)",
-						),
-				})
-				.describe("Describes analysis results of a single metric."),
-		)
-		.max(powerCheckResponseAnalysesMax),
+						.max(powerCheckBodyDesignSpecDesignUrlMaxFour),
+					zod.null(),
+				])
+				.optional(),
+			start_date: zod.string().datetime({}),
+			end_date: zod.string().datetime({}),
+			arms: zod
+				.array(
+					zod.object({
+						arm_id: zod.union([zod.string(), zod.null()]).optional(),
+						arm_name: zod
+							.string()
+							.max(powerCheckBodyDesignSpecArmsItemArmNameMaxOne),
+						arm_description: zod
+							.union([
+								zod
+									.string()
+									.max(powerCheckBodyDesignSpecArmsItemArmDescriptionMaxFour),
+								zod.null(),
+							])
+							.optional(),
+						arm_weight: zod.union([zod.number(), zod.null()]).optional(),
+					}),
+				)
+				.min(powerCheckBodyDesignSpecArmsMinOne)
+				.max(powerCheckBodyDesignSpecArmsMaxOne),
+			table_name: zod.string().max(powerCheckBodyDesignSpecTableNameMaxOne),
+			primary_key: zod
+				.string()
+				.regex(powerCheckBodyDesignSpecPrimaryKeyRegExpOne),
+			cluster_key: zod.union([zod.string(), zod.null()]).optional(),
+			strata: zod
+				.array(
+					zod.object({
+						field_name: zod
+							.string()
+							.regex(powerCheckBodyDesignSpecStrataItemFieldNameRegExpOne),
+					}),
+				)
+				.max(powerCheckBodyDesignSpecStrataMaxOne),
+			metrics: zod
+				.array(
+					zod.object({
+						field_name: zod
+							.string()
+							.regex(powerCheckBodyDesignSpecMetricsItemFieldNameRegExpOne),
+						metric_pct_change: zod.union([zod.number(), zod.null()]).optional(),
+						metric_target: zod.union([zod.number(), zod.null()]).optional(),
+						icc: zod.union([zod.number(), zod.null()]).optional(),
+						avg_cluster_size: zod.union([zod.number(), zod.null()]).optional(),
+						cv: zod.union([zod.number(), zod.null()]).optional(),
+					}),
+				)
+				.min(1)
+				.max(powerCheckBodyDesignSpecMetricsMaxOne),
+			filters: zod
+				.array(
+					zod.object({
+						field_name: zod
+							.string()
+							.regex(powerCheckBodyDesignSpecFiltersItemFieldNameRegExpOne),
+						relation: zod.enum(["includes", "excludes", "between"]),
+						value: zod.union([
+							zod.array(zod.union([zod.number(), zod.null()])),
+							zod.array(zod.union([zod.number(), zod.null()])),
+							zod.array(zod.union([zod.string(), zod.null()])),
+							zod.array(zod.union([zod.boolean(), zod.null()])),
+						]),
+					}),
+				)
+				.max(powerCheckBodyDesignSpecFiltersMaxOne),
+			desired_n: zod
+				.union([
+					zod.number().min(powerCheckBodyDesignSpecDesiredNMinFour),
+					zod.null(),
+				])
+				.optional(),
+			power: zod
+				.number()
+				.min(powerCheckBodyDesignSpecPowerMinOne)
+				.max(powerCheckBodyDesignSpecPowerMaxOne)
+				.default(powerCheckBodyDesignSpecPowerDefaultOne),
+			alpha: zod
+				.number()
+				.min(powerCheckBodyDesignSpecAlphaMinOne)
+				.max(powerCheckBodyDesignSpecAlphaMaxOne)
+				.default(powerCheckBodyDesignSpecAlphaDefaultOne),
+			fstat_thresh: zod
+				.number()
+				.min(powerCheckBodyDesignSpecFstatThreshMinOne)
+				.max(powerCheckBodyDesignSpecFstatThreshMaxOne)
+				.default(powerCheckBodyDesignSpecFstatThreshDefaultOne),
+		}),
+	]),
 });

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -10,36 +10,19 @@ export interface AddMemberToOrganizationRequest {
 
 export interface AddWebhookToOrganizationRequest {
 	type: "experiment.created";
-	/**
-	 * User-friendly name for the webhook. This name is displayed in the UI and helps identify the webhook's purpose.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	name: string;
-	/**
-	 * The HTTP or HTTPS URL that will receive webhook notifications when events occur.
-	 * @maxLength 500
-	 */
+	/** @maxLength 500 */
 	url: string;
 }
 
-/**
- * The value of the Webhook-Token: header that will be sent with the request to the configured URL.
- */
 export type AddWebhookToOrganizationResponseAuthToken = string | null;
 
-/**
- * Information on the successfully created webhook.
- */
 export interface AddWebhookToOrganizationResponse {
-	/** The ID of the newly created webhook. */
 	id: string;
-	/** The type of webhook; e.g. experiment.created */
 	type: string;
-	/** User-friendly name for the webhook. */
 	name: string;
-	/** The URL to notify. */
 	url: string;
-	/** The value of the Webhook-Token: header that will be sent with the request to the configured URL. */
 	auth_token: AddWebhookToOrganizationResponseAuthToken;
 }
 
@@ -52,9 +35,6 @@ export const AnyBanditDesignSpecInputExperimentType = {
 	mab_online: "mab_online",
 } as const;
 
-/**
- * The specific type of bandit experiment design.
- */
 export type AnyBanditDesignSpecInput =
 	| (MABExperimentSpecInput & {
 			experiment_type: AnyBanditDesignSpecInputExperimentType;
@@ -72,9 +52,6 @@ export const AnyBanditDesignSpecOutputExperimentType = {
 	mab_online: "mab_online",
 } as const;
 
-/**
- * The specific type of bandit experiment design.
- */
 export type AnyBanditDesignSpecOutput =
 	| (MABExperimentSpecOutput & {
 			experiment_type: AnyBanditDesignSpecOutputExperimentType;
@@ -92,9 +69,6 @@ export const AnyFrequentistDesignSpecInputExperimentType = {
 	freq_preassigned: "freq_preassigned",
 } as const;
 
-/**
- * The specific type of frequentist experiment design.
- */
 export type AnyFrequentistDesignSpecInput =
 	| (PreassignedFrequentistExperimentSpecInput & {
 			experiment_type: AnyFrequentistDesignSpecInputExperimentType;
@@ -112,9 +86,6 @@ export const AnyFrequentistDesignSpecOutputExperimentType = {
 	freq_preassigned: "freq_preassigned",
 } as const;
 
-/**
- * The specific type of frequentist experiment design.
- */
 export type AnyFrequentistDesignSpecOutput =
 	| (PreassignedFrequentistExperimentSpecOutput & {
 			experiment_type: AnyFrequentistDesignSpecOutputExperimentType;
@@ -142,202 +113,101 @@ export const ApiOnlyDsnType = {
 	api_only: "api_only",
 } as const;
 
-/**
- * ApiOnlyDsn describes a datasource where data is included in Evidential API requests.
- */
 export interface ApiOnlyDsn {
 	type: ApiOnlyDsnType;
 }
 
-/**
- * ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
- */
 export type ArmArmId = string | null;
 
 export type ArmArmDescription = string | null;
 
-/**
- * Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.
- */
 export type ArmArmWeight = ArmWeight | null;
 
-/**
- * Describes an experiment treatment arm.
- */
 export interface Arm {
-	/** ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
 	arm_id?: ArmArmId;
 	/** @maxLength 100 */
 	arm_name: string;
 	arm_description?: ArmArmDescription;
-	/** Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100. */
 	arm_weight?: ArmArmWeight;
 }
 
-/**
- * ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
- */
 export type ArmAnalysisArmId = string | null;
 
 export type ArmAnalysisArmDescription = string | null;
 
-/**
- * Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.
- */
 export type ArmAnalysisArmWeight = ArmWeight | null;
 
-/**
- * The p-value indicating statistical significance of the treatment effect. Value may be None if the t-stat is not available, e.g. due to inability to calculate the standard error.
- */
 export type ArmAnalysisPValue = number | null;
 
-/**
- * The t-statistic from the statistical test. If the value is actually NaN, e.g. due to inability to calculate the standard error, we return None.
- */
 export type ArmAnalysisTStat = number | null;
 
-/**
- * The standard error of the treatment effect estimate.
- */
 export type ArmAnalysisStdError = number | null;
 
-/**
- * Confidence interval lower bound for the regression coefficient estimate.
- */
 export type ArmAnalysisCiLower = number | null;
 
-/**
- * Confidence interval upper bound for the regression coefficient estimate.
- */
 export type ArmAnalysisCiUpper = number | null;
 
-/**
- * Confidence interval lower bound for the arm's mean.
- */
 export type ArmAnalysisMeanCiLower = number | null;
 
-/**
- * Confidence interval upper bound for the arm's mean.
- */
 export type ArmAnalysisMeanCiUpper = number | null;
 
 export interface ArmAnalysis {
-	/** ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
 	arm_id?: ArmAnalysisArmId;
 	/** @maxLength 100 */
 	arm_name: string;
 	arm_description?: ArmAnalysisArmDescription;
-	/** Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100. */
 	arm_weight?: ArmAnalysisArmWeight;
-	/** The estimated treatment effect relative to the baseline arm. */
 	estimate: number;
-	/** The p-value indicating statistical significance of the treatment effect. Value may be None if the t-stat is not available, e.g. due to inability to calculate the standard error. */
 	p_value: ArmAnalysisPValue;
-	/** The t-statistic from the statistical test. If the value is actually NaN, e.g. due to inability to calculate the standard error, we return None. */
 	t_stat: ArmAnalysisTStat;
-	/** The standard error of the treatment effect estimate. */
 	std_error: ArmAnalysisStdError;
-	/** Confidence interval lower bound for the regression coefficient estimate. */
 	ci_lower?: ArmAnalysisCiLower;
-	/** Confidence interval upper bound for the regression coefficient estimate. */
 	ci_upper?: ArmAnalysisCiUpper;
-	/** Confidence interval lower bound for the arm's mean. */
 	mean_ci_lower?: ArmAnalysisMeanCiLower;
-	/** Confidence interval upper bound for the arm's mean. */
 	mean_ci_upper?: ArmAnalysisMeanCiUpper;
-	/**
-	 * The number of participants assigned to this arm with missing values (NaNs) for this metric. These rows are excluded from the analysis. -1 indicates arm analysis not available due to all assignments missing outcomes for this metric.
-	 * @minimum -1
-	 */
+	/** @minimum -1 */
 	num_missing_values: number;
-	/** Whether this arm is the baseline/control arm for comparison. */
 	is_baseline: boolean;
 }
 
-/**
- * ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
- */
 export type ArmBanditArmId = string | null;
 
 export type ArmBanditArmDescription = string | null;
 
-/**
- * Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.
- */
 export type ArmBanditArmWeight = ArmWeight | null;
 
-/**
- * Initial alpha parameter for Beta prior
- */
 export type ArmBanditAlphaInit = number | null;
 
-/**
- * Initial beta parameter for Beta prior
- */
 export type ArmBanditBetaInit = number | null;
 
-/**
- * Initial mean parameter for Normal prior
- */
 export type ArmBanditMuInit = number | null;
 
-/**
- * Initial standard deviation parameter for Normal prior
- */
 export type ArmBanditSigmaInit = number | null;
 
-/**
- * Updated alpha parameter for Beta prior
- */
 export type ArmBanditAlpha = number | null;
 
-/**
- * Updated beta parameter for Beta prior
- */
 export type ArmBanditBeta = number | null;
 
-/**
- * Updated mean vector for Normal prior
- */
 export type ArmBanditMu = number[] | null;
 
-/**
- * Updated covariance matrix for Normal prior
- */
 export type ArmBanditCovariance = number[][] | null;
 
-/**
- * Describes an experiment arm for bandit experiments.
- */
 export interface ArmBandit {
-	/** ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
 	arm_id?: ArmBanditArmId;
 	/** @maxLength 100 */
 	arm_name: string;
 	arm_description?: ArmBanditArmDescription;
-	/** Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100. */
 	arm_weight?: ArmBanditArmWeight;
-	/** Initial alpha parameter for Beta prior */
 	alpha_init?: ArmBanditAlphaInit;
-	/** Initial beta parameter for Beta prior */
 	beta_init?: ArmBanditBetaInit;
-	/** Initial mean parameter for Normal prior */
 	mu_init?: ArmBanditMuInit;
-	/** Initial standard deviation parameter for Normal prior */
 	sigma_init?: ArmBanditSigmaInit;
-	/** Updated alpha parameter for Beta prior */
 	alpha?: ArmBanditAlpha;
-	/** Updated beta parameter for Beta prior */
 	beta?: ArmBanditBeta;
-	/** Updated mean vector for Normal prior */
 	mu?: ArmBanditMu;
-	/** Updated covariance matrix for Normal prior */
 	covariance?: ArmBanditCovariance;
 }
 
-/**
- * Describes the number of participants assigned to each arm.
- */
 export interface ArmSize {
 	arm: Arm;
 	size?: number;
@@ -347,191 +217,90 @@ export interface ArmSize {
  */
 export type ArmWeight = number;
 
-/**
- * Balance test results if available. 'online' experiments do not have balance checks.
- */
 export type AssignSummaryBalanceCheck = BalanceCheck | null;
 
-/**
- * For each arm, the number of participants assigned.
- */
 export type AssignSummaryArmSizes = ArmSize[] | null;
 
-/**
- * Key pieces of an AssignResponse without the assignments.
- */
 export interface AssignSummary {
-	/** Balance test results if available. 'online' experiments do not have balance checks. */
 	balance_check?: AssignSummaryBalanceCheck;
-	/** The number of participants across all arms in total. */
 	sample_size: number;
-	/** For each arm, the number of participants assigned. */
 	arm_sizes?: AssignSummaryArmSizes;
 }
 
-/**
- * The date and time the assignment was created.
- */
 export type AssignmentCreatedAt = string | null;
 
-/**
- * List of properties and their values for this participant used for stratification or tracking metrics. If stratification is not used, this will be None.
- */
 export type AssignmentStrata = Strata[] | null;
 
-/**
- * The date and time the outcome was recorded.
- */
 export type AssignmentObservedAt = string | null;
 
-/**
- * The observed outcome for this assignment.
- */
 export type AssignmentOutcome = number | null;
 
-/**
- * List of context values for this assignment. If no contexts are used, this will be None.
- */
 export type AssignmentContextValues = number[] | null;
 
-/**
- * Base class for treatment assignment in experiments.
- */
 export interface Assignment {
-	/** ID of the arm this participant was assigned to. Same as Arm.arm_id. */
 	arm_id: string;
-	/**
-	 * Unique identifier for the participant. This is the primary key for the participant in the data warehouse.
-	 * @maxLength 64
-	 */
+	/** @maxLength 64 */
 	participant_id: string;
-	/**
-	 * The arm this participant was assigned to. Same as Arm.arm_name.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	arm_name: string;
-	/** The date and time the assignment was created. */
 	created_at?: AssignmentCreatedAt;
-	/** List of properties and their values for this participant used for stratification or tracking metrics. If stratification is not used, this will be None. */
 	strata?: AssignmentStrata;
-	/** The date and time the outcome was recorded. */
 	observed_at?: AssignmentObservedAt;
-	/** The observed outcome for this assignment. */
 	outcome?: AssignmentOutcome;
-	/** List of context values for this assignment. If no contexts are used, this will be None. */
 	context_values?: AssignmentContextValues;
 }
 
-/**
- * Describes balance test results for treatment assignment.
- */
 export interface BalanceCheck {
-	/** F-statistic testing the overall significance of the model predicting treatment assignment. */
 	f_statistic: number;
-	/** The numerator degrees of freedom for the f-statistic related to number of dependent variables. */
 	numerator_df: number;
-	/** Denominator degrees of freedom related to the number of observations. */
 	denominator_df: number;
-	/** Probability of observing these data if strata do not predict treatment assignment, i.e. our randomization is balanced. */
 	p_value: number;
-	/** Whether the p-value for our observed f_statistic is greater than the f-stat threshold specified in our design specification. (See DesignSpec.fstat_thresh) */
 	balance_ok: boolean;
 }
 
-/**
- * ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence.
- */
 export type BanditArmAnalysisArmId = string | null;
 
 export type BanditArmAnalysisArmDescription = string | null;
 
-/**
- * Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100.
- */
 export type BanditArmAnalysisArmWeight = ArmWeight | null;
 
-/**
- * Initial alpha parameter for Beta prior
- */
 export type BanditArmAnalysisAlphaInit = number | null;
 
-/**
- * Initial beta parameter for Beta prior
- */
 export type BanditArmAnalysisBetaInit = number | null;
 
-/**
- * Initial mean parameter for Normal prior
- */
 export type BanditArmAnalysisMuInit = number | null;
 
-/**
- * Initial standard deviation parameter for Normal prior
- */
 export type BanditArmAnalysisSigmaInit = number | null;
 
-/**
- * Updated alpha parameter for Beta prior
- */
 export type BanditArmAnalysisAlpha = number | null;
 
-/**
- * Updated beta parameter for Beta prior
- */
 export type BanditArmAnalysisBeta = number | null;
 
-/**
- * Updated mean vector for Normal prior
- */
 export type BanditArmAnalysisMu = number[] | null;
 
-/**
- * Updated covariance matrix for Normal prior
- */
 export type BanditArmAnalysisCovariance = number[][] | null;
 
-/**
- * Describes an experiment arm analysis for bandit experiments.
- */
 export interface BanditArmAnalysis {
-	/** ID of the arm. If creating a new experiment (POST /datasources/{datasource_id}/experiments), this is generated for you and made available in the response; you should NOT set this. Only generate ids of your own if using the stateless Experiment Design API as you will do your own persistence. */
 	arm_id?: BanditArmAnalysisArmId;
 	/** @maxLength 100 */
 	arm_name: string;
 	arm_description?: BanditArmAnalysisArmDescription;
-	/** Optional weight for this arm for unequal allocation. Weight must be a float in (0, 100). If provided, all arms must have weights that sum to 100. */
 	arm_weight?: BanditArmAnalysisArmWeight;
-	/** Initial alpha parameter for Beta prior */
 	alpha_init?: BanditArmAnalysisAlphaInit;
-	/** Initial beta parameter for Beta prior */
 	beta_init?: BanditArmAnalysisBetaInit;
-	/** Initial mean parameter for Normal prior */
 	mu_init?: BanditArmAnalysisMuInit;
-	/** Initial standard deviation parameter for Normal prior */
 	sigma_init?: BanditArmAnalysisSigmaInit;
-	/** Updated alpha parameter for Beta prior */
 	alpha?: BanditArmAnalysisAlpha;
-	/** Updated beta parameter for Beta prior */
 	beta?: BanditArmAnalysisBeta;
-	/** Updated mean vector for Normal prior */
 	mu?: BanditArmAnalysisMu;
-	/** Updated covariance matrix for Normal prior */
 	covariance?: BanditArmAnalysisCovariance;
-	/** Prior predictive mean for this arm. */
 	prior_pred_mean: number;
-	/** Prior predictive standard deviation for this arm. */
 	prior_pred_stdev: number;
-	/** Prior predictive upper bound of 95% confidence interval for this arm. */
 	prior_pred_ci_upper: number;
-	/** Prior predictive lower bound of 95% confidence interval for this arm. */
 	prior_pred_ci_lower: number;
-	/** Posterior predictive mean for this arm. */
 	post_pred_mean: number;
-	/** Posterior predictive standard deviation for this arm. */
 	post_pred_stdev: number;
-	/** Posterior predictive upper bound of 95% confidence interval for this arm. */
 	post_pred_ci_upper: number;
-	/** Posterior predictive lower bound of 95% confidence interval for this arm. */
 	post_pred_ci_lower: number;
 }
 
@@ -543,25 +312,14 @@ export const BanditExperimentAnalysisResponseType = {
 	bandit: "bandit",
 } as const;
 
-/**
- * The context values used for the analysis, if applicable.
- */
 export type BanditExperimentAnalysisResponseContexts = number[] | null;
 
-/**
- * Describes changes in arms for a bandit experiment
- */
 export interface BanditExperimentAnalysisResponse {
 	type: BanditExperimentAnalysisResponseType;
-	/** ID of the experiment. */
 	experiment_id: string;
-	/** Contains one analysis per metric targeted by the experiment. */
 	arm_analyses: BanditArmAnalysis[];
-	/** The number of outcomes observed for this experiment. */
 	n_outcomes: number;
-	/** The date and time the experiment analysis was created. */
 	created_at: string;
-	/** The context values used for the analysis, if applicable. */
 	contexts?: BanditExperimentAnalysisResponseContexts;
 }
 
@@ -573,31 +331,22 @@ export const BqDsnInputType = {
 	bigquery: "bigquery",
 } as const;
 
-/**
- * This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.
- */
 export type BqDsnInputCredentials = GcpServiceAccount | Hidden;
 
-/**
- * BqDsn describes a connection to a BigQuery database.
- */
 export interface BqDsnInput {
 	type: BqDsnInputType;
 	/**
-	 * The Google Cloud Project ID containing the dataset.
 	 * @minLength 6
 	 * @maxLength 30
 	 * @pattern ^[a-z0-9-]+$
 	 */
 	project_id: string;
 	/**
-	 * The dataset name.
 	 * @minLength 1
 	 * @maxLength 1024
 	 * @pattern ^[a-zA-Z0-9_]+$
 	 */
 	dataset_id: string;
-	/** This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained. */
 	credentials: BqDsnInputCredentials;
 }
 
@@ -609,68 +358,29 @@ export const BqDsnOutputType = {
 	bigquery: "bigquery",
 } as const;
 
-/**
- * This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.
- */
 export type BqDsnOutputCredentials = GcpServiceAccount | Hidden;
 
-/**
- * BqDsn describes a connection to a BigQuery database.
- */
 export interface BqDsnOutput {
 	type: BqDsnOutputType;
 	/**
-	 * The Google Cloud Project ID containing the dataset.
 	 * @minLength 6
 	 * @maxLength 30
 	 * @pattern ^[a-z0-9-]+$
 	 */
 	project_id: string;
 	/**
-	 * The dataset name.
 	 * @minLength 1
 	 * @maxLength 1024
 	 * @pattern ^[a-zA-Z0-9_]+$
 	 */
 	dataset_id: string;
-	/** This value must be a GcpServiceAccount when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained. */
 	credentials: BqDsnOutputCredentials;
 }
 
-/**
- * 
-            List of context values for the assignment.
-            Must include exactly the same number contexts defined in the experiment.
-            The values are matched to the experiment's contexts by context_id, not by position in the list.
-            Each context_id must correspond to one of the IDs of the contexts defined in the experiment.
-            Can be None, when simply retrieving pre-existing assignments; must have valid inputs otherwise.
-            
- */
 export type CMABContextInputRequestContextInputs = ContextInput[] | null;
 
-/**
- * Request model for creating a new CMAB assignment or a CMAB experiment analysis.
-
-When submitting context values for a CMAB experiment, the following rules apply:
-1. Each context_input must reference a valid context_id from the experiment's defined contexts
-2. The order of context_inputs does not need to match the order of contexts in the experiment
-3. You must provide values for all contexts defined in the experiment
-4. Number of input context values must match the number of contexts defined in the experiment
-5. The context value input can be None, but only in the case of retrieving a pre-existing assignment.
-
-Example:
-    If an experiment defines contexts with IDs ["ctx_1", "ctx_2"], your request must include
-    both of these context_ids in the context_inputs list, but they can be in any order.
- */
 export interface CMABContextInputRequest {
 	type?: "cmab_assignment";
-	/** 
-            List of context values for the assignment.
-            Must include exactly the same number contexts defined in the experiment.
-            The values are matched to the experiment's contexts by context_id, not by position in the list.
-            Each context_id must correspond to one of the IDs of the contexts defined in the experiment.
-            Can be None, when simply retrieving pre-existing assignments; must have valid inputs otherwise.
-             */
 	context_inputs: CMABContextInputRequestContextInputs;
 }
 
@@ -682,29 +392,16 @@ export const CMABExperimentSpecInputExperimentType = {
 	cmab_online: "cmab_online",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type CMABExperimentSpecInputDesignUrl = string | null;
 
-/**
- * Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.
- */
 export type CMABExperimentSpecInputContexts = Context[] | null;
 
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with
-contextual MAB experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
 export interface CMABExperimentSpecInput {
 	experiment_type: CMABExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: CMABExperimentSpecInputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -713,11 +410,8 @@ export interface CMABExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	arms: ArmBandit[];
-	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: CMABExperimentSpecInputContexts;
-	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
-	/** The type of reward we observe from the experiment. */
 	reward_type?: LikelihoodTypes;
 }
 
@@ -729,29 +423,16 @@ export const CMABExperimentSpecOutputExperimentType = {
 	cmab_online: "cmab_online",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type CMABExperimentSpecOutputDesignUrl = string | null;
 
-/**
- * Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.
- */
 export type CMABExperimentSpecOutputContexts = Context[] | null;
 
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with
-contextual MAB experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
 export interface CMABExperimentSpecOutput {
 	experiment_type: CMABExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: CMABExperimentSpecOutputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -760,17 +441,11 @@ export interface CMABExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	arms: ArmBandit[];
-	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: CMABExperimentSpecOutputContexts;
-	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
-	/** The type of reward we observe from the experiment. */
 	reward_type?: LikelihoodTypes;
 }
 
-/**
- * Contains the OIDC authorization code, PKCE verifier, and nonce for the token exchange.
- */
 export interface CallbackRequest {
 	code: string;
 	/**
@@ -786,19 +461,10 @@ export interface CallbackRequest {
 	nonce: string;
 }
 
-/**
- * Contains the credentials the SPA will use for interacting with the Admin API.
-
-This is only returned when the SPA has successfully completed the OIDC PKCE flow.
- */
 export interface CallbackResponse {
-	/** Bearer token for use on Admin API endpoints. */
 	session_token: string;
 }
 
-/**
- * Describes the user's identity in a format suitable for use in the frontend.
- */
 export interface CallerIdentity {
 	email: string;
 	iss: string;
@@ -821,39 +487,23 @@ export interface ColumnDeleted {
 	column_name: string;
 }
 
-/**
- * Unique identifier for the context, you should NOT set this when creating a new context.
- */
 export type ContextContextId = string | null;
 
 export type ContextContextDescription = string | null;
 
-/**
- * Pydantic model for context of the experiment.
- */
 export interface Context {
-	/** Unique identifier for the context, you should NOT set this when creating a new context. */
 	context_id?: ContextContextId;
 	/** @maxLength 100 */
 	context_name: string;
 	context_description?: ContextContextDescription;
-	/** Type of value the context can take */
 	value_type?: ContextType;
 }
 
-/**
- * Pydantic model for a context input
- */
 export interface ContextInput {
-	/** Unique identifier for the context. */
 	context_id: string;
-	/** Value of the context */
 	context_value: number;
 }
 
-/**
- * Enum for the type of context.
- */
 export type ContextType = (typeof ContextType)[keyof typeof ContextType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -886,18 +536,11 @@ export type CreateExperimentRequestPowerAnalyses = PowerResponseInput | null;
 export interface CreateExperimentRequest {
 	design_spec: DesignSpecInput;
 	power_analyses?: CreateExperimentRequestPowerAnalyses;
-	/** List of webhook IDs to associate with this experiment. When the experiment is committed, these webhooks will be triggered with experiment details. Must contain unique values. */
 	webhooks?: string[];
 }
 
-/**
- * The date and time assignments were stopped. Null if assignments are still allowed to be made.
- */
 export type CreateExperimentResponseStoppedAssignmentsAt = string | null;
 
-/**
- * The reason assignments were stopped. Null if assignments are still allowed to be made.
- */
 export type CreateExperimentResponseStoppedAssignmentsReason =
 	StopAssignmentReason | null;
 
@@ -905,32 +548,19 @@ export type CreateExperimentResponsePowerAnalyses = PowerResponseOutput | null;
 
 export type CreateExperimentResponseAssignSummary = AssignSummary | null;
 
-/**
- * Same as the request but with ids filled for the experiment and arms, and summary info on the assignment.
- */
 export interface CreateExperimentResponse {
-	/** Server-generated ID of the experiment. */
 	experiment_id: string;
 	datasource_id: string;
-	/**
-	 * (legacy experiments) Persisted participant-type name for backwards compatibility. New experiments will have this set to the empty string.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	participant_type_deprecated: string;
-	/** Current state of this experiment. */
 	state: ExperimentState;
-	/** The date and time assignments were stopped. Null if assignments are still allowed to be made. */
 	stopped_assignments_at: CreateExperimentResponseStoppedAssignmentsAt;
-	/** The reason assignments were stopped. Null if assignments are still allowed to be made. */
 	stopped_assignments_reason: CreateExperimentResponseStoppedAssignmentsReason;
 	design_spec: DesignSpecOutput;
 	power_analyses: CreateExperimentResponsePowerAnalyses;
 	assign_summary: CreateExperimentResponseAssignSummary;
-	/** List of webhook IDs associated with this experiment. These webhooks are triggered when the experiment is committed. */
 	webhooks?: string[];
-	/** Record any decision(s) made because of this experiment. Will you launch it, and if so when? Regardless of positive or negative results, how do any learnings inform next steps or future hypotheses? */
 	decision?: string;
-	/** Given the results across your tracked metrics and any other observed effects seen elsewhere, record an overall summary here. Do they agree or reject your hypotheses? Beyond the metrics tracked, did variations affect scalability, cost, feedback, or other aspects? */
 	impact?: Impact;
 }
 
@@ -960,9 +590,6 @@ export interface CreateSnapshotResponse {
 	id: string;
 }
 
-/**
- * Defines the supported data types for fields in the data source.
- */
 export type DataType = (typeof DataType)[keyof typeof DataType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -995,145 +622,79 @@ export interface DatasourceSummary {
 	organization_name: string;
 }
 
-/**
- * Delete related participant assignments.
- */
 export type DeleteExperimentDataRequestAssignments = boolean | null;
 
-/**
- * Delete related snapshots.
- */
 export type DeleteExperimentDataRequestSnapshots = boolean | null;
 
-/**
- * Request to delete specific data associated with an experiment.
- */
 export interface DeleteExperimentDataRequest {
-	/** Delete related participant assignments. */
 	assignments?: DeleteExperimentDataRequestAssignments;
-	/** Delete related snapshots. */
 	snapshots?: DeleteExperimentDataRequestSnapshots;
 }
 
-/**
- * The type of assignment and experiment design.
- */
 export type DesignSpecInput =
 	| AnyFrequentistDesignSpecInput
 	| AnyBanditDesignSpecInput;
 
-/**
- * The type of assignment and experiment design.
- */
 export type DesignSpecOutput =
 	| AnyFrequentistDesignSpecOutput
 	| AnyBanditDesignSpecOutput;
 
-/**
- * Percent change target relative to the metric_baseline.
- */
 export type DesignSpecMetricMetricPctChange = number | null;
 
-/**
- * Absolute target value = metric_baseline*(1 + metric_pct_change)
- */
 export type DesignSpecMetricMetricTarget = number | null;
 
-/**
- * Inferred from dwh type.
- */
-export type DesignSpecMetricMetricType = MetricType | null;
-
-/**
- * Mean of the tracked metric.
- */
-export type DesignSpecMetricMetricBaseline = number | null;
-
-/**
- * Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0.
- */
-export type DesignSpecMetricMetricStddev = number | null;
-
-/**
- * The number of participants meeting the filtering criteria with a *non-null* value for this metric.
- */
-export type DesignSpecMetricAvailableNonnullN = number | null;
-
-/**
- * The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.
- */
-export type DesignSpecMetricAvailableN = number | null;
-
-/**
- * Intracluster correlation coefficient for cluster-randomized designs.
- */
 export type DesignSpecMetricIcc = number | null;
 
-/**
- * Average number of individuals per cluster.
- */
 export type DesignSpecMetricAvgClusterSize = number | null;
 
-/**
- * Coefficient of variation in cluster sizes (0 = equal sizes).
- */
 export type DesignSpecMetricCv = number | null;
 
-/**
- * Defines a metric to measure in an experiment with its baseline stats.
- */
+export type DesignSpecMetricMetricType = MetricType | null;
+
+export type DesignSpecMetricMetricBaseline = number | null;
+
+export type DesignSpecMetricMetricStddev = number | null;
+
+export type DesignSpecMetricAvailableNonnullN = number | null;
+
+export type DesignSpecMetricAvailableN = number | null;
+
 export interface DesignSpecMetric {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
-	/** Percent change target relative to the metric_baseline. */
 	metric_pct_change?: DesignSpecMetricMetricPctChange;
-	/** Absolute target value = metric_baseline*(1 + metric_pct_change) */
 	metric_target?: DesignSpecMetricMetricTarget;
-	/** Inferred from dwh type. */
-	metric_type?: DesignSpecMetricMetricType;
-	/** Mean of the tracked metric. */
-	metric_baseline?: DesignSpecMetricMetricBaseline;
-	/** Standard deviation is set only for metric_type.NUMERIC metrics. Must be set for numeric metrics when available_n > 0. */
-	metric_stddev?: DesignSpecMetricMetricStddev;
-	/** The number of participants meeting the filtering criteria with a *non-null* value for this metric. */
-	available_nonnull_n?: DesignSpecMetricAvailableNonnullN;
-	/** The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n. */
-	available_n?: DesignSpecMetricAvailableN;
-	/** Intracluster correlation coefficient for cluster-randomized designs. */
 	icc?: DesignSpecMetricIcc;
-	/** Average number of individuals per cluster. */
 	avg_cluster_size?: DesignSpecMetricAvgClusterSize;
-	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
 	cv?: DesignSpecMetricCv;
+	metric_type?: DesignSpecMetricMetricType;
+	metric_baseline?: DesignSpecMetricMetricBaseline;
+	metric_stddev?: DesignSpecMetricMetricStddev;
+	available_nonnull_n?: DesignSpecMetricAvailableNonnullN;
+	available_n?: DesignSpecMetricAvailableN;
 }
 
-/**
- * Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target.
- */
 export type DesignSpecMetricRequestMetricPctChange = number | null;
 
-/**
- * Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.
- */
 export type DesignSpecMetricRequestMetricTarget = number | null;
 
-/**
- * Defines a request to look up baseline stats for a metric to measure in an experiment.
- */
+export type DesignSpecMetricRequestIcc = number | null;
+
+export type DesignSpecMetricRequestAvgClusterSize = number | null;
+
+export type DesignSpecMetricRequestCv = number | null;
+
 export interface DesignSpecMetricRequest {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
-	/** Specify a meaningful min percent change relative to the metric_baseline you want to detect. Cannot be set if you set metric_target. */
 	metric_pct_change?: DesignSpecMetricRequestMetricPctChange;
-	/** Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change. */
 	metric_target?: DesignSpecMetricRequestMetricTarget;
+	icc?: DesignSpecMetricRequestIcc;
+	avg_cluster_size?: DesignSpecMetricRequestAvgClusterSize;
+	cv?: DesignSpecMetricRequestCv;
 }
 
-/**
- * Describes differences between two participant types.
- */
 export interface Drift {
-	/** List of individual changes detected that might break things. */
 	schema_diff: TableDiff[];
 }
 
@@ -1141,51 +702,27 @@ export type DsnInput = ApiOnlyDsn | PostgresDsn | BqDsnInput | RedshiftDsn;
 
 export type DsnOutput = ApiOnlyDsn | PostgresDsn | BqDsnOutput | RedshiftDsn;
 
-/**
- * A navigable link to related information.
- */
 export type EventSummaryLink = string | null;
 
 export type EventSummaryDetailsAnyOf = { [key: string]: unknown };
 
-/**
- * Details
- */
 export type EventSummaryDetails = EventSummaryDetailsAnyOf | null;
 
-/**
- * Describes an event.
- */
 export interface EventSummary {
-	/** The ID of the event. */
 	id: string;
-	/** The time the event was created. */
 	created_at: string;
-	/** The type of event. */
 	type: string;
-	/** Human-readable summary of the event. */
 	summary: string;
-	/** A navigable link to related information. */
 	link?: EventSummaryLink;
-	/** Details */
 	details: EventSummaryDetails;
 }
 
-/**
- * The type of experiment analysis response.
- */
 export type ExperimentAnalysisResponse =
 	| FreqExperimentAnalysisResponse
 	| BanditExperimentAnalysisResponse;
 
-/**
- * The date and time assignments were stopped. Null if assignments are still allowed to be made.
- */
 export type ExperimentConfigStoppedAssignmentsAt = string | null;
 
-/**
- * The reason assignments were stopped. Null if assignments are still allowed to be made.
- */
 export type ExperimentConfigStoppedAssignmentsReason =
 	StopAssignmentReason | null;
 
@@ -1193,41 +730,22 @@ export type ExperimentConfigPowerAnalyses = PowerResponseOutput | null;
 
 export type ExperimentConfigAssignSummary = AssignSummary | null;
 
-/**
- * Representation of our stored Experiment information.
- */
 export interface ExperimentConfig {
-	/** Server-generated ID of the experiment. */
 	experiment_id: string;
 	datasource_id: string;
-	/**
-	 * (legacy experiments) Persisted participant-type name for backwards compatibility. New experiments will have this set to the empty string.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	participant_type_deprecated: string;
-	/** Current state of this experiment. */
 	state: ExperimentState;
-	/** The date and time assignments were stopped. Null if assignments are still allowed to be made. */
 	stopped_assignments_at: ExperimentConfigStoppedAssignmentsAt;
-	/** The reason assignments were stopped. Null if assignments are still allowed to be made. */
 	stopped_assignments_reason: ExperimentConfigStoppedAssignmentsReason;
 	design_spec: DesignSpecOutput;
 	power_analyses: ExperimentConfigPowerAnalyses;
 	assign_summary: ExperimentConfigAssignSummary;
-	/** List of webhook IDs associated with this experiment. These webhooks are triggered when the experiment is committed. */
 	webhooks?: string[];
-	/** Record any decision(s) made because of this experiment. Will you launch it, and if so when? Regardless of positive or negative results, how do any learnings inform next steps or future hypotheses? */
 	decision?: string;
-	/** Given the results across your tracked metrics and any other observed effects seen elsewhere, record an overall summary here. Do they agree or reject your hypotheses? Beyond the metrics tracked, did variations affect scalability, cost, feedback, or other aspects? */
 	impact?: Impact;
 }
 
-/**
- * Experiment lifecycle states.
-
-note: [starting state], [[terminal state]]
-[DESIGNING]->[ASSIGNED]->{[[ABANDONED]], COMMITTED}->[[ABORTED]]
- */
 export type ExperimentState =
 	(typeof ExperimentState)[keyof typeof ExperimentState];
 
@@ -1264,27 +782,17 @@ export type FieldDescriptorExtraAnyOf = { [key: string]: string };
 export type FieldDescriptorExtra = FieldDescriptorExtraAnyOf | null;
 
 export interface FieldDescriptor {
-	/** Name of the field in the data source */
 	field_name: string;
-	/** The data type of this field */
 	data_type: DataType;
-	/** Human-readable description of the field */
 	description?: string;
-	/** Whether this field uniquely identifies records */
 	is_unique_id?: boolean;
-	/** Whether this field should be used for stratification */
 	is_strata?: boolean;
-	/** Whether this field can be used as a filter */
 	is_filter?: boolean;
-	/** Whether this field can be used as a metric */
 	is_metric?: boolean;
 	/** @deprecated */
 	extra?: FieldDescriptorExtra;
 }
 
-/**
- * Concise summary of fields in the table.
- */
 export interface FieldMetadata {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
@@ -1293,43 +801,6 @@ export interface FieldMetadata {
 	description: string;
 }
 
-/**
- * Defines criteria for filtering rows by value.
-
-## Examples
-
-| Relation | Value             | logical Result                                    |
-|----------|-------------------|---------------------------------------------------|
-| INCLUDES | [None]            | Match when `x IS NULL`                            |
-| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |
-| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |
-| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |
-| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |
-| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |
-| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |
-| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |
-| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |
-| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |
-| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |
-| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |
-
-String comparisons are case-sensitive.
-
-## Special Handling for BETWEEN support of including NULL
-
-When the relation is BETWEEN, we allow for up to 3 values to support the special case of
-including null in addition to the values in the between range via an OR IS NULL clause, as
-indicated by a 3rd value of None. Any other 3rd value is invalid.
-
-## Handling of DATE, DATETIME and TIMESTAMP values
-
-DATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.
-
-Values must be expressed as ISO8601 datetime strings compatible with Python's datetime.fromisoformat()
-(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).
-
-If a timezone is provided, it must be UTC.
- */
 export interface FilterInput {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
@@ -1337,43 +808,6 @@ export interface FilterInput {
 	value: FilterValueTypes;
 }
 
-/**
- * Defines criteria for filtering rows by value.
-
-## Examples
-
-| Relation | Value             | logical Result                                    |
-|----------|-------------------|---------------------------------------------------|
-| INCLUDES | [None]            | Match when `x IS NULL`                            |
-| INCLUDES | ["a"]             | Match when `x IN ("a")`                           |
-| INCLUDES | ["a", None]       | Match when `x IS NULL OR x IN ("a")`              |
-| INCLUDES | ["a", "b"]        | Match when `x IN ("a", "b")`                      |
-| EXCLUDES | [None]            | Match `x IS NOT NULL`                             |
-| EXCLUDES | ["a", None]       | Match `x IS NOT NULL AND x NOT IN ("a")`          |
-| EXCLUDES | ["a", "b"]        | Match `x IS NULL OR (x NOT IN ("a", "b"))`        |
-| BETWEEN  | ["a", "z"]        | Match `"a" <= x <= "z"`                           |
-| BETWEEN  | ["a", "z", None]  | Match `"a" <= x <= "z"` or `x IS NULL`            |
-| BETWEEN  | [None, "z"]       | Match `x <= "z"`                                  |
-| BETWEEN  | ["a", None]       | Match `x >= "a"`                                  |
-| BETWEEN  | [None, "a", None] | Match `x <= "a"` or `x IS NULL`                   |
-
-String comparisons are case-sensitive.
-
-## Special Handling for BETWEEN support of including NULL
-
-When the relation is BETWEEN, we allow for up to 3 values to support the special case of
-including null in addition to the values in the between range via an OR IS NULL clause, as
-indicated by a 3rd value of None. Any other 3rd value is invalid.
-
-## Handling of DATE, DATETIME and TIMESTAMP values
-
-DATE, DATETIME or TIMESTAMP-type columns support INCLUDES/EXCLUDES/BETWEEN, similar to numerics.
-
-Values must be expressed as ISO8601 datetime strings compatible with Python's datetime.fromisoformat()
-(https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat).
-
-If a timezone is provided, it must be UTC.
- */
 export interface FilterOutput {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
@@ -1399,40 +833,25 @@ export const FreqExperimentAnalysisResponseType = {
 	freq: "freq",
 } as const;
 
-/**
- * The number of participants assigned to the experiment across all arms that are not found in the data warehouse when pulling metrics.
- */
 export type FreqExperimentAnalysisResponseNumMissingParticipants =
 	| number
 	| null;
 
-/**
- * Describes the change if any in metrics targeted by an experiment.
- */
 export interface FreqExperimentAnalysisResponse {
 	type: FreqExperimentAnalysisResponseType;
-	/** ID of the experiment. */
 	experiment_id: string;
-	/** Contains one analysis per metric targeted by the experiment. */
 	metric_analyses: MetricAnalysis[];
-	/** The number of participants assigned to the experiment pulled from the dwh across all arms. Metric outcomes are not guaranteed to be present for all participants. */
 	num_participants: number;
-	/** The number of participants assigned to the experiment across all arms that are not found in the data warehouse when pulling metrics. */
 	num_missing_participants?: FreqExperimentAnalysisResponseNumMissingParticipants;
-	/** The date and time the experiment analysis was created. */
 	created_at: string;
 }
 
-/**
- * Describes a Google Cloud Platform service account.
- */
 export interface GcpServiceAccount {
 	type?: "serviceaccountinfo";
 	content: GcpServiceAccountBlob;
 }
 
 /**
- * The service account info in the canonical JSON form. Required fields: type, project_id, private_key_id, private_key, client_email.
  * @minLength 4
  * @maxLength 8000
  */
@@ -1450,44 +869,24 @@ export interface GetDatasourceResponse {
 	organization_name: string;
 }
 
-/**
- * Balance test results if available. 'online' experiments do not have balance checks.
- */
 export type GetExperimentAssignmentsResponseBalanceCheck = BalanceCheck | null;
 
-/**
- * Describes assignments for all participants and balance test results if available.
- */
 export interface GetExperimentAssignmentsResponse {
-	/** Balance test results if available. 'online' experiments do not have balance checks. */
 	balance_check?: GetExperimentAssignmentsResponseBalanceCheck;
 	experiment_id: string;
 	sample_size: number;
 	assignments: Assignment[];
 }
 
-/**
- * If available, the Participant Type information for this experiment. This field is null for experiments that only use an 'API Only' datasource.
- */
 export type GetExperimentForUiResponseParticipantType = ParticipantsDef | null;
 
-/**
- * Experiment configuration and participant type information.
- */
 export interface GetExperimentForUiResponse {
 	config: ExperimentConfig;
-	/** If available, the Participant Type information for this experiment. This field is null for experiments that only use an 'API Only' datasource. */
 	participant_type: GetExperimentForUiResponseParticipantType;
 }
 
-/**
- * The date and time assignments were stopped. Null if assignments are still allowed to be made.
- */
 export type GetExperimentResponseStoppedAssignmentsAt = string | null;
 
-/**
- * The reason assignments were stopped. Null if assignments are still allowed to be made.
- */
 export type GetExperimentResponseStoppedAssignmentsReason =
 	StopAssignmentReason | null;
 
@@ -1495,48 +894,26 @@ export type GetExperimentResponsePowerAnalyses = PowerResponseOutput | null;
 
 export type GetExperimentResponseAssignSummary = AssignSummary | null;
 
-/**
- * An experiment configuration capturing all info at design time when assignment was made.
- */
 export interface GetExperimentResponse {
-	/** Server-generated ID of the experiment. */
 	experiment_id: string;
 	datasource_id: string;
-	/**
-	 * (legacy experiments) Persisted participant-type name for backwards compatibility. New experiments will have this set to the empty string.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	participant_type_deprecated: string;
-	/** Current state of this experiment. */
 	state: ExperimentState;
-	/** The date and time assignments were stopped. Null if assignments are still allowed to be made. */
 	stopped_assignments_at: GetExperimentResponseStoppedAssignmentsAt;
-	/** The reason assignments were stopped. Null if assignments are still allowed to be made. */
 	stopped_assignments_reason: GetExperimentResponseStoppedAssignmentsReason;
 	design_spec: DesignSpecOutput;
 	power_analyses: GetExperimentResponsePowerAnalyses;
 	assign_summary: GetExperimentResponseAssignSummary;
-	/** List of webhook IDs associated with this experiment. These webhooks are triggered when the experiment is committed. */
 	webhooks?: string[];
-	/** Record any decision(s) made because of this experiment. Will you launch it, and if so when? Regardless of positive or negative results, how do any learnings inform next steps or future hypotheses? */
 	decision?: string;
-	/** Given the results across your tracked metrics and any other observed effects seen elsewhere, record an overall summary here. Do they agree or reject your hypotheses? Beyond the metrics tracked, did variations affect scalability, cost, feedback, or other aspects? */
 	impact?: Impact;
 }
 
-/**
- * Sorted list of unique values.
- */
 export type GetFiltersResponseDiscreteDistinctValues = string[] | null;
 
-/**
- * Describes a discrete filter variable.
- */
 export interface GetFiltersResponseDiscrete {
-	/**
-	 * Name of the field.
-	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
-	 */
+	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
 	data_type: DataType;
 	/**
@@ -1546,7 +923,6 @@ export interface GetFiltersResponseDiscrete {
 	relations: Relation[];
 	/** @maxLength 2000 */
 	description: string;
-	/** Sorted list of unique values. */
 	distinct_values: GetFiltersResponseDiscreteDistinctValues;
 }
 
@@ -1554,9 +930,6 @@ export type GetFiltersResponseElement =
 	| GetFiltersResponseNumericOrDate
 	| GetFiltersResponseDiscrete;
 
-/**
- * The minimum observed value.
- */
 export type GetFiltersResponseNumericOrDateMin =
 	| string
 	| string
@@ -1564,9 +937,6 @@ export type GetFiltersResponseNumericOrDateMin =
 	| number
 	| null;
 
-/**
- * The maximum observed value.
- */
 export type GetFiltersResponseNumericOrDateMax =
 	| string
 	| string
@@ -1574,14 +944,8 @@ export type GetFiltersResponseNumericOrDateMax =
 	| number
 	| null;
 
-/**
- * Describes a numeric or date filter variable.
- */
 export interface GetFiltersResponseNumericOrDate {
-	/**
-	 * Name of the field.
-	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
-	 */
+	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
 	data_type: DataType;
 	/**
@@ -1591,15 +955,10 @@ export interface GetFiltersResponseNumericOrDate {
 	relations: Relation[];
 	/** @maxLength 2000 */
 	description: string;
-	/** The minimum observed value. */
 	min: GetFiltersResponseNumericOrDateMin;
-	/** The maximum observed value. */
 	max: GetFiltersResponseNumericOrDateMax;
 }
 
-/**
- * Describes a metric.
- */
 export interface GetMetricsResponseElement {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
@@ -1617,41 +976,24 @@ export interface GetOrganizationResponse {
 	datasources: DatasourceSummary[];
 }
 
-/**
- * Null if no assignment. assignment.strata are not included.
- */
 export type GetParticipantAssignmentResponseAssignment = Assignment | null;
 
-/**
- * Describes assignment for a single <experiment, participant> pair.
- */
 export interface GetParticipantAssignmentResponse {
 	experiment_id: string;
 	participant_id: string;
-	/** Null if no assignment. assignment.strata are not included. */
 	assignment: GetParticipantAssignmentResponseAssignment;
 }
 
 export interface GetParticipantsTypeResponse {
-	/** The currently saved configuration capturing the minimal set of fields possibly used. */
 	current: ParticipantsDef;
-	/** The configuration as implied by the live table schema, merged with current config annotations. */
 	proposed: ParticipantsDef;
-	/** Differences between the current and proposed configurations that might be breaking changes. */
 	drift: Drift;
 }
 
-/**
- * Describes the status and content of a snapshot.
- */
 export interface GetSnapshotResponse {
-	/** The snapshot. */
 	snapshot: Snapshot;
 }
 
-/**
- * Describes a stratification variable.
- */
 export interface GetStrataResponseElement {
 	data_type: DataType;
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
@@ -1660,39 +1002,21 @@ export interface GetStrataResponseElement {
 	description: string;
 }
 
-/**
- * Mapping of experiment arm IDs to Turn.io journey IDs. This configures which Turn.io journey each arm corresponds to for experiments that integrate with Turn.io.
- */
 export type GetTurnArmJourneyMappingResponseArmToJourneys = {
 	[key: string]: string;
 };
 
-/**
- * Response describing the mapping between experiment arms and Turn.io journeys.
- */
 export interface GetTurnArmJourneyMappingResponse {
-	/** Mapping of experiment arm IDs to Turn.io journey IDs. This configures which Turn.io journey each arm corresponds to for experiments that integrate with Turn.io. */
 	arm_to_journeys: GetTurnArmJourneyMappingResponseArmToJourneys;
 }
 
-/**
- * Response describing an organization's Turn.io connection.
- */
 export interface GetTurnConnectionResponse {
-	/** The last 4 characters of the configured Turn.io API token, shown so admins can identify which token is currently configured without exposing the full secret. */
 	token_preview: string;
 }
 
-/**
- * Mapping of journey names to their corresponding IDs, retrieved from the Turn API. This allows admins to reference specific journeys when configuring experiments that integrate with Turn.io.
- */
 export type GetTurnJourneysResponseJourneys = { [key: string]: string };
 
-/**
- * Response describing an organization's Turn.io journeys.
- */
 export interface GetTurnJourneysResponse {
-	/** Mapping of journey names to their corresponding IDs, retrieved from the Turn API. This allows admins to reference specific journeys when configuring experiments that integrate with Turn.io. */
 	journeys: GetTurnJourneysResponseJourneys;
 }
 
@@ -1704,9 +1028,6 @@ export interface HTTPValidationError {
 	detail?: ValidationError[];
 }
 
-/**
- * Hidden represents a credential that is intentionally omitted.
- */
 export const HiddenValue = {
 	type: "hidden",
 } as const;
@@ -1728,30 +1049,18 @@ export interface InspectDatasourceResponse {
 	tables: string[];
 }
 
-/**
- * Describes a table in the datasource.
- */
 export interface InspectDatasourceTableResponse {
-	/** Fields that are primary keys. */
 	primary_key_fields: string[];
-	/** Fields that are possibly candidates for unique IDs. */
 	detected_unique_id_fields: string[];
-	/** Fields in the table. */
 	fields: FieldMetadata[];
 }
 
-/**
- * Describes a participant type's strata, metrics, and filters (including exemplar values).
- */
 export interface InspectParticipantTypesResponse {
 	filters: GetFiltersResponseElement[];
 	metrics: GetMetricsResponseElement[];
 	strata: GetStrataResponseElement[];
 }
 
-/**
- * Enum for the likelihood distribution of the reward.
- */
 export type LikelihoodTypes =
 	(typeof LikelihoodTypes)[keyof typeof LikelihoodTypes];
 
@@ -1766,7 +1075,6 @@ export interface ListApiKeysResponse {
 }
 
 export interface ListDatasourcesResponse {
-	/** Descriptions of the datasources in this organization, ordered in descending order of frequency of use. */
 	items: DatasourceSummary[];
 }
 
@@ -1775,7 +1083,6 @@ export interface ListExperimentsResponse {
 }
 
 export interface ListOrganizationEventsResponse {
-	/** Token to retrieve the next page. Empty when no more results. */
 	next_page_token?: string;
 	items: EventSummary[];
 }
@@ -1785,22 +1092,15 @@ export interface ListOrganizationsResponse {
 }
 
 export interface ListParticipantsTypeResponse {
-	/** List of participant type definitions. */
 	items: ParticipantsDef[];
-	/** True when the datasource has hidden participant types. */
 	has_hidden: boolean;
 }
 
-/**
- * The timestamp of the latest snapshot that failed, or null if there have been no snapshot failures.
- */
 export type ListSnapshotsResponseLatestFailure = string | null;
 
 export interface ListSnapshotsResponse {
-	/** Token to retrieve the next page. Empty when no more results. */
 	next_page_token?: string;
 	items: Snapshot[];
-	/** The timestamp of the latest snapshot that failed, or null if there have been no snapshot failures. */
 	latest_failure: ListSnapshotsResponseLatestFailure;
 }
 
@@ -1816,28 +1116,16 @@ export const MABExperimentSpecInputExperimentType = {
 	mab_online: "mab_online",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type MABExperimentSpecInputDesignUrl = string | null;
 
-/**
- * Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.
- */
 export type MABExperimentSpecInputContexts = Context[] | null;
 
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
 export interface MABExperimentSpecInput {
 	experiment_type: MABExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: MABExperimentSpecInputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -1846,11 +1134,8 @@ export interface MABExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	arms: ArmBandit[];
-	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: MABExperimentSpecInputContexts;
-	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
-	/** The type of reward we observe from the experiment. */
 	reward_type?: LikelihoodTypes;
 }
 
@@ -1862,28 +1147,16 @@ export const MABExperimentSpecOutputExperimentType = {
 	mab_online: "mab_online",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type MABExperimentSpecOutputDesignUrl = string | null;
 
-/**
- * Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments.
- */
 export type MABExperimentSpecOutputContexts = Context[] | null;
 
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with MAB experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
 export interface MABExperimentSpecOutput {
 	experiment_type: MABExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: MABExperimentSpecOutputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -1892,11 +1165,8 @@ export interface MABExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	arms: ArmBandit[];
-	/** Optional list of contexts that can be used to condition the bandit assignment. Required for contextual bandit experiments. */
 	contexts?: MABExperimentSpecOutputContexts;
-	/** The type of prior distribution for the arms. */
 	prior_type?: PriorTypes;
-	/** The type of reward we observe from the experiment. */
 	reward_type?: LikelihoodTypes;
 }
 
@@ -1904,181 +1174,83 @@ export interface MessageError {
 	message: string;
 }
 
-/**
- * Describes the change in a single metric for each arm of an experiment.
- */
 export interface MetricAnalysis {
 	metric_name: string;
 	metric: DesignSpecMetricRequest;
-	/** The results of the analysis for each arm (coefficient) for this specific metric. */
 	arm_analyses: ArmAnalysis[];
 }
 
-/**
- * Minimum sample size needed to meet the design specs.
- */
 export type MetricPowerAnalysisInputTargetN = number | null;
 
-/**
- * Whether or not there are enough available units to sample from to meet target_n.
- */
 export type MetricPowerAnalysisInputSufficientN = boolean | null;
 
-/**
- * If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.
- */
 export type MetricPowerAnalysisInputTargetPossible = number | null;
 
-/**
- * If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.
- */
 export type MetricPowerAnalysisInputPctChangePossible = number | null;
 
-/**
- * The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).
- */
 export type MetricPowerAnalysisInputPctChangeWithDesiredN = number | null;
 
-/**
- * Human friendly message about the above results.
- */
 export type MetricPowerAnalysisInputMsg = MetricPowerAnalysisMessage | null;
 
-/**
- * Total number of clusters needed across all arms
- */
 export type MetricPowerAnalysisInputNumClustersTotal = number | null;
 
-/**
- * Number of clusters needed for each arm (one entry per arm)
- */
 export type MetricPowerAnalysisInputClustersPerArm = number[] | null;
 
-/**
- * Number of participants for each arm (one entry per arm)
- */
 export type MetricPowerAnalysisInputNPerArm = number[] | null;
 
-/**
- * Design effect (DEFF) - clustering penalty multiplier
- */
 export type MetricPowerAnalysisInputDesignEffect = number | null;
 
-/**
- * Effective sample size accounting for clustering (total_n / DEFF)
- */
 export type MetricPowerAnalysisInputEffectiveSampleSize = number | null;
 
-/**
- * Describes analysis results of a single metric.
- */
 export interface MetricPowerAnalysisInput {
 	metric_spec: DesignSpecMetric;
-	/** Minimum sample size needed to meet the design specs. */
 	target_n?: MetricPowerAnalysisInputTargetN;
-	/** Whether or not there are enough available units to sample from to meet target_n. */
 	sufficient_n?: MetricPowerAnalysisInputSufficientN;
-	/** If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	target_possible?: MetricPowerAnalysisInputTargetPossible;
-	/** If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	pct_change_possible?: MetricPowerAnalysisInputPctChangePossible;
-	/** The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs). */
 	pct_change_with_desired_n?: MetricPowerAnalysisInputPctChangeWithDesiredN;
-	/** Human friendly message about the above results. */
 	msg?: MetricPowerAnalysisInputMsg;
-	/** Total number of clusters needed across all arms */
 	num_clusters_total?: MetricPowerAnalysisInputNumClustersTotal;
-	/** Number of clusters needed for each arm (one entry per arm) */
 	clusters_per_arm?: MetricPowerAnalysisInputClustersPerArm;
-	/** Number of participants for each arm (one entry per arm) */
 	n_per_arm?: MetricPowerAnalysisInputNPerArm;
-	/** Design effect (DEFF) - clustering penalty multiplier */
 	design_effect?: MetricPowerAnalysisInputDesignEffect;
-	/** Effective sample size accounting for clustering (total_n / DEFF) */
 	effective_sample_size?: MetricPowerAnalysisInputEffectiveSampleSize;
 }
 
-/**
- * Minimum sample size needed to meet the design specs.
- */
 export type MetricPowerAnalysisOutputTargetN = number | null;
 
-/**
- * Whether or not there are enough available units to sample from to meet target_n.
- */
 export type MetricPowerAnalysisOutputSufficientN = boolean | null;
 
-/**
- * If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change.
- */
 export type MetricPowerAnalysisOutputTargetPossible = number | null;
 
-/**
- * If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change.
- */
 export type MetricPowerAnalysisOutputPctChangePossible = number | null;
 
-/**
- * The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs).
- */
 export type MetricPowerAnalysisOutputPctChangeWithDesiredN = number | null;
 
-/**
- * Human friendly message about the above results.
- */
 export type MetricPowerAnalysisOutputMsg = MetricPowerAnalysisMessage | null;
 
-/**
- * Total number of clusters needed across all arms
- */
 export type MetricPowerAnalysisOutputNumClustersTotal = number | null;
 
-/**
- * Number of clusters needed for each arm (one entry per arm)
- */
 export type MetricPowerAnalysisOutputClustersPerArm = number[] | null;
 
-/**
- * Number of participants for each arm (one entry per arm)
- */
 export type MetricPowerAnalysisOutputNPerArm = number[] | null;
 
-/**
- * Design effect (DEFF) - clustering penalty multiplier
- */
 export type MetricPowerAnalysisOutputDesignEffect = number | null;
 
-/**
- * Effective sample size accounting for clustering (total_n / DEFF)
- */
 export type MetricPowerAnalysisOutputEffectiveSampleSize = number | null;
 
-/**
- * Describes analysis results of a single metric.
- */
 export interface MetricPowerAnalysisOutput {
 	metric_spec: DesignSpecMetric;
-	/** Minimum sample size needed to meet the design specs. */
 	target_n?: MetricPowerAnalysisOutputTargetN;
-	/** Whether or not there are enough available units to sample from to meet target_n. */
 	sufficient_n?: MetricPowerAnalysisOutputSufficientN;
-	/** If there is an insufficient sample size to meet the desired metric_target, we report what is possible given the available_n. This value is equivalent to the relative pct_change_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	target_possible?: MetricPowerAnalysisOutputTargetPossible;
-	/** If there is an insufficient sample size to meet the desired metric_pct_change, we report what is possible given the available_n. This value is equivalent to the absolute target_possible. This is None when there is a sufficient sample size to detect the desired change. */
 	pct_change_possible?: MetricPowerAnalysisOutputPctChangePossible;
-	/** The MDE achievable given design_spec.desired_n, confidence, and power. Only present when design_spec.desired_n is set (frequentist design specs). */
 	pct_change_with_desired_n?: MetricPowerAnalysisOutputPctChangeWithDesiredN;
-	/** Human friendly message about the above results. */
 	msg?: MetricPowerAnalysisOutputMsg;
-	/** Total number of clusters needed across all arms */
 	num_clusters_total?: MetricPowerAnalysisOutputNumClustersTotal;
-	/** Number of clusters needed for each arm (one entry per arm) */
 	clusters_per_arm?: MetricPowerAnalysisOutputClustersPerArm;
-	/** Number of participants for each arm (one entry per arm) */
 	n_per_arm?: MetricPowerAnalysisOutputNPerArm;
-	/** Design effect (DEFF) - clustering penalty multiplier */
 	design_effect?: MetricPowerAnalysisOutputDesignEffect;
-	/** Effective sample size accounting for clustering (total_n / DEFF) */
 	effective_sample_size?: MetricPowerAnalysisOutputEffectiveSampleSize;
 }
 
@@ -2089,21 +1261,14 @@ export type MetricPowerAnalysisMessageValuesAnyOf = {
 export type MetricPowerAnalysisMessageValues =
 	MetricPowerAnalysisMessageValuesAnyOf | null;
 
-/**
- * Describes interpretation of power analysis results.
- */
 export interface MetricPowerAnalysisMessage {
 	type: MetricPowerAnalysisMessageType;
-	/** Main power analysis result stated in human-friendly English. */
 	msg: string;
-	/** Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages. */
 	source_msg: string;
 	values?: MetricPowerAnalysisMessageValues;
+	high_cluster_variation?: boolean;
 }
 
-/**
- * Classifies metric power analysis results.
- */
 export type MetricPowerAnalysisMessageType =
 	(typeof MetricPowerAnalysisMessageType)[keyof typeof MetricPowerAnalysisMessageType];
 
@@ -2117,9 +1282,6 @@ export const MetricPowerAnalysisMessageType = {
 	zero_variation: "zero variation",
 } as const;
 
-/**
- * Classifies metrics by their value type.
- */
 export type MetricType = (typeof MetricType)[keyof typeof MetricType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -2128,19 +1290,6 @@ export const MetricType = {
 	numeric: "numeric",
 } as const;
 
-/**
- * Request model for creating a new frequentist online assignment with server-side filtering.
-
-Usage notes:
-1. Currently only used for FREQ_ONLINE experiments.
-2. If the experiment defines no filters, use the corresponding GET endpoint instead.
-3. If an assignment already exists for a given participant, the property list is ignored and assignment returned.
-4. Property names must reference a valid field_name from the experiment's fields.
-5. Property list may be empty.
-6. If a filter is specified but no value is found, it is treated as NULL.
-7. Other differences from the SQL-based filtering logic:
-    - NO support for special experiment_id-based filters.
- */
 export interface OnlineAssignmentWithFiltersRequest {
 	/** List of participant properties to potentially filter against the experiment's filters. */
 	properties: ParticipantProperty[];
@@ -2154,29 +1303,18 @@ export const OnlineFrequentistExperimentSpecInputExperimentType = {
 	freq_online: "freq_online",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type OnlineFrequentistExperimentSpecInputDesignUrl = string | null;
 
-/**
- * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
- */
+export type OnlineFrequentistExperimentSpecInputClusterKey = string | null;
+
 export type OnlineFrequentistExperimentSpecInputDesiredN = number | null;
 
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with
-frequentist A/B experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
 export interface OnlineFrequentistExperimentSpecInput {
 	experiment_type: OnlineFrequentistExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: OnlineFrequentistExperimentSpecInputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -2185,48 +1323,32 @@ export interface OnlineFrequentistExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	arms: Arm[];
-	/**
-	 * Datasource table used to resolve participant field metadata.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	table_name: string;
-	/**
-	 * Column name in table_name that uniquely identifies each participant.
-	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
-	 */
+	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	primary_key: string;
-	/**
-	 * Optional fields to use for stratified assignment.
-	 * @maxItems 150
-	 */
+	cluster_key?: OnlineFrequentistExperimentSpecInputClusterKey;
+	/** @maxItems 150 */
 	strata: Stratum[];
 	/**
-	 * Primary and optional secondary metrics to target.
 	 * @minItems 1
 	 * @maxItems 150
 	 */
 	metrics: DesignSpecMetricRequest[];
-	/**
-	 * Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.
-	 * @maxItems 20
-	 */
+	/** @maxItems 20 */
 	filters: FilterInput[];
-	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: OnlineFrequentistExperimentSpecInputDesiredN;
 	/**
-	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	power?: number;
 	/**
-	 * The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	alpha?: number;
 	/**
-	 * Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".
 	 * @minimum 0
 	 * @maximum 1
 	 */
@@ -2241,29 +1363,18 @@ export const OnlineFrequentistExperimentSpecOutputExperimentType = {
 	freq_online: "freq_online",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type OnlineFrequentistExperimentSpecOutputDesignUrl = string | null;
 
-/**
- * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
- */
+export type OnlineFrequentistExperimentSpecOutputClusterKey = string | null;
+
 export type OnlineFrequentistExperimentSpecOutputDesiredN = number | null;
 
-/**
- * Use this type to randomly assign participants into arms during live experiment execution with
-frequentist A/B experiments.
-
-For example, you may wish to experiment on new users. Assignments are issued via API request.
- */
 export interface OnlineFrequentistExperimentSpecOutput {
 	experiment_type: OnlineFrequentistExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: OnlineFrequentistExperimentSpecOutputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -2272,48 +1383,32 @@ export interface OnlineFrequentistExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	arms: Arm[];
-	/**
-	 * Datasource table used to resolve participant field metadata.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	table_name: string;
-	/**
-	 * Column name in table_name that uniquely identifies each participant.
-	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
-	 */
+	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	primary_key: string;
-	/**
-	 * Optional fields to use for stratified assignment.
-	 * @maxItems 150
-	 */
+	cluster_key?: OnlineFrequentistExperimentSpecOutputClusterKey;
+	/** @maxItems 150 */
 	strata: Stratum[];
 	/**
-	 * Primary and optional secondary metrics to target.
 	 * @minItems 1
 	 * @maxItems 150
 	 */
 	metrics: DesignSpecMetricRequest[];
-	/**
-	 * Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.
-	 * @maxItems 20
-	 */
+	/** @maxItems 20 */
 	filters: FilterOutput[];
-	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: OnlineFrequentistExperimentSpecOutputDesiredN;
 	/**
-	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	power?: number;
 	/**
-	 * The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	alpha?: number;
 	/**
-	 * Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".
 	 * @minimum 0
 	 * @maximum 1
 	 */
@@ -2327,50 +1422,27 @@ export interface OrganizationSummary {
 	name: string;
 }
 
-/**
- * Properties about a participant that are used to filter the assignment.
- */
 export interface ParticipantProperty {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
 	value: PropertyValueTypes;
 }
 
-/**
- * Participants are a logical representation of a table in the data warehouse.
-
-Participants are defined by a participant_type, table_name and a schema.
- */
 export interface ParticipantsDef {
-	/** Name of the table in the data warehouse */
 	table_name: string;
-	/** List of fields available in this table */
 	fields: FieldDescriptor[];
-	/** Indicates that the schema is determined by an inline schema. */
 	type: "schema";
-	/** The name of the set of participants defined by the filters. This name must be unique within a datasource when not hidden (i.e. not auto-generated). */
 	participant_type: string;
-	/** If true, this participant type is hidden from list_participant_types. Used for auto-generated participant types. */
 	hidden?: boolean;
 }
 
-/**
- * Represents a single worksheet describing metadata about a type of Participant.
- */
 export interface ParticipantsSchemaInput {
-	/** Name of the table in the data warehouse */
 	table_name: string;
-	/** List of fields available in this table */
 	fields: FieldDescriptor[];
 }
 
-/**
- * Represents a single worksheet describing metadata about a type of Participant.
- */
 export interface ParticipantsSchemaOutput {
-	/** Name of the table in the data warehouse */
 	table_name: string;
-	/** List of fields available in this table */
 	fields: FieldDescriptor[];
 }
 
@@ -2382,9 +1454,6 @@ export const PostgresDsnType = {
 	postgres: "postgres",
 } as const;
 
-/**
- * This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.
- */
 export type PostgresDsnPassword = RevealedStr | Hidden;
 
 export type PostgresDsnSslmode =
@@ -2400,9 +1469,6 @@ export const PostgresDsnSslmode = {
 
 export type PostgresDsnSearchPath = string | null;
 
-/**
- * PostgresDsn describes a connection to a Postgres-compatible database.
- */
 export interface PostgresDsn {
 	type: PostgresDsnType;
 	host: string;
@@ -2412,7 +1478,6 @@ export interface PostgresDsn {
 	 */
 	port: number;
 	user: string;
-	/** This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained. */
 	password: PostgresDsnPassword;
 	dbname: string;
 	sslmode: PostgresDsnSslmode;
@@ -2441,27 +1506,18 @@ export const PreassignedFrequentistExperimentSpecInputExperimentType = {
 	freq_preassigned: "freq_preassigned",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type PreassignedFrequentistExperimentSpecInputDesignUrl = string | null;
 
-/**
- * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
- */
+export type PreassignedFrequentistExperimentSpecInputClusterKey = string | null;
+
 export type PreassignedFrequentistExperimentSpecInputDesiredN = number | null;
 
-/**
- * Use this type to randomly select and assign from existing participants at design time with
-frequentist A/B experiments.
- */
 export interface PreassignedFrequentistExperimentSpecInput {
 	experiment_type: PreassignedFrequentistExperimentSpecInputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: PreassignedFrequentistExperimentSpecInputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -2470,48 +1526,32 @@ export interface PreassignedFrequentistExperimentSpecInput {
 	 * @maxItems 20
 	 */
 	arms: Arm[];
-	/**
-	 * Datasource table used to resolve participant field metadata.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	table_name: string;
-	/**
-	 * Column name in table_name that uniquely identifies each participant.
-	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
-	 */
+	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	primary_key: string;
-	/**
-	 * Optional fields to use for stratified assignment.
-	 * @maxItems 150
-	 */
+	cluster_key?: PreassignedFrequentistExperimentSpecInputClusterKey;
+	/** @maxItems 150 */
 	strata: Stratum[];
 	/**
-	 * Primary and optional secondary metrics to target.
 	 * @minItems 1
 	 * @maxItems 150
 	 */
 	metrics: DesignSpecMetricRequest[];
-	/**
-	 * Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.
-	 * @maxItems 20
-	 */
+	/** @maxItems 20 */
 	filters: FilterInput[];
-	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: PreassignedFrequentistExperimentSpecInputDesiredN;
 	/**
-	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	power?: number;
 	/**
-	 * The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	alpha?: number;
 	/**
-	 * Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".
 	 * @minimum 0
 	 * @maximum 1
 	 */
@@ -2526,27 +1566,20 @@ export const PreassignedFrequentistExperimentSpecOutputExperimentType = {
 	freq_preassigned: "freq_preassigned",
 } as const;
 
-/**
- * Optional URL to a more detailed experiment design doc.
- */
 export type PreassignedFrequentistExperimentSpecOutputDesignUrl = string | null;
 
-/**
- * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
- */
+export type PreassignedFrequentistExperimentSpecOutputClusterKey =
+	| string
+	| null;
+
 export type PreassignedFrequentistExperimentSpecOutputDesiredN = number | null;
 
-/**
- * Use this type to randomly select and assign from existing participants at design time with
-frequentist A/B experiments.
- */
 export interface PreassignedFrequentistExperimentSpecOutput {
 	experiment_type: PreassignedFrequentistExperimentSpecOutputExperimentType;
 	/** @maxLength 100 */
 	experiment_name: string;
 	/** @maxLength 2000 */
 	description: string;
-	/** Optional URL to a more detailed experiment design doc. */
 	design_url?: PreassignedFrequentistExperimentSpecOutputDesignUrl;
 	start_date: string;
 	end_date: string;
@@ -2555,57 +1588,38 @@ export interface PreassignedFrequentistExperimentSpecOutput {
 	 * @maxItems 20
 	 */
 	arms: Arm[];
-	/**
-	 * Datasource table used to resolve participant field metadata.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	table_name: string;
-	/**
-	 * Column name in table_name that uniquely identifies each participant.
-	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
-	 */
+	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	primary_key: string;
-	/**
-	 * Optional fields to use for stratified assignment.
-	 * @maxItems 150
-	 */
+	cluster_key?: PreassignedFrequentistExperimentSpecOutputClusterKey;
+	/** @maxItems 150 */
 	strata: Stratum[];
 	/**
-	 * Primary and optional secondary metrics to target.
 	 * @minItems 1
 	 * @maxItems 150
 	 */
 	metrics: DesignSpecMetricRequest[];
-	/**
-	 * Optional filters that constrain a general eligible audience to a specific subset who can participate in an experiment.
-	 * @maxItems 20
-	 */
+	/** @maxItems 20 */
 	filters: FilterOutput[];
-	/** Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.  */
 	desired_n?: PreassignedFrequentistExperimentSpecOutputDesiredN;
 	/**
-	 * The chance of detecting a real non-null effect, i.e. 1 - false negative rate.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	power?: number;
 	/**
-	 * The chance of a false positive, i.e. there is no real non-null effect, but we mistakenly think there is one.
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	alpha?: number;
 	/**
-	 * Threshold on the p-value of joint significance in doing the omnibus balance check, above which we declare the data to be "balanced".
 	 * @minimum 0
 	 * @maximum 1
 	 */
 	fstat_thresh?: number;
 }
 
-/**
- * Enum for the prior distribution of the arm.
- */
 export type PriorTypes = (typeof PriorTypes)[keyof typeof PriorTypes];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -2629,16 +1643,10 @@ export const RedshiftDsnType = {
 	redshift: "redshift",
 } as const;
 
-/**
- * This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained.
- */
 export type RedshiftDsnPassword = RevealedStr | Hidden;
 
 export type RedshiftDsnSearchPath = string | null;
 
-/**
- * RedshiftDsn describes a connection to a Redshift database.
- */
 export interface RedshiftDsn {
 	type: RedshiftDsnType;
 	host: string;
@@ -2648,23 +1656,11 @@ export interface RedshiftDsn {
 	 */
 	port: number;
 	user: string;
-	/** This value must be a RevealedStr when creating the datasource or when updating a datasource's credentials. It may be a Hidden when updating a datasource. When hidden, the existing credentials are retained. */
 	password: RedshiftDsnPassword;
 	dbname: string;
 	search_path: RedshiftDsnSearchPath;
 }
 
-/**
- * Defines operators for filtering values.
-
-INCLUDES matches when the value matches any of the provided values, including null if explicitly
-specified. This is equivalent to NOT(EXCLUDES(values)).
-
-EXCLUDES matches when the value does not match any of the provided values, including null if
-explicitly specified. If null is not explicitly excluded, we include nulls in the result.
-
-BETWEEN matches when the value is between the two provided values (inclusive).
- */
 export type Relation = (typeof Relation)[keyof typeof Relation];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -2674,72 +1670,40 @@ export const Relation = {
 	between: "between",
 } as const;
 
-/**
- * RevealedStr contains a credential.
- */
 export interface RevealedStr {
 	type?: "revealed";
 	value: string;
 }
 
-/**
- * Request to create or update an organization's Turn.io connection.
- */
 export interface SetConnectionToTurnRequest {
-	/**
-	 * The Turn.io API token used to authenticate calls to the Turn API on behalf of the organization.
-	 * @minLength 335
-	 */
+	/** @minLength 335 */
 	turn_api_token: string;
 }
 
-/**
- * Mapping of experiment arm IDs to Turn.io journey IDs. This configures which Turn.io journey each arm corresponds to for experiments that integrate with Turn.io.
- */
 export type SetTurnArmJourneyMappingRequestArmToJourneys = {
 	[key: string]: string;
 };
 
-/**
- * Request to create or update the mapping between experiment arms and Turn.io journeys.
- */
 export interface SetTurnArmJourneyMappingRequest {
-	/** Mapping of experiment arm IDs to Turn.io journey IDs. This configures which Turn.io journey each arm corresponds to for experiments that integrate with Turn.io. */
 	arm_to_journeys: SetTurnArmJourneyMappingRequestArmToJourneys;
 }
 
 export type SnapshotDetailsAnyOf = { [key: string]: unknown };
 
-/**
- * Additional data about this snapshot.
- */
 export type SnapshotDetails = SnapshotDetailsAnyOf | null;
 
-/**
- * Analysis results as of the updated_at time.
- */
 export type SnapshotData = ExperimentAnalysisResponse | null;
 
 export interface Snapshot {
-	/** The experiment that this snapshot was captured for. */
 	experiment_id: string;
-	/** The unique ID of the snapshot. */
 	id: string;
-	/** The status of the snapshot. When not `success`, data will be null. */
 	status: SnapshotStatus;
-	/** Additional data about this snapshot. */
 	details: SnapshotDetails;
-	/** The time the snapshot was requested. */
 	created_at: string;
-	/** The time the snapshot was acquired. */
 	updated_at: string;
-	/** Analysis results as of the updated_at time. */
 	data: SnapshotData;
 }
 
-/**
- * Describes the status of a snapshot.
- */
 export type SnapshotStatus =
 	(typeof SnapshotStatus)[keyof typeof SnapshotStatus];
 
@@ -2750,9 +1714,6 @@ export const SnapshotStatus = {
 	failed: "failed",
 } as const;
 
-/**
- * The reason assignments were stopped.
- */
 export type StopAssignmentReason =
 	(typeof StopAssignmentReason)[keyof typeof StopAssignmentReason];
 
@@ -2766,18 +1727,12 @@ export const StopAssignmentReason = {
 
 export type StrataStrataValue = string | null;
 
-/**
- * Describes stratification for an experiment participant.
- */
 export interface Strata {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
 	strata_value?: StrataStrataValue;
 }
 
-/**
- * Describes a variable used for stratification.
- */
 export interface Stratum {
 	/** @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$ */
 	field_name: string;
@@ -2804,9 +1759,6 @@ export type TableDiff = ColumnDeleted | FieldChangedType | TableDeleted;
 
 export type TurnConfigResponseArmJourneyMap = { [key: string]: string };
 
-/**
- * Describes the configuration for Turn.io Evidential App.
- */
 export interface TurnConfigResponse {
 	experiment_id: string;
 	experiment_name: string;
@@ -2817,17 +1769,11 @@ export type UpdateArmRequestName = string | null;
 
 export type UpdateArmRequestDescription = string | null;
 
-/**
- * Defines the subset of fields that can be updated for an Arm after creation.
- */
 export interface UpdateArmRequest {
 	name?: UpdateArmRequestName;
 	description?: UpdateArmRequestDescription;
 }
 
-/**
- * Describes the outcome of a bandit experiment.
- */
 export interface UpdateBanditArmOutcomeRequest {
 	outcome: number;
 }
@@ -2855,9 +1801,6 @@ export type UpdateExperimentRequestImpact = Impact | null;
 
 export type UpdateExperimentRequestDecision = string | null;
 
-/**
- * Defines the subset of fields that can be updated for an experiment after creation.
- */
 export interface UpdateExperimentRequest {
 	name?: UpdateExperimentRequestName;
 	description?: UpdateExperimentRequestDescription;
@@ -2874,19 +1817,10 @@ export interface UpdateOrganizationRequest {
 	name?: UpdateOrganizationRequestName;
 }
 
-/**
- * Request to update a webhook's name and URL.
- */
 export interface UpdateOrganizationWebhookRequest {
-	/**
-	 * User-friendly name for the webhook. This name is displayed in the UI and helps identify the webhook's purpose.
-	 * @maxLength 100
-	 */
+	/** @maxLength 100 */
 	name: string;
-	/**
-	 * The HTTP or HTTPS URL that will receive webhook notifications when events occur.
-	 * @maxLength 500
-	 */
+	/** @maxLength 500 */
 	url: string;
 }
 
@@ -2932,24 +1866,13 @@ export interface ValidationError {
 	ctx?: ValidationErrorCtx;
 }
 
-/**
- * The value of the Webhook-Token: header that will be sent with the request to the configured URL.
- */
 export type WebhookSummaryAuthToken = string | null;
 
-/**
- * Summarizes a Webhook configuration for an organization.
- */
 export interface WebhookSummary {
-	/** The ID of the webhook. */
 	id: string;
-	/** The type of webhook; e.g. experiment.created */
 	type: string;
-	/** User-friendly name for the webhook. */
 	name: string;
-	/** The URL to notify. */
 	url: string;
-	/** The value of the Webhook-Token: header that will be sent with the request to the configured URL. */
 	auth_token: WebhookSummaryAuthToken;
 }
 
@@ -2966,157 +1889,93 @@ export interface XValidationError {
 }
 
 export type DeleteSnapshotParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type ListSnapshotsParams = {
-	/**
-	 * Filter the returned snapshots to only those of this status. May be specified multiple times.
-	 */
 	status?: SnapshotStatus[] | null;
 	/**
-	 * Maximum number of items to return per page.
 	 * @minimum 1
 	 * @maximum 100
 	 */
 	page_size?: number;
-	/**
-	 * Token from a previous response to fetch the next page.
-	 */
 	page_token?: string | null;
 	/**
-	 * Number of items to skip after page_token (or from the start when page_token is omitted).
 	 * @minimum 0
 	 */
 	skip?: number;
 };
 
 export type DeleteWebhookFromOrganizationParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type ListOrganizationEventsParams = {
 	/**
-	 * Maximum number of items to return per page.
 	 * @minimum 1
 	 * @maximum 100
 	 */
 	page_size?: number;
-	/**
-	 * Token from a previous response to fetch the next page.
-	 */
 	page_token?: string | null;
 	/**
-	 * Number of items to skip after page_token (or from the start when page_token is omitted).
 	 * @minimum 0
 	 */
 	skip?: number;
 };
 
 export type RemoveMemberFromOrganizationParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type CreateDatasourceParams = {
-	/**
-	 * When true, validate datasource connectivity before creation.
-	 */
 	connectivity_check?: boolean;
 };
 
 export type InspectDatasourceParams = {
-	/**
-	 * Refresh the cache.
-	 */
 	refresh?: boolean;
 };
 
 export type InspectTableInDatasourceParams = {
-	/**
-	 * Refresh the cache.
-	 */
 	refresh?: boolean;
 };
 
 export type DeleteDatasourceParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type InspectParticipantTypesParams = {
-	/**
-	 * Refresh the cache.
-	 */
 	refresh?: boolean;
-	/**
-	 * Whether to run expensive metadata queries.
-	 */
 	expensive?: boolean;
 };
 
 export type DeleteParticipantParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type DeleteApiKeyParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type CreateExperimentParams = {
-	/**
-	 * Whether to also stratify on metrics during assignment.
-	 */
 	stratify_on_metrics?: boolean;
 };
 
 export type AnalyzeExperimentParams = {
-	/**
-	 * UUID of the baseline arm. If None, the first design spec arm is used.
-	 */
 	baseline_arm_id?: string | null;
 };
 
 export type DeleteExperimentParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type GetOrganizationTurnConnectionParams = {
-	/**
-	 * If true, return a 200 with null body if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type DeleteTurnConnectionFromOrganizationParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };
 
 export type DeleteTurnArmJourneyMappingParams = {
-	/**
-	 * If true, return a 204 even if the resource does not exist.
-	 */
 	allow_missing?: boolean;
 };


### PR DESCRIPTION
Shave ~150KB from JS bundle, ~90KB from first page loads.

Summary:

1. Generated Zod schemas got much smaller. Orval was emitting Zod for every request/response/parameter/header for
   every Admin endpoint, including all the OpenAPI description text. Configured Orval to only emit request bodies (
   because
   that is all we use), and stripped the description text.▎ admin.zod.ts went from 353 KB → 44 KB on disk;
   /experiments/create First Load dropped from 407 → 393 kB.

2. Wired up @next/bundle-analyzer: run `task analyze` to get interactive treemaps in .next/analyze/.

3. Dropped Sentry Replay and browser tracing from the client bundle. We never used it and there are open privacy
   questions. This removes −118 KB gz of Sentry code. Core Sentry error capture features still work.

Largest remaining contributors (per analyzer) are recharts (~117 KB gz on chart routes), Radix Themes (~82 KB gz), and
Next.js itself (~218 KB gz).
