### PR TITLE
use `npm ci` for `task nodedeps`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
         echo "Tip: Run 'nvm install' from the repo root to install and then run 'nvm use' to switch to the correct version."
         exit 1
       fi
-      npm install
+      npm ci
   start:
     desc: 'Starts the development server'
     interactive: true


### PR DESCRIPTION
This avoids non-linux platforms from accidentally removing libc metadata for native binary dependencies in our lockfile.