### PR TITLE
Add a 'resend' button on outbound webhook events.

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1271,6 +1271,90 @@ export const useListOrganizationEvents = <
 	};
 };
 /**
+ * Re-enqueues the outbound webhook task that produced a webhook.sent event.
+ * @summary Resend Organization Event
+ */
+export const getResendOrganizationEventUrl = (
+	organizationId: string,
+	eventId: string,
+) => {
+	return `/v1/m/organizations/${organizationId}/events/${eventId}/resend`;
+};
+
+export const resendOrganizationEvent = async (
+	organizationId: string,
+	eventId: string,
+	options?: RequestInit,
+): Promise<void> => {
+	return orvalFetch<void>(
+		getResendOrganizationEventUrl(organizationId, eventId),
+		{
+			...options,
+			method: "POST",
+		},
+	);
+};
+
+export const getResendOrganizationEventMutationFetcher = (
+	organizationId: string,
+	eventId: string,
+	options?: SecondParameter<typeof orvalFetch>,
+) => {
+	return (_: Key, __: { arg: Arguments }) => {
+		return resendOrganizationEvent(organizationId, eventId, options);
+	};
+};
+export const getResendOrganizationEventMutationKey = (
+	organizationId: string,
+	eventId: string,
+) =>
+	[`/v1/m/organizations/${organizationId}/events/${eventId}/resend`] as const;
+
+export type ResendOrganizationEventMutationResult = NonNullable<
+	Awaited<ReturnType<typeof resendOrganizationEvent>>
+>;
+export type ResendOrganizationEventMutationError = ErrorType<
+	HTTPExceptionError | HTTPValidationError
+>;
+
+/**
+ * @summary Resend Organization Event
+ */
+export const useResendOrganizationEvent = <
+	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
+>(
+	organizationId: string,
+	eventId: string,
+	options?: {
+		swr?: SWRMutationConfiguration<
+			Awaited<ReturnType<typeof resendOrganizationEvent>>,
+			TError,
+			Key,
+			Arguments,
+			Awaited<ReturnType<typeof resendOrganizationEvent>>
+		> & { swrKey?: string };
+		request?: SecondParameter<typeof orvalFetch>;
+	},
+) => {
+	const { swr: swrOptions, request: requestOptions } = options ?? {};
+
+	const swrKey =
+		swrOptions?.swrKey ??
+		getResendOrganizationEventMutationKey(organizationId, eventId);
+	const swrFn = getResendOrganizationEventMutationFetcher(
+		organizationId,
+		eventId,
+		requestOptions,
+	);
+
+	const query = useSWRMutation(swrKey, swrFn, swrOptions);
+
+	return {
+		swrKey,
+		...query,
+	};
+};
+/**
  * Adds a new member to an organization.
 
 The authenticated user must be part of the organization to add members.

--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -99,6 +99,24 @@ export const getSnapshotResponse = zod
 																.describe(
 																	"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
 																),
+															icc: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Intracluster correlation coefficient for cluster-randomized designs.",
+																),
+															avg_cluster_size: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Average number of individuals per cluster.",
+																),
+															cv: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Coefficient of variation in cluster sizes (0 = equal sizes).",
+																),
 														})
 														.describe(
 															"Defines a request to look up baseline stats for a metric to measure in an experiment.",
@@ -515,6 +533,24 @@ export const listSnapshotsResponse = zod.object({
 																.optional()
 																.describe(
 																	"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+																),
+															icc: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Intracluster correlation coefficient for cluster-randomized designs.",
+																),
+															avg_cluster_size: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Average number of individuals per cluster.",
+																),
+															cv: zod
+																.union([zod.number(), zod.null()])
+																.optional()
+																.describe(
+																	"Coefficient of variation in cluster sizes (0 = equal sizes).",
 																),
 														})
 														.describe(
@@ -1035,6 +1071,15 @@ export const listOrganizationEventsResponse = zod.object({
 			})
 			.describe("Describes an event."),
 	),
+});
+
+/**
+ * Re-enqueues the outbound webhook task that produced a webhook.sent event.
+ * @summary Resend Organization Event
+ */
+export const resendOrganizationEventParams = zod.object({
+	organization_id: zod.string(),
+	event_id: zod.string(),
 });
 
 /**
@@ -2953,6 +2998,7 @@ export const createExperimentBodyDesignSpecContextsMaxFour = 150;
 
 export const createExperimentBodyPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const createExperimentBodyPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const createExperimentBodyPowerAnalysesAnalysesMax = 150;
 
 export const createExperimentBodyWebhooksDefault = [];
@@ -3032,6 +3078,12 @@ export const createExperimentBody = zod.object({
 								.describe(
 									"Column name in table_name that uniquely identifies each participant.",
 								),
+							cluster_key: zod
+								.union([zod.string(), zod.null()])
+								.optional()
+								.describe(
+									"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+								),
 							strata: zod
 								.array(
 									zod
@@ -3066,6 +3118,22 @@ export const createExperimentBody = zod.object({
 												.optional()
 												.describe(
 													"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+												),
+											icc: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Intracluster correlation coefficient for cluster-randomized designs.",
+												),
+											avg_cluster_size: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe("Average number of individuals per cluster."),
+											cv: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Coefficient of variation in cluster sizes (0 = equal sizes).",
 												),
 										})
 										.describe(
@@ -3215,6 +3283,12 @@ export const createExperimentBody = zod.object({
 								.describe(
 									"Column name in table_name that uniquely identifies each participant.",
 								),
+							cluster_key: zod
+								.union([zod.string(), zod.null()])
+								.optional()
+								.describe(
+									"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+								),
 							strata: zod
 								.array(
 									zod
@@ -3249,6 +3323,22 @@ export const createExperimentBody = zod.object({
 												.optional()
 												.describe(
 													"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+												),
+											icc: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Intracluster correlation coefficient for cluster-randomized designs.",
+												),
+											avg_cluster_size: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe("Average number of individuals per cluster."),
+											cv: zod
+												.union([zod.number(), zod.null()])
+												.optional()
+												.describe(
+													"Coefficient of variation in cluster sizes (0 = equal sizes).",
 												),
 										})
 										.describe(
@@ -3666,6 +3756,22 @@ export const createExperimentBody = zod.object({
 											.describe(
 												"Absolute target value = metric_baseline*(1 + metric_pct_change)",
 											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
+											),
 										metric_type: zod
 											.union([
 												zod
@@ -3696,22 +3802,6 @@ export const createExperimentBody = zod.object({
 											.optional()
 											.describe(
 												"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-											),
-										icc: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Intracluster correlation coefficient for cluster-randomized designs.",
-											),
-										avg_cluster_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Average number of individuals per cluster."),
-										cv: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 									})
 									.describe(
@@ -3782,6 +3872,7 @@ export const createExperimentBody = zod.object({
 														zod.null(),
 													])
 													.optional(),
+												high_cluster_variation: zod.boolean().optional(),
 											})
 											.describe(
 												"Describes interpretation of power analysis results.",
@@ -3964,6 +4055,7 @@ export const createExperimentResponseDesignSpecContextsMaxFour = 150;
 
 export const createExperimentResponsePowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const createExperimentResponsePowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const createExperimentResponsePowerAnalysesAnalysesMax = 150;
 
 export const createExperimentResponseAssignSummaryArmSizesItemArmArmNameMax = 100;
@@ -4084,6 +4176,12 @@ export const createExperimentResponse = zod
 									.describe(
 										"Column name in table_name that uniquely identifies each participant.",
 									),
+								cluster_key: zod
+									.union([zod.string(), zod.null()])
+									.optional()
+									.describe(
+										"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+									),
 								strata: zod
 									.array(
 										zod
@@ -4122,6 +4220,24 @@ export const createExperimentResponse = zod
 													.optional()
 													.describe(
 														"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 											})
 											.describe(
@@ -4273,6 +4389,12 @@ export const createExperimentResponse = zod
 									.describe(
 										"Column name in table_name that uniquely identifies each participant.",
 									),
+								cluster_key: zod
+									.union([zod.string(), zod.null()])
+									.optional()
+									.describe(
+										"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+									),
 								strata: zod
 									.array(
 										zod
@@ -4311,6 +4433,24 @@ export const createExperimentResponse = zod
 													.optional()
 													.describe(
 														"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 											})
 											.describe(
@@ -4745,6 +4885,22 @@ export const createExperimentResponse = zod
 											.describe(
 												"Absolute target value = metric_baseline*(1 + metric_pct_change)",
 											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
+											),
 										metric_type: zod
 											.union([
 												zod
@@ -4775,22 +4931,6 @@ export const createExperimentResponse = zod
 											.optional()
 											.describe(
 												"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-											),
-										icc: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Intracluster correlation coefficient for cluster-randomized designs.",
-											),
-										avg_cluster_size: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe("Average number of individuals per cluster."),
-										cv: zod
-											.union([zod.number(), zod.null()])
-											.optional()
-											.describe(
-												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 									})
 									.describe(
@@ -4861,6 +5001,7 @@ export const createExperimentResponse = zod
 														zod.null(),
 													])
 													.optional(),
+												high_cluster_variation: zod.boolean().optional(),
 											})
 											.describe(
 												"Describes interpretation of power analysis results.",
@@ -5082,6 +5223,22 @@ export const analyzeExperimentResponse = zod
 											.optional()
 											.describe(
 												"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 									})
 									.describe(
@@ -5414,6 +5571,22 @@ export const analyzeCmabExperimentResponse = zod
 											.optional()
 											.describe(
 												"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+											),
+										icc: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Intracluster correlation coefficient for cluster-randomized designs.",
+											),
+										avg_cluster_size: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe("Average number of individuals per cluster."),
+										cv: zod
+											.union([zod.number(), zod.null()])
+											.optional()
+											.describe(
+												"Coefficient of variation in cluster sizes (0 = equal sizes).",
 											),
 									})
 									.describe(
@@ -5817,6 +5990,7 @@ export const listOrganizationExperimentsResponseItemsItemDesignSpecContextsMaxFo
 
 export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const listOrganizationExperimentsResponseItemsItemPowerAnalysesAnalysesMax = 150;
 
 export const listOrganizationExperimentsResponseItemsItemAssignSummaryArmSizesItemArmArmNameMax = 100;
@@ -5955,6 +6129,12 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -5995,6 +6175,24 @@ export const listOrganizationExperimentsResponse = zod.object({
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -6184,6 +6382,12 @@ export const listOrganizationExperimentsResponse = zod.object({
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -6224,6 +6428,24 @@ export const listOrganizationExperimentsResponse = zod.object({
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -6720,6 +6942,24 @@ export const listOrganizationExperimentsResponse = zod.object({
 													.describe(
 														"Absolute target value = metric_baseline*(1 + metric_pct_change)",
 													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
+													),
 												metric_type: zod
 													.union([
 														zod
@@ -6752,24 +6992,6 @@ export const listOrganizationExperimentsResponse = zod.object({
 													.optional()
 													.describe(
 														"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-													),
-												icc: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Intracluster correlation coefficient for cluster-randomized designs.",
-													),
-												avg_cluster_size: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Average number of individuals per cluster.",
-													),
-												cv: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 											})
 											.describe(
@@ -6840,6 +7062,7 @@ export const listOrganizationExperimentsResponse = zod.object({
 																zod.null(),
 															])
 															.optional(),
+														high_cluster_variation: zod.boolean().optional(),
 													})
 													.describe(
 														"Describes interpretation of power analysis results.",
@@ -7149,6 +7372,7 @@ export const getExperimentForUiResponseConfigDesignSpecContextsMaxFour = 150;
 
 export const getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const getExperimentForUiResponseConfigPowerAnalysesAnalysesItemMsgHighClusterVariationDefault = false;
 export const getExperimentForUiResponseConfigPowerAnalysesAnalysesMax = 150;
 
 export const getExperimentForUiResponseConfigAssignSummaryArmSizesItemArmArmNameMax = 100;
@@ -7288,6 +7512,12 @@ export const getExperimentForUiResponse = zod
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -7326,6 +7556,24 @@ export const getExperimentForUiResponse = zod
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -7501,6 +7749,12 @@ export const getExperimentForUiResponse = zod
 											.describe(
 												"Column name in table_name that uniquely identifies each participant.",
 											),
+										cluster_key: zod
+											.union([zod.string(), zod.null()])
+											.optional()
+											.describe(
+												"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+											),
 										strata: zod
 											.array(
 												zod
@@ -7541,6 +7795,24 @@ export const getExperimentForUiResponse = zod
 															.optional()
 															.describe(
 																"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+															),
+														icc: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Intracluster correlation coefficient for cluster-randomized designs.",
+															),
+														avg_cluster_size: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Average number of individuals per cluster.",
+															),
+														cv: zod
+															.union([zod.number(), zod.null()])
+															.optional()
+															.describe(
+																"Coefficient of variation in cluster sizes (0 = equal sizes).",
 															),
 													})
 													.describe(
@@ -8035,6 +8307,24 @@ export const getExperimentForUiResponse = zod
 													.describe(
 														"Absolute target value = metric_baseline*(1 + metric_pct_change)",
 													),
+												icc: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Intracluster correlation coefficient for cluster-randomized designs.",
+													),
+												avg_cluster_size: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Average number of individuals per cluster.",
+													),
+												cv: zod
+													.union([zod.number(), zod.null()])
+													.optional()
+													.describe(
+														"Coefficient of variation in cluster sizes (0 = equal sizes).",
+													),
 												metric_type: zod
 													.union([
 														zod
@@ -8067,24 +8357,6 @@ export const getExperimentForUiResponse = zod
 													.optional()
 													.describe(
 														"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-													),
-												icc: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Intracluster correlation coefficient for cluster-randomized designs.",
-													),
-												avg_cluster_size: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Average number of individuals per cluster.",
-													),
-												cv: zod
-													.union([zod.number(), zod.null()])
-													.optional()
-													.describe(
-														"Coefficient of variation in cluster sizes (0 = equal sizes).",
 													),
 											})
 											.describe(
@@ -8155,6 +8427,7 @@ export const getExperimentForUiResponse = zod
 																zod.null(),
 															])
 															.optional(),
+														high_cluster_variation: zod.boolean().optional(),
 													})
 													.describe(
 														"Describes interpretation of power analysis results.",
@@ -8700,6 +8973,12 @@ export const powerCheckBody = zod.object({
 						.describe(
 							"Column name in table_name that uniquely identifies each participant.",
 						),
+					cluster_key: zod
+						.union([zod.string(), zod.null()])
+						.optional()
+						.describe(
+							"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+						),
 					strata: zod
 						.array(
 							zod
@@ -8730,6 +9009,22 @@ export const powerCheckBody = zod.object({
 										.optional()
 										.describe(
 											"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+										),
+									icc: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Intracluster correlation coefficient for cluster-randomized designs.",
+										),
+									avg_cluster_size: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe("Average number of individuals per cluster."),
+									cv: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Coefficient of variation in cluster sizes (0 = equal sizes).",
 										),
 								})
 								.describe(
@@ -8871,6 +9166,12 @@ export const powerCheckBody = zod.object({
 						.describe(
 							"Column name in table_name that uniquely identifies each participant.",
 						),
+					cluster_key: zod
+						.union([zod.string(), zod.null()])
+						.optional()
+						.describe(
+							"Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.",
+						),
 					strata: zod
 						.array(
 							zod
@@ -8905,6 +9206,22 @@ export const powerCheckBody = zod.object({
 										.optional()
 										.describe(
 											"Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change.",
+										),
+									icc: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Intracluster correlation coefficient for cluster-randomized designs.",
+										),
+									avg_cluster_size: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe("Average number of individuals per cluster."),
+									cv: zod
+										.union([zod.number(), zod.null()])
+										.optional()
+										.describe(
+											"Coefficient of variation in cluster sizes (0 = equal sizes).",
 										),
 								})
 								.describe(
@@ -8986,6 +9303,7 @@ export const powerCheckBody = zod.object({
 
 export const powerCheckResponseAnalysesItemMetricSpecFieldNameRegExp =
 	new RegExp("^[a-zA-Z_][a-zA-Z0-9_]*$");
+export const powerCheckResponseAnalysesItemMsgHighClusterVariationDefault = false;
 export const powerCheckResponseAnalysesMax = 150;
 
 export const powerCheckResponse = zod.object({
@@ -9009,6 +9327,22 @@ export const powerCheckResponse = zod.object({
 								.optional()
 								.describe(
 									"Absolute target value = metric_baseline*(1 + metric_pct_change)",
+								),
+							icc: zod
+								.union([zod.number(), zod.null()])
+								.optional()
+								.describe(
+									"Intracluster correlation coefficient for cluster-randomized designs.",
+								),
+							avg_cluster_size: zod
+								.union([zod.number(), zod.null()])
+								.optional()
+								.describe("Average number of individuals per cluster."),
+							cv: zod
+								.union([zod.number(), zod.null()])
+								.optional()
+								.describe(
+									"Coefficient of variation in cluster sizes (0 = equal sizes).",
 								),
 							metric_type: zod
 								.union([
@@ -9040,22 +9374,6 @@ export const powerCheckResponse = zod.object({
 								.optional()
 								.describe(
 									"The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n.",
-								),
-							icc: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Intracluster correlation coefficient for cluster-randomized designs.",
-								),
-							avg_cluster_size: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe("Average number of individuals per cluster."),
-							cv: zod
-								.union([zod.number(), zod.null()])
-								.optional()
-								.describe(
-									"Coefficient of variation in cluster sizes (0 = equal sizes).",
 								),
 						})
 						.describe(
@@ -9122,6 +9440,7 @@ export const powerCheckResponse = zod.object({
 											zod.null(),
 										])
 										.optional(),
+									high_cluster_variation: zod.boolean().optional(),
 								})
 								.describe(
 									"Describes interpretation of power analysis results.",

--- a/src/api/admin.zod.ts
+++ b/src/api/admin.zod.ts
@@ -1045,6 +1045,7 @@ export const listOrganizationEventsQueryParams = zod.object({
 });
 
 export const listOrganizationEventsResponseNextPageTokenDefault = "";
+export const listOrganizationEventsResponseItemsItemStatusIconDefault = "info";
 
 export const listOrganizationEventsResponse = zod.object({
 	next_page_token: zod
@@ -1068,6 +1069,10 @@ export const listOrganizationEventsResponse = zod.object({
 				details: zod
 					.union([zod.record(zod.string(), zod.unknown()), zod.null()])
 					.describe("Details"),
+				status_icon: zod
+					.enum(["success", "info", "failure"])
+					.default(listOrganizationEventsResponseItemsItemStatusIconDefault)
+					.describe("Status icon to display for this event."),
 			})
 			.describe("Describes an event."),
 	),

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -1040,6 +1040,21 @@ export type DesignSpecMetricMetricPctChange = number | null;
 export type DesignSpecMetricMetricTarget = number | null;
 
 /**
+ * Intracluster correlation coefficient for cluster-randomized designs.
+ */
+export type DesignSpecMetricIcc = number | null;
+
+/**
+ * Average number of individuals per cluster.
+ */
+export type DesignSpecMetricAvgClusterSize = number | null;
+
+/**
+ * Coefficient of variation in cluster sizes (0 = equal sizes).
+ */
+export type DesignSpecMetricCv = number | null;
+
+/**
  * Inferred from dwh type.
  */
 export type DesignSpecMetricMetricType = MetricType | null;
@@ -1065,21 +1080,6 @@ export type DesignSpecMetricAvailableNonnullN = number | null;
 export type DesignSpecMetricAvailableN = number | null;
 
 /**
- * Intracluster correlation coefficient for cluster-randomized designs.
- */
-export type DesignSpecMetricIcc = number | null;
-
-/**
- * Average number of individuals per cluster.
- */
-export type DesignSpecMetricAvgClusterSize = number | null;
-
-/**
- * Coefficient of variation in cluster sizes (0 = equal sizes).
- */
-export type DesignSpecMetricCv = number | null;
-
-/**
  * Defines a metric to measure in an experiment with its baseline stats.
  */
 export interface DesignSpecMetric {
@@ -1089,6 +1089,12 @@ export interface DesignSpecMetric {
 	metric_pct_change?: DesignSpecMetricMetricPctChange;
 	/** Absolute target value = metric_baseline*(1 + metric_pct_change) */
 	metric_target?: DesignSpecMetricMetricTarget;
+	/** Intracluster correlation coefficient for cluster-randomized designs. */
+	icc?: DesignSpecMetricIcc;
+	/** Average number of individuals per cluster. */
+	avg_cluster_size?: DesignSpecMetricAvgClusterSize;
+	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
+	cv?: DesignSpecMetricCv;
 	/** Inferred from dwh type. */
 	metric_type?: DesignSpecMetricMetricType;
 	/** Mean of the tracked metric. */
@@ -1099,12 +1105,6 @@ export interface DesignSpecMetric {
 	available_nonnull_n?: DesignSpecMetricAvailableNonnullN;
 	/** The number of participants meeting the filtering criteria regardless of whether or not this metric's value is NULL. NOTE: Assignments are made from the targeted aviailable_n population, so be sure you are ok with participants potentially having this value missing during assignment if available_n != available_nonnull_n. */
 	available_n?: DesignSpecMetricAvailableN;
-	/** Intracluster correlation coefficient for cluster-randomized designs. */
-	icc?: DesignSpecMetricIcc;
-	/** Average number of individuals per cluster. */
-	avg_cluster_size?: DesignSpecMetricAvgClusterSize;
-	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
-	cv?: DesignSpecMetricCv;
 }
 
 /**
@@ -1118,6 +1118,21 @@ export type DesignSpecMetricRequestMetricPctChange = number | null;
 export type DesignSpecMetricRequestMetricTarget = number | null;
 
 /**
+ * Intracluster correlation coefficient for cluster-randomized designs.
+ */
+export type DesignSpecMetricRequestIcc = number | null;
+
+/**
+ * Average number of individuals per cluster.
+ */
+export type DesignSpecMetricRequestAvgClusterSize = number | null;
+
+/**
+ * Coefficient of variation in cluster sizes (0 = equal sizes).
+ */
+export type DesignSpecMetricRequestCv = number | null;
+
+/**
  * Defines a request to look up baseline stats for a metric to measure in an experiment.
  */
 export interface DesignSpecMetricRequest {
@@ -1127,6 +1142,12 @@ export interface DesignSpecMetricRequest {
 	metric_pct_change?: DesignSpecMetricRequestMetricPctChange;
 	/** Specify the absolute value you want to detect. Cannot be set if you set metric_pct_change. */
 	metric_target?: DesignSpecMetricRequestMetricTarget;
+	/** Intracluster correlation coefficient for cluster-randomized designs. */
+	icc?: DesignSpecMetricRequestIcc;
+	/** Average number of individuals per cluster. */
+	avg_cluster_size?: DesignSpecMetricRequestAvgClusterSize;
+	/** Coefficient of variation in cluster sizes (0 = equal sizes). */
+	cv?: DesignSpecMetricRequestCv;
 }
 
 /**
@@ -2099,6 +2120,7 @@ export interface MetricPowerAnalysisMessage {
 	/** Power analysis result formatted as a template string with curly-braced {} named placeholders. Use with the dictionary of values to support localization of messages. */
 	source_msg: string;
 	values?: MetricPowerAnalysisMessageValues;
+	high_cluster_variation?: boolean;
 }
 
 /**
@@ -2160,6 +2182,11 @@ export const OnlineFrequentistExperimentSpecInputExperimentType = {
 export type OnlineFrequentistExperimentSpecInputDesignUrl = string | null;
 
 /**
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type OnlineFrequentistExperimentSpecInputClusterKey = string | null;
+
+/**
  * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type OnlineFrequentistExperimentSpecInputDesiredN = number | null;
@@ -2195,6 +2222,8 @@ export interface OnlineFrequentistExperimentSpecInput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: OnlineFrequentistExperimentSpecInputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2247,6 +2276,11 @@ export const OnlineFrequentistExperimentSpecOutputExperimentType = {
 export type OnlineFrequentistExperimentSpecOutputDesignUrl = string | null;
 
 /**
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type OnlineFrequentistExperimentSpecOutputClusterKey = string | null;
+
+/**
  * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type OnlineFrequentistExperimentSpecOutputDesiredN = number | null;
@@ -2282,6 +2316,8 @@ export interface OnlineFrequentistExperimentSpecOutput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: OnlineFrequentistExperimentSpecOutputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2447,6 +2483,11 @@ export const PreassignedFrequentistExperimentSpecInputExperimentType = {
 export type PreassignedFrequentistExperimentSpecInputDesignUrl = string | null;
 
 /**
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type PreassignedFrequentistExperimentSpecInputClusterKey = string | null;
+
+/**
  * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type PreassignedFrequentistExperimentSpecInputDesiredN = number | null;
@@ -2480,6 +2521,8 @@ export interface PreassignedFrequentistExperimentSpecInput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: PreassignedFrequentistExperimentSpecInputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150
@@ -2532,6 +2575,13 @@ export const PreassignedFrequentistExperimentSpecOutputExperimentType = {
 export type PreassignedFrequentistExperimentSpecOutputDesignUrl = string | null;
 
 /**
+ * Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized.
+ */
+export type PreassignedFrequentistExperimentSpecOutputClusterKey =
+	| string
+	| null;
+
+/**
  * Used in both power calculations and experiment creation. Required for *creation* of preassigned experiments. Optional for power calculations; if set, calculates minimum detectable effect for the desired size in addition to the min sample size.
  */
 export type PreassignedFrequentistExperimentSpecOutputDesiredN = number | null;
@@ -2565,6 +2615,8 @@ export interface PreassignedFrequentistExperimentSpecOutput {
 	 * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
 	 */
 	primary_key: string;
+	/** Column name in table_name that identifies clusters for a cluster-randomized design. When set, per-metric icc, avg_cluster_size, and cv are either supplied on each metric or computed from this column at power_check time. When None, the design is assumed to be individual-randomized. */
+	cluster_key?: PreassignedFrequentistExperimentSpecOutputClusterKey;
 	/**
 	 * Optional fields to use for stratified assignment.
 	 * @maxItems 150

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -1175,6 +1175,19 @@ export type EventSummaryDetailsAnyOf = { [key: string]: unknown };
 export type EventSummaryDetails = EventSummaryDetailsAnyOf | null;
 
 /**
+ * Status icon to display for this event.
+ */
+export type EventSummaryStatusIcon =
+	(typeof EventSummaryStatusIcon)[keyof typeof EventSummaryStatusIcon];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const EventSummaryStatusIcon = {
+	success: "success",
+	info: "info",
+	failure: "failure",
+} as const;
+
+/**
  * Describes an event.
  */
 export interface EventSummary {
@@ -1190,6 +1203,8 @@ export interface EventSummary {
 	link?: EventSummaryLink;
 	/** Details */
 	details: EventSummaryDetails;
+	/** Status icon to display for this event. */
+	status_icon?: EventSummaryStatusIcon;
 }
 
 /**

--- a/src/components/features/organizations/event-row-status-icon.tsx
+++ b/src/components/features/organizations/event-row-status-icon.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { Flex, Text, Tooltip } from '@radix-ui/themes';
+import { CheckCircledIcon, CrossCircledIcon, InfoCircledIcon } from '@radix-ui/react-icons';
+import { EventSummary, EventSummaryStatusIcon } from '@/api/methods.schemas';
+
+const STATUS_CONFIG = {
+  [EventSummaryStatusIcon.success]: { content: 'Success', color: 'green', Icon: CheckCircledIcon },
+  [EventSummaryStatusIcon.failure]: { content: 'Failure', color: 'red', Icon: CrossCircledIcon },
+  [EventSummaryStatusIcon.info]: { content: 'Info', color: 'gray', Icon: InfoCircledIcon },
+} as const;
+
+export function EventRowStatusIcon({ icon }: { icon: EventSummary['status_icon'] }) {
+  const { content, color, Icon } = STATUS_CONFIG[icon ?? EventSummaryStatusIcon.info];
+  return (
+    <Tooltip content={content}>
+      <Flex display="inline-flex" align="center" asChild>
+        <Text color={color} as="span">
+          <Icon />
+        </Text>
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/src/components/features/organizations/event-row.tsx
+++ b/src/components/features/organizations/event-row.tsx
@@ -5,6 +5,7 @@ import { EventSummary } from '@/api/methods.schemas';
 import Link from 'next/link';
 import { CodeSnippetCard } from '@/components/ui/cards/code-snippet-card';
 import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
+import { EventRowStatusIcon } from '@/components/features/organizations/event-row-status-icon';
 import { ResendWebhookDialog } from '@/components/features/organizations/resend-webhook-dialog';
 import { useState } from 'react';
 
@@ -38,7 +39,12 @@ export function EventRow({ event, organizationId }: { event: EventSummary; organ
         <Table.Row style={{ cursor: 'pointer' }}>
           <Table.Cell>{event.type}</Table.Cell>
           <Table.Cell>{new Date(event.created_at).toLocaleString()}</Table.Cell>
-          <Table.Cell>{event.summary}</Table.Cell>
+          <Table.Cell>
+            <Flex align="center" gap="2">
+              <EventRowStatusIcon icon={event.status_icon} />
+              {event.summary}
+            </Flex>
+          </Table.Cell>
           <Table.Cell>
             <Flex gap="2">
               {event.link ? (

--- a/src/components/features/organizations/event-row.tsx
+++ b/src/components/features/organizations/event-row.tsx
@@ -1,0 +1,92 @@
+'use client';
+import { DataList, Flex, HoverCard, IconButton, Table, Tooltip } from '@radix-ui/themes';
+import { EyeOpenIcon } from '@radix-ui/react-icons';
+import { EventSummary } from '@/api/methods.schemas';
+import Link from 'next/link';
+import { CodeSnippetCard } from '@/components/ui/cards/code-snippet-card';
+import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
+import { ResendWebhookDialog } from '@/components/features/organizations/resend-webhook-dialog';
+import { useState } from 'react';
+
+const WEBHOOK_SENT_EVENT_TYPE = 'webhook.sent';
+
+const EVENT_DETAILS = [
+  {
+    label: 'Event ID',
+    value: (event: EventSummary) => event.id,
+    copy: true,
+  },
+  {
+    label: 'Timestamp',
+    value: (event: EventSummary) => event.created_at,
+    copy: false,
+  },
+  {
+    label: 'Summary',
+    value: (event: EventSummary) => event.summary,
+    copy: false,
+  },
+] as const;
+
+export function EventRow({ event, organizationId }: { event: EventSummary; organizationId: string }) {
+  const [isHoverOpen, setIsHoverOpen] = useState(false);
+  const [isResendOpen, setIsResendOpen] = useState(false);
+
+  return (
+    <HoverCard.Root open={isHoverOpen && !isResendOpen} onOpenChange={setIsHoverOpen}>
+      <HoverCard.Trigger>
+        <Table.Row style={{ cursor: 'pointer' }}>
+          <Table.Cell>{event.type}</Table.Cell>
+          <Table.Cell>{new Date(event.created_at).toLocaleString()}</Table.Cell>
+          <Table.Cell>{event.summary}</Table.Cell>
+          <Table.Cell>
+            <Flex gap="2">
+              {event.link && (
+                <Tooltip content="View">
+                  <Link href={event.link} target="_blank" rel="noopener noreferrer">
+                    <IconButton variant="soft" color="green">
+                      <EyeOpenIcon />
+                    </IconButton>
+                  </Link>
+                </Tooltip>
+              )}
+              {event.type === WEBHOOK_SENT_EVENT_TYPE && (
+                <ResendWebhookDialog
+                  organizationId={organizationId}
+                  eventId={event.id}
+                  open={isResendOpen}
+                  onOpenChange={setIsResendOpen}
+                />
+              )}
+            </Flex>
+          </Table.Cell>
+        </Table.Row>
+      </HoverCard.Trigger>
+      <HoverCard.Content>
+        <DataList.Root>
+          {EVENT_DETAILS.map((detail) => (
+            <DataList.Item key={detail.label}>
+              <DataList.Label>{detail.label}</DataList.Label>
+              <DataList.Value>
+                <Flex align="center" gap="2" justify="between" width="100%">
+                  {detail.value(event)}
+                  {detail.copy && (
+                    <CopyToClipBoard content={detail.value(event)} tooltipContent={`Copy ${detail.label}`} />
+                  )}
+                </Flex>
+              </DataList.Value>
+            </DataList.Item>
+          ))}
+        </DataList.Root>
+
+        {event.details && (
+          <CodeSnippetCard
+            title="Details"
+            content={JSON.stringify(event.details, undefined, 2)}
+            tooltipContent="Copy details"
+          />
+        )}
+      </HoverCard.Content>
+    </HoverCard.Root>
+  );
+}

--- a/src/components/features/organizations/event-row.tsx
+++ b/src/components/features/organizations/event-row.tsx
@@ -42,7 +42,7 @@ export function EventRow({ event, organizationId }: { event: EventSummary; organ
           <Table.Cell>
             <Flex gap="2">
               {event.link && (
-                <Tooltip content="View">
+                <Tooltip content="View Experiment">
                   <Link href={event.link} target="_blank" rel="noopener noreferrer">
                     <IconButton variant="soft" color="green">
                       <EyeOpenIcon />

--- a/src/components/features/organizations/event-row.tsx
+++ b/src/components/features/organizations/event-row.tsx
@@ -41,7 +41,7 @@ export function EventRow({ event, organizationId }: { event: EventSummary; organ
           <Table.Cell>{event.summary}</Table.Cell>
           <Table.Cell>
             <Flex gap="2">
-              {event.link && (
+              {event.link ? (
                 <Tooltip content="View Experiment">
                   <Link href={event.link} target="_blank" rel="noopener noreferrer">
                     <IconButton variant="soft" color="green">
@@ -49,15 +49,15 @@ export function EventRow({ event, organizationId }: { event: EventSummary; organ
                     </IconButton>
                   </Link>
                 </Tooltip>
-              )}
-              {event.type === WEBHOOK_SENT_EVENT_TYPE && (
+              ) : null}
+              {event.type === WEBHOOK_SENT_EVENT_TYPE ? (
                 <ResendWebhookDialog
                   organizationId={organizationId}
                   eventId={event.id}
                   open={isResendOpen}
                   onOpenChange={setIsResendOpen}
                 />
-              )}
+              ) : null}
             </Flex>
           </Table.Cell>
         </Table.Row>
@@ -70,22 +70,22 @@ export function EventRow({ event, organizationId }: { event: EventSummary; organ
               <DataList.Value>
                 <Flex align="center" gap="2" justify="between" width="100%">
                   {detail.value(event)}
-                  {detail.copy && (
+                  {detail.copy ? (
                     <CopyToClipBoard content={detail.value(event)} tooltipContent={`Copy ${detail.label}`} />
-                  )}
+                  ) : null}
                 </Flex>
               </DataList.Value>
             </DataList.Item>
           ))}
         </DataList.Root>
 
-        {event.details && (
+        {event.details ? (
           <CodeSnippetCard
             title="Details"
             content={JSON.stringify(event.details, undefined, 2)}
             tooltipContent="Copy details"
           />
-        )}
+        ) : null}
       </HoverCard.Content>
     </HoverCard.Root>
   );

--- a/src/components/features/organizations/events-table.tsx
+++ b/src/components/features/organizations/events-table.tsx
@@ -38,6 +38,7 @@ export function EventsTable({ organizationId }: EventsTableProps) {
       swr: {
         keepPreviousData: true,
         enabled: !!organizationId,
+        refreshInterval: 15000,
       },
     },
   );

--- a/src/components/features/organizations/events-table.tsx
+++ b/src/components/features/organizations/events-table.tsx
@@ -1,14 +1,11 @@
 'use client';
-import { Button, DataList, Flex, Heading, HoverCard, Select, Table } from '@radix-ui/themes';
+import { Button, Flex, Heading, Select, Table } from '@radix-ui/themes';
 import { useListOrganizationEvents } from '@/api/admin';
-import { EventSummary } from '@/api/methods.schemas';
 import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
-import Link from 'next/link';
-import { CodeSnippetCard } from '@/components/ui/cards/code-snippet-card';
-import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { EmptyStateCard } from '@/components/ui/cards/empty-state-card';
+import { EventRow } from '@/components/features/organizations/event-row';
 import { useEffect, useState } from 'react';
 
 const DEFAULT_EVENTS_PAGE_SIZE = '10';
@@ -19,24 +16,6 @@ type EventsPageSize = (typeof EVENTS_PAGE_SIZE_OPTIONS)[number];
 interface EventsTableProps {
   organizationId?: string;
 }
-
-const EVENT_DETAILS = [
-  {
-    label: 'Event ID',
-    value: (event: EventSummary) => event.id,
-    copy: true,
-  },
-  {
-    label: 'Timestamp',
-    value: (event: EventSummary) => event.created_at,
-    copy: false,
-  },
-  {
-    label: 'Summary',
-    value: (event: EventSummary) => event.summary,
-    copy: false,
-  },
-] as const;
 
 const isEventsPageSize = (value: string): value is EventsPageSize => {
   return EVENTS_PAGE_SIZE_OPTIONS.includes(value as EventsPageSize);
@@ -145,52 +124,12 @@ export function EventsTable({ organizationId }: EventsTableProps) {
               <Table.ColumnHeaderCell>Event Type</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Created At</Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell>Summary</Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell>Link</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Actions</Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>
           <Table.Body>
             {events.map((event) => (
-              <HoverCard.Root key={event.id}>
-                <HoverCard.Trigger>
-                  <Table.Row style={{ cursor: 'pointer' }}>
-                    <Table.Cell>{event.type}</Table.Cell>
-                    <Table.Cell>{new Date(event.created_at).toLocaleString()}</Table.Cell>
-                    <Table.Cell>{event.summary}</Table.Cell>
-                    <Table.Cell>
-                      {event.link && (
-                        <Link href={event.link} target="_blank" rel="noopener noreferrer">
-                          View
-                        </Link>
-                      )}
-                    </Table.Cell>
-                  </Table.Row>
-                </HoverCard.Trigger>
-                <HoverCard.Content>
-                  <DataList.Root>
-                    {EVENT_DETAILS.map((detail) => (
-                      <DataList.Item key={detail.label}>
-                        <DataList.Label>{detail.label}</DataList.Label>
-                        <DataList.Value>
-                          <Flex align="center" gap="2" justify="between" width="100%">
-                            {detail.value(event)}
-                            {detail.copy && (
-                              <CopyToClipBoard content={detail.value(event)} tooltipContent={`Copy ${detail.label}`} />
-                            )}
-                          </Flex>
-                        </DataList.Value>
-                      </DataList.Item>
-                    ))}
-                  </DataList.Root>
-
-                  {event.details && (
-                    <CodeSnippetCard
-                      title="Details"
-                      content={JSON.stringify(event.details, undefined, 2)}
-                      tooltipContent="Copy details"
-                    />
-                  )}
-                </HoverCard.Content>
-              </HoverCard.Root>
+              <EventRow key={event.id} event={event} organizationId={organizationId} />
             ))}
           </Table.Body>
         </Table.Root>

--- a/src/components/features/organizations/resend-webhook-dialog.tsx
+++ b/src/components/features/organizations/resend-webhook-dialog.tsx
@@ -8,8 +8,8 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 interface ResendWebhookDialogProps {
   organizationId: string;
   eventId: string;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChange }: ResendWebhookDialogProps) {
@@ -17,7 +17,7 @@ export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChang
     swr: {
       onSuccess: async () => {
         await invalidatePath(getListOrganizationEventsKey(organizationId)[0]);
-        onOpenChange?.(false);
+        onOpenChange(false);
       },
     },
   });
@@ -26,7 +26,7 @@ export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChang
     if (!next) {
       reset();
     }
-    onOpenChange?.(next);
+    onOpenChange(next);
   };
 
   return (

--- a/src/components/features/organizations/resend-webhook-dialog.tsx
+++ b/src/components/features/organizations/resend-webhook-dialog.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { AlertDialog, Button, Flex, IconButton, Tooltip } from '@radix-ui/themes';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { getListOrganizationEventsKey, useResendOrganizationEvent } from '@/api/admin';
+import { mutate } from 'swr';
+
+interface ResendWebhookDialogProps {
+  organizationId: string;
+  eventId: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChange }: ResendWebhookDialogProps) {
+  const eventsUrl = getListOrganizationEventsKey(organizationId)[0];
+  const { trigger, isMutating } = useResendOrganizationEvent(organizationId, eventId, {
+    swr: {
+      onSuccess: () => mutate((key) => Array.isArray(key) && key[0] === eventsUrl),
+    },
+  });
+
+  return (
+    <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Trigger>
+        <Tooltip content="Resend">
+          <IconButton variant="soft" color="gray">
+            <ReloadIcon />
+          </IconButton>
+        </Tooltip>
+      </AlertDialog.Trigger>
+      <AlertDialog.Content>
+        <AlertDialog.Title>Resend webhook?</AlertDialog.Title>
+        <AlertDialog.Description>
+          This will requeue the original webhook request to your server. Your infrastructure may receive multiple events
+          for the same experiment if a previous attempt actually succeeded.
+        </AlertDialog.Description>
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button variant="solid" loading={isMutating} onClick={async () => await trigger({})}>
+              Yes, send again.
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  );
+}

--- a/src/components/features/organizations/resend-webhook-dialog.tsx
+++ b/src/components/features/organizations/resend-webhook-dialog.tsx
@@ -21,18 +21,18 @@ export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChang
 
   return (
     <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
-      <AlertDialog.Trigger>
-        <Tooltip content="Resend">
+      <Tooltip content="Resend">
+        <AlertDialog.Trigger>
           <IconButton variant="soft" color="gray">
             <ReloadIcon />
           </IconButton>
-        </Tooltip>
-      </AlertDialog.Trigger>
+        </AlertDialog.Trigger>
+      </Tooltip>
       <AlertDialog.Content>
         <AlertDialog.Title>Resend webhook?</AlertDialog.Title>
         <AlertDialog.Description>
           This will requeue the original webhook request to your server. Your infrastructure may receive multiple events
-          for the same experiment if a previous attempt actually succeeded.
+          for the same experiment.
         </AlertDialog.Description>
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>

--- a/src/components/features/organizations/resend-webhook-dialog.tsx
+++ b/src/components/features/organizations/resend-webhook-dialog.tsx
@@ -2,7 +2,7 @@
 import { AlertDialog, Button, Flex, IconButton, Tooltip } from '@radix-ui/themes';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { getListOrganizationEventsKey, useResendOrganizationEvent } from '@/api/admin';
-import { mutate } from 'swr';
+import { invalidatePath } from '@/services/swr-cache';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 
 interface ResendWebhookDialogProps {
@@ -13,11 +13,10 @@ interface ResendWebhookDialogProps {
 }
 
 export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChange }: ResendWebhookDialogProps) {
-  const eventsUrl = getListOrganizationEventsKey(organizationId)[0];
   const { trigger, isMutating, error, reset } = useResendOrganizationEvent(organizationId, eventId, {
     swr: {
       onSuccess: async () => {
-        await mutate((key) => Array.isArray(key) && key[0] === eventsUrl);
+        await invalidatePath(getListOrganizationEventsKey(organizationId)[0]);
         onOpenChange?.(false);
       },
     },

--- a/src/components/features/organizations/resend-webhook-dialog.tsx
+++ b/src/components/features/organizations/resend-webhook-dialog.tsx
@@ -3,6 +3,7 @@ import { AlertDialog, Button, Flex, IconButton, Tooltip } from '@radix-ui/themes
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { getListOrganizationEventsKey, useResendOrganizationEvent } from '@/api/admin';
 import { mutate } from 'swr';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
 
 interface ResendWebhookDialogProps {
   organizationId: string;
@@ -13,14 +14,24 @@ interface ResendWebhookDialogProps {
 
 export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChange }: ResendWebhookDialogProps) {
   const eventsUrl = getListOrganizationEventsKey(organizationId)[0];
-  const { trigger, isMutating } = useResendOrganizationEvent(organizationId, eventId, {
+  const { trigger, isMutating, error, reset } = useResendOrganizationEvent(organizationId, eventId, {
     swr: {
-      onSuccess: () => mutate((key) => Array.isArray(key) && key[0] === eventsUrl),
+      onSuccess: async () => {
+        await mutate((key) => Array.isArray(key) && key[0] === eventsUrl);
+        onOpenChange?.(false);
+      },
     },
   });
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      reset();
+    }
+    onOpenChange?.(next);
+  };
+
   return (
-    <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
+    <AlertDialog.Root open={open} onOpenChange={handleOpenChange}>
       <Tooltip content="Resend">
         <AlertDialog.Trigger>
           <IconButton variant="soft" color="gray">
@@ -34,6 +45,7 @@ export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChang
           This will requeue the original webhook request to your server. Your infrastructure may receive multiple events
           for the same experiment.
         </AlertDialog.Description>
+        {error ? <GenericErrorCallout title="Failed to resend webhook" error={error} /> : null}
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>
             <Button variant="soft" color="gray">
@@ -41,7 +53,14 @@ export function ResendWebhookDialog({ organizationId, eventId, open, onOpenChang
             </Button>
           </AlertDialog.Cancel>
           <AlertDialog.Action>
-            <Button variant="solid" loading={isMutating} onClick={async () => await trigger({})}>
+            <Button
+              variant="solid"
+              loading={isMutating}
+              onClick={async (e) => {
+                e.preventDefault();
+                await trigger({}, { throwOnError: false });
+              }}
+            >
               Yes, send again.
             </Button>
           </AlertDialog.Action>


### PR DESCRIPTION
Recent Events table now has an "Actions" column. experiment.created events show
a green EyeOpenIcon linking to the experiment; webhook.sent events show a gray
ReloadIcon that opens a confirmation dialog.  The table will also automatically
refresh every 15 seconds.
