### PR TITLE
Auto-expand webhooks section when webhooks are configured.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "evidential-fe",
       "version": "0.1.0",
       "dependencies": {
+        "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.2.1",
         "@sentry/nextjs": "^9.47.1",
@@ -3083,6 +3084,19 @@
         "@orval/core": "7.19.0",
         "lodash.uniq": "^4.5.0",
         "openapi3-ts": "4.5.0"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@polka/url": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/themes": "^3.2.1",
     "@sentry/nextjs": "^9.47.1",
     "next": "15.5.18",
+    "@phosphor-icons/react": "^2.1.10",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "recharts": "^3.5.1",

--- a/src/app/experiments/create/experiment-form/experiment-metadata-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-metadata-screen.tsx
@@ -1,11 +1,8 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
-import { Box, Button, Flex, Separator, Text, TextArea, TextField } from '@radix-ui/themes';
+import { Box, Flex, Separator, Text, TextArea, TextField } from '@radix-ui/themes';
 import { SelectWebhooksSection } from '@/app/experiments/create/experiment-form/select-webhooks-section';
-import { Collapsible } from 'radix-ui';
-import { ChevronDownIcon, ChevronRightIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
 
 export type ExperimentMetadataMessages =
   | { type: 'set-name'; value: string }
@@ -19,8 +16,6 @@ export const ExperimentMetadataScreen = ({
   data,
   dispatch,
 }: ScreenProps<ExperimentFormData, ExperimentMetadataMessages, ExperimentScreenId>) => {
-  const [webhooksOpen, setWebhooksOpen] = useState(false);
-
   return (
     <Flex direction="column" gap={'3'}>
       <Box>
@@ -82,21 +77,10 @@ export const ExperimentMetadataScreen = ({
 
       <Separator size="4" my="3" />
 
-      <Collapsible.Root open={webhooksOpen} onOpenChange={setWebhooksOpen}>
-        <Collapsible.Trigger asChild>
-          <Button variant={'ghost'} style={{ backgroundColor: 'unset' }}>
-            <>{webhooksOpen ? <ChevronDownIcon /> : <ChevronRightIcon />}Advanced: Webhooks</>
-          </Button>
-        </Collapsible.Trigger>
-        <Collapsible.Content asChild>
-          <Flex direction={'column'} gap={'3'} ml={'20px'}>
-            <SelectWebhooksSection
-              selectedWebhookIds={data.selectedWebhookIds ?? []}
-              onWebhookIdsChange={(ids) => dispatch({ type: 'set-webhook-ids', value: ids })}
-            />
-          </Flex>
-        </Collapsible.Content>
-      </Collapsible.Root>
+      <SelectWebhooksSection
+        selectedWebhookIds={data.selectedWebhookIds ?? []}
+        onWebhookIdsChange={(ids) => dispatch({ type: 'set-webhook-ids', value: ids })}
+      />
     </Flex>
   );
 };

--- a/src/app/experiments/create/experiment-form/select-webhooks-section.tsx
+++ b/src/app/experiments/create/experiment-form/select-webhooks-section.tsx
@@ -1,9 +1,10 @@
 'use client';
-import { CheckboxCards, Flex, Grid, Link, Text } from '@radix-ui/themes';
+import { Box, Callout, CheckboxCards, Flex, Text } from '@radix-ui/themes';
+import Link from 'next/link';
 import { useListOrganizationWebhooks } from '@/api/admin';
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { XSpinner } from '@/components/ui/x-spinner';
-import { GearIcon } from '@radix-ui/react-icons';
+import { WebhooksLogoIcon } from '@phosphor-icons/react';
 
 type SelectWebhooksSectionProps = {
   selectedWebhookIds: string[];
@@ -20,38 +21,50 @@ export const SelectWebhooksSection = ({ selectedWebhookIds, onWebhookIdsChange }
 
   const webhooks = webhooksData?.items ?? [];
 
+  if (isLoading) {
+    return <XSpinner />;
+  }
+
+  if (webhooks.length === 0) {
+    return (
+      <Callout.Root color="gray" variant="surface">
+        <Callout.Icon>
+          <WebhooksLogoIcon />
+        </Callout.Icon>
+        <Callout.Text>
+          Optional: We can send your system a webhook when an experiment is created. Configure your first webhook in{' '}
+          <Link href={`/organizations/${organizationId}`} target="_blank" rel="noopener noreferrer">
+            Settings
+          </Link>
+          .
+        </Callout.Text>
+      </Callout.Root>
+    );
+  }
+
   return (
-    <>
-      <Text size="2" color="gray">
-        Select which webhooks should receive notifications when this experiment is created.
+    <Box>
+      <Text as="label" size="2" weight="bold" mb="6px">
+        Webhooks
       </Text>
 
-      {isLoading ? (
-        <XSpinner />
-      ) : webhooks.length === 0 ? (
+      <Flex direction="column" gap="3">
         <Text size="2" color="gray">
-          There are no webhooks configured for your organization. Please visit the{' '}
-          <Link href={`/organizations/${organizationId}`}>
-            <GearIcon /> Settings Page
-          </Link>{' '}
-          to configure them.
+          Select which webhooks should receive notifications when this experiment is created.
         </Text>
-      ) : (
-        <CheckboxCards.Root value={selectedWebhookIds} onValueChange={onWebhookIdsChange}>
-          <Grid columns="4" gap="3">
-            {webhooks.map((webhook) => (
-              <CheckboxCards.Item key={webhook.id} value={webhook.id}>
-                <Flex direction="column" width="100%">
-                  <Text weight="bold">{webhook.name}</Text>
-                  <Text size="2" color="gray">
-                    {webhook.url}
-                  </Text>
-                </Flex>
-              </CheckboxCards.Item>
-            ))}
-          </Grid>
+        <CheckboxCards.Root value={selectedWebhookIds} onValueChange={onWebhookIdsChange} columns="4" gap="3">
+          {webhooks.map((webhook) => (
+            <CheckboxCards.Item key={webhook.id} value={webhook.id}>
+              <Flex direction="column" width="100%">
+                <Text weight="bold">{webhook.name}</Text>
+                <Text size="2" color="gray">
+                  {webhook.url}
+                </Text>
+              </Flex>
+            </CheckboxCards.Item>
+          ))}
         </CheckboxCards.Root>
-      )}
-    </>
+      </Flex>
+    </Box>
   );
 };


### PR DESCRIPTION
Replaces the "advanced" expando with a "webhooks" section that is automatically expanded when an organization has webhooks configured. When it doesn't, we show them a callout inviting them to configure webhooks.
