### PR TITLE
Computes estimated MDE given user's desired N

### DIFF
--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -570,12 +570,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           // If the desiredN changes due to user selection, reset the stored MDE estimate response.
           return {
             ...data,
-            desiredN: msg.value,
-            mdePowerCheckResponse: data.desiredN !== msg.value ? undefined : data.mdePowerCheckResponse,
+            desiredN: msg.desiredN,
+            sampleSizeOption: msg.sampleSizeOption,
+            mdePowerCheckResponse: msg.mdePowerCheckResponse,
           };
-        }
-        if (msg.type === 'set-sample-size-option') {
-          return { ...data, sampleSizeOption: msg.value };
         }
         if (msg.type === 'set-create-error') {
           return { ...data, createExperimentError: msg.response, createExperimentResponse: undefined };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -85,6 +85,8 @@ export type ExperimentFormData = {
   powerCheckResponse?: PowerResponseOutput;
   // Populated by the custom MDE estimate request when the user selects ENTER_OWN sample size.
   customPowerCheckResponse?: PowerResponseOutput;
+  // Populated by the MDE estimate request when the user selects USE_ALL_NON_NULL_SAMPLES.
+  nonNullSamplesPowerCheckResponse?: PowerResponseOutput;
   createExperimentResponse?: CreateExperimentResponse;
   createExperimentError?: ErrorType<unknown>;
 
@@ -271,6 +273,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -453,6 +456,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -464,6 +468,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -475,6 +480,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -485,6 +491,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -495,6 +502,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -506,6 +514,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -518,6 +527,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             filters: msg.filters,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -541,6 +551,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             confidence: msg.value,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -551,6 +562,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             power: msg.value,
             powerCheckResponse: undefined,
             customPowerCheckResponse: undefined,
+            nonNullSamplesPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -565,6 +577,12 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
         }
         if (msg.type === 'set-custom-power-check-response') {
           return { ...data, customPowerCheckResponse: msg.response, desiredN: msg.desiredN };
+        }
+        if (msg.type === 'clear-custom-power-check-response') {
+          return { ...data, customPowerCheckResponse: undefined, desiredN: undefined };
+        }
+        if (msg.type === 'set-non-null-samples-power-check-response') {
+          return { ...data, nonNullSamplesPowerCheckResponse: msg.response };
         }
         if (msg.type === 'set-chosen-n') {
           return { ...data, desiredN: msg.value };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -555,7 +555,28 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             sampleSizeOption: undefined,
           };
         }
+        if (msg.type === 'set-chosen-n') {
+          switch (msg.sampleSizeOption) {
+            case PowerCheckOption.NONE:
+            case PowerCheckOption.USE_POWER_CHECK:
+              return {
+                ...data,
+                sampleSizeOption: msg.sampleSizeOption,
+                desiredN: msg.desiredN,
+                powerCheckResponse: msg.response,
+              };
+            case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
+            case PowerCheckOption.ENTER_OWN:
+              return {
+                ...data,
+                sampleSizeOption: msg.sampleSizeOption,
+                desiredN: msg.desiredN,
+                mdePowerCheckResponse: msg.response,
+              };
+          }
+        }
         if (msg.type === 'set-power-check-response') {
+          // Same as set-chosen-n, but we check for stale MDE estimate responses first.
           const isMdeEstimateResponse =
             msg.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES ||
             msg.sampleSizeOption === PowerCheckOption.ENTER_OWN;
@@ -564,6 +585,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             msg.response !== undefined &&
             (msg.sampleSizeOption !== data.sampleSizeOption || msg.desiredN !== data.desiredN)
           ) {
+            console.log('stale MDE estimate response, so ignore the message.');
             // Stale MDE estimate response, so ignore the message.
             return data;
           }

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -555,38 +555,15 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             sampleSizeOption: undefined,
           };
         }
-        if (msg.type === 'set-chosen-n') {
-          switch (msg.sampleSizeOption) {
-            case PowerCheckOption.NONE:
-            case PowerCheckOption.USE_POWER_CHECK:
-              return {
-                ...data,
-                sampleSizeOption: msg.sampleSizeOption,
-                desiredN: msg.desiredN,
-                powerCheckResponse: msg.response,
-              };
-            case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
-            case PowerCheckOption.ENTER_OWN:
-              return {
-                ...data,
-                sampleSizeOption: msg.sampleSizeOption,
-                desiredN: msg.desiredN,
-                mdePowerCheckResponse: msg.response,
-              };
-          }
-        }
-        if (msg.type === 'set-power-check-response') {
-          // Same as set-chosen-n, but we check for stale MDE estimate responses first.
-          const isMdeEstimateResponse =
-            msg.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES ||
-            msg.sampleSizeOption === PowerCheckOption.ENTER_OWN;
+        if (msg.type === 'set-chosen-n' || msg.type === 'set-power-check-response') {
+          // For handling async power check responses, first check if they are stale.
           if (
-            isMdeEstimateResponse &&
+            msg.type === 'set-power-check-response' &&
+            (msg.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES ||
+              msg.sampleSizeOption === PowerCheckOption.ENTER_OWN) &&
             msg.response !== undefined &&
             (msg.sampleSizeOption !== data.sampleSizeOption || msg.desiredN !== data.desiredN)
           ) {
-            console.log('stale MDE estimate response, so ignore the message.');
-            // Stale MDE estimate response, so ignore the message.
             return data;
           }
 

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -556,24 +556,36 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-power-check-response') {
-          return {
-            ...data,
-            powerCheckResponse: msg.response,
-            desiredN: msg.desiredN,
-            sampleSizeOption: msg.sampleSizeOption,
-          };
-        }
-        if (msg.type === 'set-custom-power-check-response') {
-          return { ...data, mdePowerCheckResponse: msg.response, desiredN: msg.desiredN };
-        }
-        if (msg.type === 'set-chosen-n') {
-          // If the desiredN changes due to user selection, reset the stored MDE estimate response.
-          return {
-            ...data,
-            desiredN: msg.desiredN,
-            sampleSizeOption: msg.sampleSizeOption,
-            mdePowerCheckResponse: msg.mdePowerCheckResponse,
-          };
+          const isMdeEstimateResponse =
+            msg.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES ||
+            msg.sampleSizeOption === PowerCheckOption.ENTER_OWN;
+          if (
+            isMdeEstimateResponse &&
+            msg.response !== undefined &&
+            (msg.sampleSizeOption !== data.sampleSizeOption || msg.desiredN !== data.desiredN)
+          ) {
+            // Stale MDE estimate response, so ignore the message.
+            return data;
+          }
+
+          switch (msg.sampleSizeOption) {
+            case PowerCheckOption.NONE:
+            case PowerCheckOption.USE_POWER_CHECK:
+              return {
+                ...data,
+                sampleSizeOption: msg.sampleSizeOption,
+                desiredN: msg.desiredN,
+                powerCheckResponse: msg.response,
+              };
+            case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
+            case PowerCheckOption.ENTER_OWN:
+              return {
+                ...data,
+                sampleSizeOption: msg.sampleSizeOption,
+                desiredN: msg.desiredN,
+                mdePowerCheckResponse: msg.response,
+              };
+          }
         }
         if (msg.type === 'set-create-error') {
           return { ...data, createExperimentError: msg.response, createExperimentResponse: undefined };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -83,10 +83,8 @@ export type ExperimentFormData = {
   desiredN?: number;
   sampleSizeOption?: PowerCheckOption;
   powerCheckResponse?: PowerResponseOutput;
-  // Populated by the custom MDE estimate request when the user selects ENTER_OWN sample size.
-  customPowerCheckResponse?: PowerResponseOutput;
-  // Populated by the MDE estimate request when the user selects USE_ALL_NON_NULL_SAMPLES.
-  nonNullSamplesPowerCheckResponse?: PowerResponseOutput;
+  // Populated by the MDE estimate for the currently-active custom N (ENTER_OWN or USE_ALL_NON_NULL_SAMPLES).
+  mdePowerCheckResponse?: PowerResponseOutput;
   createExperimentResponse?: CreateExperimentResponse;
   createExperimentError?: ErrorType<unknown>;
 
@@ -272,8 +270,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -455,8 +452,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             primaryMetric: msg.primaryMetric,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -467,8 +463,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -479,8 +474,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -490,8 +484,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -501,8 +494,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -513,8 +505,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric ?? data.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -526,8 +517,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             filters: msg.filters,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -550,8 +540,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             confidence: msg.value,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -561,8 +550,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             power: msg.value,
             powerCheckResponse: undefined,
-            customPowerCheckResponse: undefined,
-            nonNullSamplesPowerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -576,16 +564,15 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-custom-power-check-response') {
-          return { ...data, customPowerCheckResponse: msg.response, desiredN: msg.desiredN };
-        }
-        if (msg.type === 'clear-custom-power-check-response') {
-          return { ...data, customPowerCheckResponse: undefined, desiredN: undefined };
-        }
-        if (msg.type === 'set-non-null-samples-power-check-response') {
-          return { ...data, nonNullSamplesPowerCheckResponse: msg.response };
+          return { ...data, mdePowerCheckResponse: msg.response, desiredN: msg.desiredN };
         }
         if (msg.type === 'set-chosen-n') {
-          return { ...data, desiredN: msg.value };
+          // If the desiredN changes due to user selection, reset the stored MDE estimate response.
+          return {
+            ...data,
+            desiredN: msg.value,
+            mdePowerCheckResponse: data.desiredN !== msg.value ? undefined : data.mdePowerCheckResponse,
+          };
         }
         if (msg.type === 'set-sample-size-option') {
           return { ...data, sampleSizeOption: msg.value };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -455,6 +455,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'primary-metric-deselect') {
@@ -466,6 +467,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'promote-secondary-to-primary') {
@@ -477,6 +479,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'secondary-metric-add') {
@@ -487,6 +490,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'secondary-metric-remove') {
@@ -497,6 +501,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'mde-change') {
@@ -508,6 +513,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
 
@@ -520,6 +526,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
 
@@ -543,6 +550,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'set-power') {
@@ -553,6 +561,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
+            createExperimentError: undefined,
           };
         }
         if (msg.type === 'set-chosen-n' || msg.type === 'set-power-check-response') {
@@ -575,6 +584,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 sampleSizeOption: msg.sampleSizeOption,
                 desiredN: msg.desiredN,
                 powerCheckResponse: msg.response,
+                createExperimentError: undefined,
               };
             case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
             case PowerCheckOption.ENTER_OWN:
@@ -583,6 +593,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 sampleSizeOption: msg.sampleSizeOption,
                 desiredN: msg.desiredN,
                 mdePowerCheckResponse: msg.response,
+                createExperimentError: undefined,
               };
           }
         }

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -566,6 +566,8 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
         }
         if (msg.type === 'set-chosen-n' || msg.type === 'set-power-check-response') {
           // For handling async power check responses, first check if they are stale.
+          // This does NOT currently address potentially stale power responses from USE_POWER_CHECK,
+          // e.g. if the user changes any values while the original trigger is in flight.
           if (
             msg.type === 'set-power-check-response' &&
             (msg.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES ||
@@ -595,6 +597,8 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 mdePowerCheckResponse: msg.response,
                 createExperimentError: undefined,
               };
+            default:
+              return data;
           }
         }
         if (msg.type === 'set-create-error') {

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -83,6 +83,8 @@ export type ExperimentFormData = {
   desiredN?: number;
   sampleSizeOption?: PowerCheckOption;
   powerCheckResponse?: PowerResponseOutput;
+  // Populated by the custom MDE estimate request when the user selects ENTER_OWN sample size.
+  customPowerCheckResponse?: PowerResponseOutput;
   createExperimentResponse?: CreateExperimentResponse;
   createExperimentError?: ErrorType<unknown>;
 
@@ -268,6 +270,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -449,6 +452,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             primaryMetric: msg.primaryMetric,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -459,6 +463,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -469,6 +474,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -478,6 +484,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -487,6 +494,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             secondaryMetrics: msg.secondaryMetrics,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -497,6 +505,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             primaryMetric: msg.primaryMetric ?? data.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics ?? data.secondaryMetrics,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -508,6 +517,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             filters: msg.filters,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -530,6 +540,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             confidence: msg.value,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -539,6 +550,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             power: msg.value,
             powerCheckResponse: undefined,
+            customPowerCheckResponse: undefined,
             desiredN: undefined,
             sampleSizeOption: undefined,
           };
@@ -550,6 +562,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             desiredN: msg.desiredN,
             sampleSizeOption: msg.sampleSizeOption,
           };
+        }
+        if (msg.type === 'set-custom-power-check-response') {
+          return { ...data, customPowerCheckResponse: msg.response };
         }
         if (msg.type === 'set-chosen-n') {
           return { ...data, desiredN: msg.value };

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -492,7 +492,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 // seeing if the spec used differs from what we would produce now, i.e. did the user
                 // change a value while the request was in flight?
                 // (We cannot check for sampleSizeOption && desiredN mismatches because they start off undefined.)
-                const expected_stringified_spec = JSON.stringify(convertToFrequentistDesignSpec(data));
+                const expected_stringified_spec = JSON.stringify(
+                  convertToFrequentistDesignSpec({ ...data, desiredN: undefined }),
+                );
                 if (JSON.stringify(msg.designSpec) !== expected_stringified_spec) {
                   return data;
                 }

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/app/experiments/create/experiment-form/experiment-freq-stack-screen';
 import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-freq-screen';
 import {
+  convertToFrequentistDesignSpec,
   getReasonableEndDate,
   getReasonableStartDate,
   removeFieldByName,
@@ -483,22 +484,19 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-chosen-n' || msg.type === 'set-power-check-response') {
-          // For handling async power check responses, first check if they are stale.
-          // This does NOT currently address potentially stale power responses from USE_POWER_CHECK,
-          // e.g. if the user changes any values while the original trigger is in flight.
-          if (
-            msg.type === 'set-power-check-response' &&
-            (msg.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES ||
-              msg.sampleSizeOption === PowerCheckOption.ENTER_OWN) &&
-            msg.response !== undefined &&
-            (msg.sampleSizeOption !== data.sampleSizeOption || msg.desiredN !== data.desiredN)
-          ) {
-            return data;
-          }
-
           switch (msg.sampleSizeOption) {
             case PowerCheckOption.NONE:
             case PowerCheckOption.USE_POWER_CHECK:
+              if (msg.type === 'set-power-check-response') {
+                // For handling async min sample size responses, we check for stale requests by
+                // seeing if the spec used differs from what we would produce now, i.e. did the user
+                // change a value while the request was in flight?
+                // (We cannot check for sampleSizeOption && desiredN mismatches because they start off undefined.)
+                const expected_stringified_spec = JSON.stringify(convertToFrequentistDesignSpec(data));
+                if (JSON.stringify(msg.designSpec) !== expected_stringified_spec) {
+                  return data;
+                }
+              }
               return {
                 ...data,
                 sampleSizeOption: msg.sampleSizeOption,
@@ -508,6 +506,13 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
               };
             case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
             case PowerCheckOption.ENTER_OWN:
+              if (msg.type === 'set-power-check-response') {
+                // For handling async MDE responses, to check for stale requests we only need to
+                // verify that the option and desiredN haven't changed since the request was made.
+                if (msg.sampleSizeOption !== data.sampleSizeOption || msg.desiredN !== data.desiredN) {
+                  return data;
+                }
+              }
               return {
                 ...data,
                 sampleSizeOption: msg.sampleSizeOption,

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -564,7 +564,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-custom-power-check-response') {
-          return { ...data, customPowerCheckResponse: msg.response };
+          return { ...data, customPowerCheckResponse: msg.response, desiredN: msg.desiredN };
         }
         if (msg.type === 'set-chosen-n') {
           return { ...data, desiredN: msg.value };

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -148,6 +148,7 @@ export const ExperimentFreqStackScreen = ({
       data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
         ? data.mdePowerCheckResponse
         : data.powerCheckResponse;
+
     const createExperimentRequest = createExperimentBody.strict().parse({
       design_spec: designSpec,
       power_analyses: powerAnalyses,

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -34,25 +34,29 @@ const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefi
 };
 
 const isNextEnabled = (data: ExperimentFormData) => {
-  const isFreqPreassigned = data.experimentType === 'freq_preassigned';
-
   // Must have primary metric selected
   if (!data.primaryMetric) return false;
-  // Must have valid confidence value (50-99)
+
+  const isFreqPreassigned = data.experimentType === 'freq_preassigned';
   if (isFreqPreassigned) {
+    // Must have valid confidence value (50-99)
     const confidence = Number(data.confidence);
     if (isNaN(confidence) || confidence < 50 || confidence > 99) return false;
+
     // Must have valid power value (50-99) for pre-assigned frequentist experiment
     const power = Number(data.power);
     if (isNaN(power) || power < 50 || power > 99) return false;
+
     // Must have run power check for pre-assigned frequentist experiment
     if (!data.powerCheckResponse) return false;
+
     // Must have selected a sample size for pre-assigned frequentist experiment
     if (data.desiredN === undefined || data.desiredN === 0) return false;
+
     // desiredN must not exceed the primary metric's available samples
     const availableN = getPrimaryAnalysisAvailableN(data);
-    if (availableN === undefined) return false;
-    if (data.desiredN > availableN) return false;
+    if (availableN === undefined || data.desiredN > availableN) return false;
+
     // If in MDE mode, must have an MDE estimate
     if (
       (data.sampleSizeOption === PowerCheckOption.ENTER_OWN ||
@@ -67,14 +71,22 @@ const isNextEnabled = (data: ExperimentFormData) => {
 
 const getNextTooltip = (data: ExperimentFormData): string | undefined => {
   if (isNextEnabled(data)) return undefined;
+
   const isFreqPreassigned = data.experimentType === 'freq_preassigned';
   if (!isFreqPreassigned) return undefined;
+
+  const power = Number(data.power);
+  if (isNaN(power) || power < 50 || power > 99) return 'Please enter a valid power value (50-99).';
+
   if (!data.powerCheckResponse) return 'Please run a power check first.';
+
   if (data.desiredN === undefined || data.desiredN === 0) return 'Please select a sample size.';
+
   const availableN = getPrimaryAnalysisAvailableN(data);
   if (availableN !== undefined && data.desiredN > availableN) {
-    return `Desired N (${data.desiredN.toLocaleString()}) exceeds the available samples for the primary metric (${availableN.toLocaleString()}).`;
+    return `Desired N (${data.desiredN.toLocaleString()}) exceeds the primary metric's available samples (${availableN.toLocaleString()}).`;
   }
+
   return undefined;
 };
 
@@ -135,7 +147,6 @@ export const ExperimentFreqStackScreen = ({
       power_analyses: powerAnalyses,
       webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
     });
-    console.log('converted', createExperimentRequest);
     await triggerCreate(createExperimentRequest, { throwOnError: false });
   };
 

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -33,29 +33,55 @@ const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefi
   return primaryAnalysis?.metric_spec.available_n ?? undefined;
 };
 
-const isNextEnabled = (data: ExperimentFormData) => {
+const getNextDisabledReasons = (data: ExperimentFormData): string[] => {
+  const reasons: string[] = [];
+
   // Must have primary metric selected
-  if (!data.primaryMetric) return false;
+  if (!data.primaryMetric) {
+    reasons.push('Please select a primary metric.');
+  }
 
   const isFreqPreassigned = data.experimentType === 'freq_preassigned';
   if (isFreqPreassigned) {
     // Must have valid confidence value (50-99)
     const confidence = Number(data.confidence);
-    if (isNaN(confidence) || confidence < 50 || confidence > 99) return false;
+    if (isNaN(confidence) || confidence < 50 || confidence > 99) {
+      reasons.push('Enter a valid confidence value (50-99).');
+    }
 
     // Must have valid power value (50-99) for pre-assigned frequentist experiment
     const power = Number(data.power);
-    if (isNaN(power) || power < 50 || power > 99) return false;
+    if (isNaN(power) || power < 50 || power > 99) {
+      reasons.push('Enter a valid power value (50-99).');
+    }
 
     // Must have run power check for pre-assigned frequentist experiment
-    if (!data.powerCheckResponse) return false;
+    if (!data.powerCheckResponse) {
+      reasons.push('Please perform a sample size estimation.');
+    }
+
+    // Batch the above checks into a single set of reasons if any are present.
+    if (reasons.length > 0) {
+      return reasons;
+    }
 
     // Must have selected a sample size for pre-assigned frequentist experiment
-    if (data.desiredN === undefined || data.desiredN === 0) return false;
+    if (data.desiredN === undefined || data.desiredN === 0) {
+      reasons.push('Select a sample size.');
+    }
 
     // desiredN must not exceed the primary metric's available samples
     const availableN = getPrimaryAnalysisAvailableN(data);
-    if (availableN === undefined || data.desiredN > availableN) return false;
+    const hasAvailableN = availableN !== undefined && availableN !== 0;
+    if (!hasAvailableN) {
+      reasons.push('The primary metric has no available samples per the latest power check results.');
+    }
+
+    if (data.desiredN !== undefined && hasAvailableN && data.desiredN > availableN) {
+      reasons.push(
+        `Desired N (${data.desiredN.toLocaleString()}) exceeds the primary metric's available samples (${availableN.toLocaleString()}).`,
+      );
+    }
 
     // If in MDE mode, must have an MDE estimate
     if (
@@ -63,31 +89,10 @@ const isNextEnabled = (data: ExperimentFormData) => {
         data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES) &&
       !data.mdePowerCheckResponse
     ) {
-      return false;
+      reasons.push('Please generate a valid MDE estimate first.');
     }
   }
-  return true;
-};
-
-const getNextTooltip = (data: ExperimentFormData): string | undefined => {
-  if (isNextEnabled(data)) return undefined;
-
-  const isFreqPreassigned = data.experimentType === 'freq_preassigned';
-  if (!isFreqPreassigned) return undefined;
-
-  const power = Number(data.power);
-  if (isNaN(power) || power < 50 || power > 99) return 'Please enter a valid power value (50-99).';
-
-  if (!data.powerCheckResponse) return 'Please run a power check first.';
-
-  if (data.desiredN === undefined || data.desiredN === 0) return 'Please select a sample size.';
-
-  const availableN = getPrimaryAnalysisAvailableN(data);
-  if (availableN !== undefined && data.desiredN > availableN) {
-    return `Desired N (${data.desiredN.toLocaleString()}) exceeds the primary metric's available samples (${availableN.toLocaleString()}).`;
-  }
-
-  return undefined;
+  return reasons;
 };
 
 /** ExperimentFreqStackScreen allows users to define the primary key, metrics, filters, strata, confidence, power,
@@ -132,8 +137,9 @@ export const ExperimentFreqStackScreen = ({
     .map((s) => availableStrata.find((f) => f.field_name === s.field_name))
     .filter((f): f is FieldMetadata => Boolean(f));
 
-  const nextEnabled = isNextEnabled(data);
-  const nextTooltip = getNextTooltip(data);
+  const nextDisabledReasons = getNextDisabledReasons(data);
+  const nextEnabled = nextDisabledReasons.length === 0;
+  const nextTooltip = nextEnabled ? undefined : nextDisabledReasons.join('\n');
 
   const handleCreate = async () => {
     const designSpec = convertToFrequentistDesignSpec(data);

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -31,8 +31,12 @@ export type ExperimentFreqStackScreenMessage =
     }
   | { type: 'set-create-response'; response: CreateExperimentResponse }
   | { type: 'set-create-error'; response: ErrorType<unknown> }
-  | { type: 'set-chosen-n'; value: number | undefined }
-  | { type: 'set-sample-size-option'; value: PowerCheckOption }
+  | {
+      type: 'set-chosen-n';
+      desiredN: number | undefined;
+      sampleSizeOption: PowerCheckOption;
+      mdePowerCheckResponse?: PowerResponseOutput;
+    }
   | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
 
 const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefined => {

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -6,8 +6,8 @@ import { MetricBuilder, MetricBuilderAction } from '@/components/features/experi
 import { FilterBuilder } from '@/components/features/experiments/querybuilder/filter-builder';
 import { StrataBuilder } from '@/components/features/experiments/strata-builder';
 import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
-import { CreateExperimentResponse, FieldMetadata, FilterInput, PowerResponseOutput } from '@/api/methods.schemas';
-import { PowerCheckSection } from './power-check-section';
+import { CreateExperimentResponse, FieldMetadata, FilterInput } from '@/api/methods.schemas';
+import { PowerCheckSection, PowerCheckSectionAction } from './power-check-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import {
   convertToFrequentistDesignSpec,
@@ -19,25 +19,11 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 
 export type ExperimentFreqStackScreenMessage =
   | MetricBuilderAction
+  | PowerCheckSectionAction
   | { type: 'set-filters'; filters: FilterInput[] }
   | { type: 'set-strata'; strata: FieldMetadata[] }
-  | { type: 'set-confidence'; value: string }
-  | { type: 'set-power'; value: string }
-  | {
-      type: 'set-power-check-response';
-      response: PowerResponseOutput;
-      desiredN?: number;
-      sampleSizeOption?: PowerCheckOption;
-    }
   | { type: 'set-create-response'; response: CreateExperimentResponse }
-  | { type: 'set-create-error'; response: ErrorType<unknown> }
-  | {
-      type: 'set-chosen-n';
-      desiredN: number | undefined;
-      sampleSizeOption: PowerCheckOption;
-      mdePowerCheckResponse?: PowerResponseOutput;
-    }
-  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
+  | { type: 'set-create-error'; response: ErrorType<unknown> };
 
 const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefined => {
   if (!data.powerCheckResponse || !data.primaryMetric) return undefined;

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -33,7 +33,7 @@ export type ExperimentFreqStackScreenMessage =
   | { type: 'set-create-error'; response: ErrorType<unknown> }
   | { type: 'set-chosen-n'; value: number | undefined }
   | { type: 'set-sample-size-option'; value: PowerCheckOption }
-  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput };
+  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
 
 const isNextEnabled = (data: ExperimentFormData) => {
   const isFreqPreassigned = data.experimentType === 'freq_preassigned';

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -33,7 +33,9 @@ export type ExperimentFreqStackScreenMessage =
   | { type: 'set-create-error'; response: ErrorType<unknown> }
   | { type: 'set-chosen-n'; value: number | undefined }
   | { type: 'set-sample-size-option'; value: PowerCheckOption }
-  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
+  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number }
+  | { type: 'clear-custom-power-check-response' }
+  | { type: 'set-non-null-samples-power-check-response'; response: PowerResponseOutput };
 
 const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefined => {
   if (!data.powerCheckResponse || !data.primaryMetric) return undefined;
@@ -127,7 +129,11 @@ export const ExperimentFreqStackScreen = ({
   const handleCreate = async () => {
     const designSpec = convertToFrequentistDesignSpec(data);
     const powerAnalyses =
-      data.sampleSizeOption === PowerCheckOption.ENTER_OWN ? data.customPowerCheckResponse : data.powerCheckResponse;
+      data.sampleSizeOption === PowerCheckOption.ENTER_OWN
+        ? data.customPowerCheckResponse
+        : data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
+          ? data.nonNullSamplesPowerCheckResponse
+          : data.powerCheckResponse;
     const createExperimentRequest = createExperimentBody.strict().parse({
       design_spec: designSpec,
       power_analyses: powerAnalyses,

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -32,7 +32,8 @@ export type ExperimentFreqStackScreenMessage =
   | { type: 'set-create-response'; response: CreateExperimentResponse }
   | { type: 'set-create-error'; response: ErrorType<unknown> }
   | { type: 'set-chosen-n'; value: number | undefined }
-  | { type: 'set-sample-size-option'; value: PowerCheckOption };
+  | { type: 'set-sample-size-option'; value: PowerCheckOption }
+  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput };
 
 const isNextEnabled = (data: ExperimentFormData) => {
   const isFreqPreassigned = data.experimentType === 'freq_preassigned';
@@ -100,9 +101,11 @@ export const ExperimentFreqStackScreen = ({
 
   const handleCreate = async () => {
     const designSpec = convertToFrequentistDesignSpec(data);
+    const powerAnalyses =
+      data.sampleSizeOption === PowerCheckOption.ENTER_OWN ? data.customPowerCheckResponse : data.powerCheckResponse;
     const createExperimentRequest = createExperimentBody.strict().parse({
       design_spec: designSpec,
-      power_analyses: data.powerCheckResponse,
+      power_analyses: powerAnalyses,
       webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
     });
     console.log('converted', createExperimentRequest);

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -33,9 +33,7 @@ export type ExperimentFreqStackScreenMessage =
   | { type: 'set-create-error'; response: ErrorType<unknown> }
   | { type: 'set-chosen-n'; value: number | undefined }
   | { type: 'set-sample-size-option'; value: PowerCheckOption }
-  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number }
-  | { type: 'clear-custom-power-check-response' }
-  | { type: 'set-non-null-samples-power-check-response'; response: PowerResponseOutput };
+  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
 
 const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefined => {
   if (!data.powerCheckResponse || !data.primaryMetric) return undefined;
@@ -63,7 +61,16 @@ const isNextEnabled = (data: ExperimentFormData) => {
     if (data.desiredN === undefined || data.desiredN === 0) return false;
     // desiredN must not exceed the primary metric's available samples
     const availableN = getPrimaryAnalysisAvailableN(data);
-    if (availableN !== undefined && data.desiredN > availableN) return false;
+    if (availableN === undefined) return false;
+    if (data.desiredN > availableN) return false;
+    // If in MDE mode, must have an MDE estimate
+    if (
+      (data.sampleSizeOption === PowerCheckOption.ENTER_OWN ||
+        data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES) &&
+      !data.mdePowerCheckResponse
+    ) {
+      return false;
+    }
   }
   return true;
 };
@@ -129,11 +136,10 @@ export const ExperimentFreqStackScreen = ({
   const handleCreate = async () => {
     const designSpec = convertToFrequentistDesignSpec(data);
     const powerAnalyses =
-      data.sampleSizeOption === PowerCheckOption.ENTER_OWN
-        ? data.customPowerCheckResponse
-        : data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
-          ? data.nonNullSamplesPowerCheckResponse
-          : data.powerCheckResponse;
+      data.sampleSizeOption === PowerCheckOption.ENTER_OWN ||
+      data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES
+        ? data.mdePowerCheckResponse
+        : data.powerCheckResponse;
     const createExperimentRequest = createExperimentBody.strict().parse({
       design_spec: designSpec,
       power_analyses: powerAnalyses,

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -35,6 +35,14 @@ export type ExperimentFreqStackScreenMessage =
   | { type: 'set-sample-size-option'; value: PowerCheckOption }
   | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
 
+const getPrimaryAnalysisAvailableN = (data: ExperimentFormData): number | undefined => {
+  if (!data.powerCheckResponse || !data.primaryMetric) return undefined;
+  const primaryAnalysis = data.powerCheckResponse.analyses.find(
+    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+  );
+  return primaryAnalysis?.metric_spec.available_n ?? undefined;
+};
+
 const isNextEnabled = (data: ExperimentFormData) => {
   const isFreqPreassigned = data.experimentType === 'freq_preassigned';
 
@@ -51,8 +59,24 @@ const isNextEnabled = (data: ExperimentFormData) => {
     if (!data.powerCheckResponse) return false;
     // Must have selected a sample size for pre-assigned frequentist experiment
     if (data.desiredN === undefined || data.desiredN === 0) return false;
+    // desiredN must not exceed the primary metric's available samples
+    const availableN = getPrimaryAnalysisAvailableN(data);
+    if (availableN !== undefined && data.desiredN > availableN) return false;
   }
   return true;
+};
+
+const getNextTooltip = (data: ExperimentFormData): string | undefined => {
+  if (isNextEnabled(data)) return undefined;
+  const isFreqPreassigned = data.experimentType === 'freq_preassigned';
+  if (!isFreqPreassigned) return undefined;
+  if (!data.powerCheckResponse) return 'Please run a power check first.';
+  if (data.desiredN === undefined || data.desiredN === 0) return 'Please select a sample size.';
+  const availableN = getPrimaryAnalysisAvailableN(data);
+  if (availableN !== undefined && data.desiredN > availableN) {
+    return `Desired N (${data.desiredN.toLocaleString()}) exceeds the available samples for the primary metric (${availableN.toLocaleString()}).`;
+  }
+  return undefined;
 };
 
 /** ExperimentFreqStackScreen allows users to define the primary key, metrics, filters, strata, confidence, power,
@@ -98,6 +122,7 @@ export const ExperimentFreqStackScreen = ({
     .filter((f): f is FieldMetadata => Boolean(f));
 
   const nextEnabled = isNextEnabled(data);
+  const nextTooltip = getNextTooltip(data);
 
   const handleCreate = async () => {
     const designSpec = convertToFrequentistDesignSpec(data);
@@ -167,6 +192,7 @@ export const ExperimentFreqStackScreen = ({
         onNext={handleCreate}
         nextDisabled={!nextEnabled}
         nextLoading={triggerLoading}
+        nextTooltipContent={nextTooltip}
       />
     </>
   );

--- a/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
@@ -15,6 +15,13 @@ interface PowerCheckDesiredNInputProps {
   max?: number;
 }
 
+/**
+ * Semi-controlled number input with local draft state and debounced commits.
+ *
+ * - `value`: external sync/reset string (e.g. when parent changes desiredN from outside typing).
+ * - `onChange`: latest ref called after debounce delay with a parsed positive integer, or
+ * `undefined` for empty/invalid input.
+ */
 export function PowerCheckDesiredNInput({ value, onChange, max }: PowerCheckDesiredNInputProps) {
   const [draftN, setDraftN] = useState(value);
   // Guard against the onChange function changing between debounce calls with a ref.

--- a/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { TextField } from '@radix-ui/themes';
+import { useEffect, useState } from 'react';
+import { useDebounced } from '@/providers/use-debounced';
+
+function getValidDraftN(input: string): number | undefined {
+  const parsed = input === '' ? undefined : Number(input);
+  return parsed !== undefined && !isNaN(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+interface PowerCheckDesiredNInputProps {
+  value: string;
+  onChange: (debouncedValidN: number | undefined) => void;
+  max?: number;
+}
+
+export function PowerCheckDesiredNInput({ value, onChange, max }: PowerCheckDesiredNInputProps) {
+  const [draftN, setDraftN] = useState(value);
+  const debouncedValidN = useDebounced(getValidDraftN(draftN), 400);
+
+  useEffect(() => {
+    setDraftN(value);
+  }, [value]);
+
+  useEffect(() => {
+    onChange(debouncedValidN);
+  }, [debouncedValidN, onChange]);
+
+  return (
+    <TextField.Root
+      style={{ width: '150px' }}
+      size="2"
+      type="number"
+      min={1}
+      max={max}
+      value={draftN}
+      onChange={(e) => setDraftN(e.target.value)}
+      placeholder="Enter your desired N"
+    />
+  );
+}

--- a/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TextField } from '@radix-ui/themes';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDebounced } from '@/providers/use-debounced';
 
 function getValidDraftN(input: string): number | undefined {
@@ -17,15 +17,19 @@ interface PowerCheckDesiredNInputProps {
 
 export function PowerCheckDesiredNInput({ value, onChange, max }: PowerCheckDesiredNInputProps) {
   const [draftN, setDraftN] = useState(value);
+  // Guard against the onChange function changing between debounce calls with a ref.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
   const debouncedValidN = useDebounced(getValidDraftN(draftN), 400);
 
+  // Allow updates to the input due to prop changes, as can happen if the user chose all samples.
   useEffect(() => {
     setDraftN(value);
   }, [value]);
 
   useEffect(() => {
-    onChange(debouncedValidN);
-  }, [debouncedValidN, onChange]);
+    onChangeRef.current(debouncedValidN);
+  }, [debouncedValidN]);
 
   return (
     <TextField.Root

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -42,7 +42,7 @@ interface PowerCheckSampleSizeSelectorProps {
    */
   onOptionChange: (change: PowerCheckSampleOptionChange) => void;
   /**
-   * Called on completion of any async MDE estimation request.
+   * Called on successful completion of any async MDE estimation request.
    * Parent is responsible for handling potentially stale responses.
    */
   onEstimatedMDEChange: (change: PowerCheckSampleOptionChange) => void;
@@ -99,7 +99,7 @@ export function PowerCheckSampleSizeSelector({
     isMutating: isEstimatingMde,
     error,
   } = usePowerCheck(datasourceId, {
-    swr: { swrKey: `${datasourceId}/power/mde-estimate/${desiredN}` },
+    swr: { swrKey: `${datasourceId}/power/mde-estimate` },
   });
 
   const primaryAnalysis = powerCheckResponse.analyses.find((a) => a.metric_spec.field_name === primaryMetricFieldName);
@@ -120,12 +120,17 @@ export function PowerCheckSampleSizeSelector({
   /**
    * Estimates may trigger on option selection or custom desired n entry.
    *
-   * We always dispatch the result even if stale, letting the parent handle it.
+   * We always dispatch a valid response even if stale, letting the parent handle it.
    */
   const estimateMde = (sampleSizeOption: PowerCheckOption, desiredN: number) => {
     const designSpec = makeDesignSpec(desiredN);
     void (async () => {
       const response = await triggerEstimateMde({ design_spec: designSpec });
+      if (!response) {
+        // Can happen if this request has gone stale and failed, superceded by a more recent request.
+        // Stale requests that succeed will be handled by the parent.
+        return;
+      }
       onEstimatedMDEChange({ sampleSizeOption, desiredN, response });
     })();
   };

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -77,8 +77,11 @@ function EstimatedMdeBadge({ isSelectedOption, isEstimatingMde, estimatedMdePct,
   );
 }
 
-// Reponsible for making MDE estimates if the user selects a sample size other than the minimum
-// sample size (USE_POWER_CHECK).
+/**
+ * Handles sample size selection for experiment arms and triggers Minimum Detectable Effect
+ * re-estimation when the user chooses an option other than the min sample size.  Estimates are
+ * dispatched to the parent, which is responsible for managing and validating latest state.
+ */
 export function PowerCheckSampleSizeSelector({
   datasourceId,
   selectedSampleOption,
@@ -128,9 +131,12 @@ export function PowerCheckSampleSizeSelector({
   };
 
   /**
-   * We immediately report back the selected option, the desiredN if appropriate for the option, and
-   * its current estimate if it doesn't need updating. If the cached response doesn't match the desiredN,
-   * we also kick off an MDE estimate for the new desiredN.
+   * Handler immediately reports back:
+   * - the selected option,
+   * - the desiredN if appropriate for the option, and
+   * - its current power estimate if it doesn't need updating.
+   *
+   * If the cached response doesn't match the desiredN, we also trigger a new MDE estimate.
    */
   const handleOptionChange = (option: PowerCheckOption) => {
     let useCachedResponse = false;
@@ -161,6 +167,9 @@ export function PowerCheckSampleSizeSelector({
         }
         break;
       case PowerCheckOption.ENTER_OWN:
+        // Switching away from ENTER_OWN will either keep desiredN set to nonNullSamples or change
+        // it away, so switching back to ENTER_OWN will not reuse a stale custom response with the
+        // following restricted reuse check.
         useCachedResponse = mdePowerCheckResponse !== undefined && desiredN === nonNullSamples;
         onOptionChange({
           sampleSizeOption: option,

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -198,15 +198,15 @@ export function PowerCheckSampleSizeSelector({
   };
 
   return (
-    <Flex direction="column" gap="2">
+    <Flex direction="column" gap="2" justify="center" width="100%">
       <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleOptionChange}>
-        <Flex direction={'row'} gap={'3'} justify={'between'}>
+        <Flex direction="row" gap="3" justify="center" wrap="wrap">
           <RadioCards.Item
             value={PowerCheckOption.USE_POWER_CHECK}
             disabled={targetN === undefined || targetN === 0 || targetN > allSamples}
           >
             <Flex align="center" direction="column" gap="2">
-              <Text size="2">Use minimum sample required:</Text>
+              <Text size="2">Use the minimum required sample:</Text>
               <Flex height="32px" align="center">
                 <Text size="2">{targetN ?? 'N/A'}</Text>
               </Flex>
@@ -224,7 +224,7 @@ export function PowerCheckSampleSizeSelector({
             disabled={nonNullSamples === undefined || nonNullSamples === 0}
           >
             <Flex align="center" direction="column" gap="2">
-              <Text size="2">Use all available non-null samples:</Text>
+              <Text size="2">Use all non-null samples:</Text>
               <Flex height="32px" align="center">
                 <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
               </Flex>
@@ -239,7 +239,7 @@ export function PowerCheckSampleSizeSelector({
           </RadioCards.Item>
           <RadioCards.Item value={PowerCheckOption.ENTER_OWN} disabled={allSamples === undefined || allSamples === 0}>
             <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
-              <Text size="2">Use custom sample size:</Text>
+              <Text size="2">Use a custom sample size:</Text>
               <PowerCheckDesiredNInput
                 value={String(desiredN ?? '')}
                 onChange={handleInputChange}

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -38,10 +38,14 @@ interface PowerCheckSampleSizeSelectorProps {
   /** Used for making MDE estimates. Creates a design spec for the given desired N. */
   makeDesignSpec: (desiredN: number) => AnyFrequentistDesignSpecInput;
   /**
-   * Handles both the radio button selection immediately and any async MDE estimation request
-   * corresponding to the selection. Parent is responsible for handling potentially stale responses.
+   * Handles the radio button selection immediately.
    */
   onOptionChange: (change: PowerCheckSampleOptionChange) => void;
+  /**
+   * Called on completion of any async MDE estimation request.
+   * Parent is responsible for handling potentially stale responses.
+   */
+  onEstimatedMDEChange: (change: PowerCheckSampleOptionChange) => void;
 }
 
 interface EstimatedMdeBadgeProps {
@@ -85,6 +89,7 @@ export function PowerCheckSampleSizeSelector({
   desiredN,
   makeDesignSpec,
   onOptionChange,
+  onEstimatedMDEChange,
 }: PowerCheckSampleSizeSelectorProps) {
   const {
     trigger: triggerEstimateMde,
@@ -118,7 +123,7 @@ export function PowerCheckSampleSizeSelector({
     const designSpec = makeDesignSpec(desiredN);
     void (async () => {
       const response = await triggerEstimateMde({ design_spec: designSpec });
-      onOptionChange({ sampleSizeOption, desiredN, response });
+      onEstimatedMDEChange({ sampleSizeOption, desiredN, response });
     })();
   };
 
@@ -128,6 +133,7 @@ export function PowerCheckSampleSizeSelector({
    * we also kick off an MDE estimate for the new desiredN.
    */
   const handleOptionChange = (option: PowerCheckOption) => {
+    let useCachedResponse = false;
     switch (option) {
       case PowerCheckOption.NONE:
         onOptionChange({
@@ -144,40 +150,37 @@ export function PowerCheckSampleSizeSelector({
         });
         break;
       case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
+        useCachedResponse = mdePowerCheckResponse !== undefined && desiredN === nonNullSamples;
         onOptionChange({
           sampleSizeOption: option,
           desiredN: nonNullSamples,
-          response: undefined,
+          response: useCachedResponse ? mdePowerCheckResponse : undefined,
         });
-        estimateMde(option, nonNullSamples);
+        if (!useCachedResponse) {
+          estimateMde(option, nonNullSamples);
+        }
         break;
       case PowerCheckOption.ENTER_OWN:
+        useCachedResponse = mdePowerCheckResponse !== undefined && desiredN === nonNullSamples;
         onOptionChange({
           sampleSizeOption: option,
           desiredN: desiredN,
-          response: undefined,
+          response: useCachedResponse ? mdePowerCheckResponse : undefined,
         });
-        if (desiredN !== undefined) {
+        if (!useCachedResponse && desiredN !== undefined) {
           estimateMde(option, desiredN);
         }
         break;
     }
   };
 
-  const handleInputChange = (validN: number | undefined) => {
-    if (
-      selectedSampleOption === PowerCheckOption.ENTER_OWN &&
-      validN !== undefined &&
-      (validN !== desiredN || mdePowerCheckResponse === undefined)
-    ) {
-      // Notify parent that we want a new desiredN.
-      onOptionChange({
-        sampleSizeOption: selectedSampleOption,
-        desiredN: validN,
-        response: undefined,
-      });
-      estimateMde(PowerCheckOption.ENTER_OWN, validN);
+  const handleInputChange = (newN: number | undefined) => {
+    if (newN === undefined || selectedSampleOption !== PowerCheckOption.ENTER_OWN) {
+      return;
     }
+    // Notify parent that we want a new desiredN.
+    onOptionChange({ sampleSizeOption: selectedSampleOption, desiredN: newN, response: undefined });
+    estimateMde(PowerCheckOption.ENTER_OWN, newN);
   };
 
   return (

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -5,7 +5,17 @@ import { usePowerCheck } from '@/api/admin';
 import { AnyFrequentistDesignSpecInput, PowerResponseOutput } from '@/api/methods.schemas';
 import { PowerCheckDesiredNInput } from './power-check-desired-n-input';
 import { PowerCheckOption } from './experiment-form-types';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
 
+/**
+ * `sampleSizeOption` is the selected sample size option.
+ *
+ * `desiredN` is the final sample size selection from the user, regardless of wheather it was
+ * derived from the minimum sample size, max available, or other user-entered value.
+ * `desiredN` may be set with `response` undefined, signaling an upcoming MDE estimate.
+ *
+ * `response` if set should always correspond to the `desiredN` in this same message.
+ */
 export type PowerCheckSampleOptionChange = {
   sampleSizeOption: PowerCheckOption;
   desiredN: number | undefined;
@@ -29,9 +39,9 @@ interface PowerCheckSampleSizeSelectorProps {
   makeDesignSpec: (desiredN: number) => AnyFrequentistDesignSpecInput;
   /**
    * Handles both the radio button selection immediately and any async MDE estimation request
-   * corresponding to the selection.
+   * corresponding to the selection. Parent is responsible for handling potentially stale responses.
    */
-  onSampleOptionChange: (change: PowerCheckSampleOptionChange) => void;
+  onOptionChange: (change: PowerCheckSampleOptionChange) => void;
 }
 
 interface EstimatedMdeBadgeProps {
@@ -74,7 +84,7 @@ export function PowerCheckSampleSizeSelector({
   mdePowerCheckResponse,
   desiredN,
   makeDesignSpec,
-  onSampleOptionChange,
+  onOptionChange,
 }: PowerCheckSampleSizeSelectorProps) {
   const {
     trigger: triggerEstimateMde,
@@ -99,16 +109,16 @@ export function PowerCheckSampleSizeSelector({
         ? (mdePrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
         : 'N/A';
 
-  const estimateMde = (forOption: PowerCheckOption, desiredN: number) => {
+  /**
+   * Estimates may trigger on option selection or custom desired n entry.
+   *
+   * We always dispatch the result even if stale, letting the parent handle it.
+   */
+  const estimateMde = (sampleSizeOption: PowerCheckOption, desiredN: number) => {
     const designSpec = makeDesignSpec(desiredN);
     void (async () => {
       const response = await triggerEstimateMde({ design_spec: designSpec });
-      // Always dispatch the result even if stale; let the reducer handle it.
-      onSampleOptionChange({
-        sampleSizeOption: forOption,
-        desiredN: designSpec.desired_n ?? undefined,
-        response,
-      });
+      onOptionChange({ sampleSizeOption, desiredN, response });
     })();
   };
 
@@ -120,13 +130,21 @@ export function PowerCheckSampleSizeSelector({
   const handleOptionChange = (option: PowerCheckOption) => {
     switch (option) {
       case PowerCheckOption.NONE:
-        onSampleOptionChange({ sampleSizeOption: option, desiredN: undefined, response: powerCheckResponse });
+        onOptionChange({
+          sampleSizeOption: option,
+          desiredN: undefined,
+          response: powerCheckResponse,
+        });
         break;
       case PowerCheckOption.USE_POWER_CHECK:
-        onSampleOptionChange({ sampleSizeOption: option, desiredN: targetN, response: powerCheckResponse });
+        onOptionChange({
+          sampleSizeOption: option,
+          desiredN: targetN,
+          response: powerCheckResponse,
+        });
         break;
       case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
-        onSampleOptionChange({
+        onOptionChange({
           sampleSizeOption: option,
           desiredN: nonNullSamples,
           response: undefined,
@@ -134,7 +152,7 @@ export function PowerCheckSampleSizeSelector({
         estimateMde(option, nonNullSamples);
         break;
       case PowerCheckOption.ENTER_OWN:
-        onSampleOptionChange({
+        onOptionChange({
           sampleSizeOption: option,
           desiredN: desiredN,
           response: undefined,
@@ -146,14 +164,14 @@ export function PowerCheckSampleSizeSelector({
     }
   };
 
-  const handleDesiredNChange = (validN: number | undefined) => {
+  const handleInputChange = (validN: number | undefined) => {
     if (
       selectedSampleOption === PowerCheckOption.ENTER_OWN &&
       validN !== undefined &&
       (validN !== desiredN || mdePowerCheckResponse === undefined)
     ) {
       // Notify parent that we want a new desiredN.
-      onSampleOptionChange({
+      onOptionChange({
         sampleSizeOption: selectedSampleOption,
         desiredN: validN,
         response: undefined,
@@ -163,61 +181,64 @@ export function PowerCheckSampleSizeSelector({
   };
 
   return (
-    <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleOptionChange}>
-      <Flex direction={'row'} gap={'3'} justify={'between'}>
-        <RadioCards.Item
-          value={PowerCheckOption.USE_POWER_CHECK}
-          disabled={targetN === undefined || targetN === 0 || targetN > allSamples}
-        >
-          <Flex align="center" direction="column" gap="2">
-            <Text size="2">Use minimum sample required:</Text>
-            <Flex height="32px" align="center">
-              <Text size="2">{targetN ?? 'N/A'}</Text>
+    <Flex direction="column" gap="2">
+      <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleOptionChange}>
+        <Flex direction={'row'} gap={'3'} justify={'between'}>
+          <RadioCards.Item
+            value={PowerCheckOption.USE_POWER_CHECK}
+            disabled={targetN === undefined || targetN === 0 || targetN > allSamples}
+          >
+            <Flex align="center" direction="column" gap="2">
+              <Text size="2">Use minimum sample required:</Text>
+              <Flex height="32px" align="center">
+                <Text size="2">{targetN ?? 'N/A'}</Text>
+              </Flex>
+              <Flex align="center" style={{ minHeight: '24px' }}>
+                {targetMde !== undefined ? (
+                  <Badge color="purple" variant="soft" size="2">
+                    Target MDE: {targetMde}%
+                  </Badge>
+                ) : null}
+              </Flex>
             </Flex>
-            <Flex align="center" style={{ minHeight: '24px' }}>
-              {targetMde !== undefined ? (
-                <Badge color="purple" variant="soft" size="2">
-                  Target MDE: {targetMde}%
-                </Badge>
-              ) : null}
-            </Flex>
-          </Flex>
-        </RadioCards.Item>
-        <RadioCards.Item
-          value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-          disabled={nonNullSamples === undefined || nonNullSamples === 0}
-        >
-          <Flex align="center" direction="column" gap="2">
-            <Text size="2">Use all available non-null samples:</Text>
-            <Flex height="32px" align="center">
-              <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
-            </Flex>
+          </RadioCards.Item>
+          <RadioCards.Item
+            value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
+            disabled={nonNullSamples === undefined || nonNullSamples === 0}
+          >
+            <Flex align="center" direction="column" gap="2">
+              <Text size="2">Use all available non-null samples:</Text>
+              <Flex height="32px" align="center">
+                <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
+              </Flex>
 
-            <EstimatedMdeBadge
-              isSelectedOption={selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-              isEstimatingMde={isEstimatingMde}
-              estimatedMdePct={estimatedMdePct}
-              error={error}
-            />
-          </Flex>
-        </RadioCards.Item>
-        <RadioCards.Item value={PowerCheckOption.ENTER_OWN} disabled={allSamples === undefined || allSamples === 0}>
-          <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
-            <Text size="2">Use custom sample size:</Text>
-            <PowerCheckDesiredNInput
-              value={String(desiredN ?? '')}
-              onChange={handleDesiredNChange}
-              max={allSamples ?? undefined}
-            />
-            <EstimatedMdeBadge
-              isSelectedOption={selectedSampleOption === PowerCheckOption.ENTER_OWN}
-              isEstimatingMde={isEstimatingMde}
-              estimatedMdePct={estimatedMdePct}
-              error={error}
-            />
-          </Flex>
-        </RadioCards.Item>
-      </Flex>
-    </RadioCards.Root>
+              <EstimatedMdeBadge
+                isSelectedOption={selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
+                isEstimatingMde={isEstimatingMde}
+                estimatedMdePct={estimatedMdePct}
+                error={error}
+              />
+            </Flex>
+          </RadioCards.Item>
+          <RadioCards.Item value={PowerCheckOption.ENTER_OWN} disabled={allSamples === undefined || allSamples === 0}>
+            <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
+              <Text size="2">Use custom sample size:</Text>
+              <PowerCheckDesiredNInput
+                value={String(desiredN ?? '')}
+                onChange={handleInputChange}
+                max={allSamples ?? undefined}
+              />
+              <EstimatedMdeBadge
+                isSelectedOption={selectedSampleOption === PowerCheckOption.ENTER_OWN}
+                isEstimatingMde={isEstimatingMde}
+                estimatedMdePct={estimatedMdePct}
+                error={error}
+              />
+            </Flex>
+          </RadioCards.Item>
+        </Flex>
+      </RadioCards.Root>
+      {error && <GenericErrorCallout title={'MDE estimate failed'} error={error} />}
+    </Flex>
   );
 }

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { Badge, Flex, RadioCards, Spinner, Text } from '@radix-ui/themes';
+import { usePowerCheck } from '@/api/admin';
+import { AnyFrequentistDesignSpecInput, PowerResponseOutput } from '@/api/methods.schemas';
+import { PowerCheckDesiredNInput } from './power-check-desired-n-input';
+import { PowerCheckOption } from './experiment-form-types';
+
+export type PowerCheckSampleOptionChange = {
+  sampleSizeOption: PowerCheckOption;
+  desiredN: number | undefined;
+  response: PowerResponseOutput | undefined;
+};
+
+interface PowerCheckSampleSizeSelectorProps {
+  datasourceId: string;
+  selectedSampleOption: PowerCheckOption;
+  primaryMetricFieldName: string;
+  /** Values for display in sample size mode (USE_POWER_CHECK) */
+  powerCheckResponse: PowerResponseOutput;
+  targetMde?: string;
+  /**
+   * Values for display in MDE mode (USE_ALL_NON_NULL_SAMPLES or ENTER_OWN).
+   * desiredN should always correspond to the mdePowerCheckResponse if it exists.
+   */
+  mdePowerCheckResponse?: PowerResponseOutput;
+  desiredN?: number;
+  /** Used for making MDE estimates. Creates a design spec for the given desired N. */
+  makeDesignSpec: (desiredN: number) => AnyFrequentistDesignSpecInput;
+  /**
+   * Handles both the radio button selection immediately and any async MDE estimation request
+   * corresponding to the selection.
+   */
+  onSampleOptionChange: (change: PowerCheckSampleOptionChange) => void;
+}
+
+interface EstimatedMdeBadgeProps {
+  isSelectedOption: boolean;
+  isEstimatingMde: boolean;
+  estimatedMdePct: string | undefined;
+  error: Error | undefined;
+}
+
+function EstimatedMdeBadge({ isSelectedOption, isEstimatingMde, estimatedMdePct, error }: EstimatedMdeBadgeProps) {
+  return (
+    <Flex align="center" style={{ minHeight: '24px' }}>
+      {isSelectedOption &&
+        (isEstimatingMde ? (
+          <Badge color="purple" variant="soft" size="2">
+            Estimated MDE: …
+            <Spinner size="1" />
+          </Badge>
+        ) : estimatedMdePct !== undefined ? (
+          <Badge color="purple" variant="soft" size="2">
+            Estimated MDE: {estimatedMdePct}%
+          </Badge>
+        ) : error ? (
+          <Badge color="red" variant="soft" size="2">
+            MDE Error
+          </Badge>
+        ) : null)}
+    </Flex>
+  );
+}
+
+// Reponsible for making MDE estimates if the user selects a sample size other than the minimum
+// sample size (USE_POWER_CHECK).
+export function PowerCheckSampleSizeSelector({
+  datasourceId,
+  selectedSampleOption,
+  primaryMetricFieldName,
+  powerCheckResponse,
+  targetMde,
+  mdePowerCheckResponse,
+  desiredN,
+  makeDesignSpec,
+  onSampleOptionChange,
+}: PowerCheckSampleSizeSelectorProps) {
+  const {
+    trigger: triggerEstimateMde,
+    isMutating: isEstimatingMde,
+    error,
+  } = usePowerCheck(datasourceId, {
+    swr: { swrKey: `${datasourceId}/power/mde-estimate/${desiredN}` },
+  });
+
+  const primaryAnalysis = powerCheckResponse.analyses.find((a) => a.metric_spec.field_name === primaryMetricFieldName);
+  const targetN = primaryAnalysis?.target_n ?? undefined;
+  const nonNullSamples = primaryAnalysis?.metric_spec.available_nonnull_n ?? 0;
+  const allSamples = primaryAnalysis?.metric_spec.available_n ?? 0;
+
+  const mdePrimaryAnalysis = mdePowerCheckResponse?.analyses.find(
+    (a) => a.metric_spec.field_name === primaryMetricFieldName,
+  );
+  const estimatedMdePct =
+    mdePrimaryAnalysis === undefined
+      ? undefined
+      : mdePrimaryAnalysis.pct_change_with_desired_n != null
+        ? (mdePrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
+        : 'N/A';
+
+  const estimateMde = (forOption: PowerCheckOption, desiredN: number) => {
+    const designSpec = makeDesignSpec(desiredN);
+    void (async () => {
+      const response = await triggerEstimateMde({ design_spec: designSpec });
+      // Always dispatch the result even if stale; let the reducer handle it.
+      onSampleOptionChange({
+        sampleSizeOption: forOption,
+        desiredN: designSpec.desired_n ?? undefined,
+        response,
+      });
+    })();
+  };
+
+  /**
+   * We immediately report back the selected option, the desiredN if appropriate for the option, and
+   * its current estimate if it doesn't need updating. If the cached response doesn't match the desiredN,
+   * we also kick off an MDE estimate for the new desiredN.
+   */
+  const handleOptionChange = (option: PowerCheckOption) => {
+    switch (option) {
+      case PowerCheckOption.NONE:
+        onSampleOptionChange({ sampleSizeOption: option, desiredN: undefined, response: powerCheckResponse });
+        break;
+      case PowerCheckOption.USE_POWER_CHECK:
+        onSampleOptionChange({ sampleSizeOption: option, desiredN: targetN, response: powerCheckResponse });
+        break;
+      case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
+        onSampleOptionChange({
+          sampleSizeOption: option,
+          desiredN: nonNullSamples,
+          response: undefined,
+        });
+        estimateMde(option, nonNullSamples);
+        break;
+      case PowerCheckOption.ENTER_OWN:
+        onSampleOptionChange({
+          sampleSizeOption: option,
+          desiredN: desiredN,
+          response: undefined,
+        });
+        if (desiredN !== undefined) {
+          estimateMde(option, desiredN);
+        }
+        break;
+    }
+  };
+
+  const handleDesiredNChange = (validN: number | undefined) => {
+    if (
+      selectedSampleOption === PowerCheckOption.ENTER_OWN &&
+      validN !== undefined &&
+      (validN !== desiredN || mdePowerCheckResponse === undefined)
+    ) {
+      // Notify parent that we want a new desiredN.
+      onSampleOptionChange({
+        sampleSizeOption: selectedSampleOption,
+        desiredN: validN,
+        response: undefined,
+      });
+      estimateMde(PowerCheckOption.ENTER_OWN, validN);
+    }
+  };
+
+  return (
+    <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleOptionChange}>
+      <Flex direction={'row'} gap={'3'} justify={'between'}>
+        <RadioCards.Item
+          value={PowerCheckOption.USE_POWER_CHECK}
+          disabled={targetN === undefined || targetN === 0 || targetN > allSamples}
+        >
+          <Flex align="center" direction="column" gap="2">
+            <Text size="2">Use minimum sample required:</Text>
+            <Flex height="32px" align="center">
+              <Text size="2">{targetN ?? 'N/A'}</Text>
+            </Flex>
+            <Flex align="center" style={{ minHeight: '24px' }}>
+              {targetMde !== undefined ? (
+                <Badge color="purple" variant="soft" size="2">
+                  Target MDE: {targetMde}%
+                </Badge>
+              ) : null}
+            </Flex>
+          </Flex>
+        </RadioCards.Item>
+        <RadioCards.Item
+          value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
+          disabled={nonNullSamples === undefined || nonNullSamples === 0}
+        >
+          <Flex align="center" direction="column" gap="2">
+            <Text size="2">Use all available non-null samples:</Text>
+            <Flex height="32px" align="center">
+              <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
+            </Flex>
+
+            <EstimatedMdeBadge
+              isSelectedOption={selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
+              isEstimatingMde={isEstimatingMde}
+              estimatedMdePct={estimatedMdePct}
+              error={error}
+            />
+          </Flex>
+        </RadioCards.Item>
+        <RadioCards.Item value={PowerCheckOption.ENTER_OWN} disabled={allSamples === undefined || allSamples === 0}>
+          <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
+            <Text size="2">Use custom sample size:</Text>
+            <PowerCheckDesiredNInput
+              value={String(desiredN ?? '')}
+              onChange={handleDesiredNChange}
+              max={allSamples ?? undefined}
+            />
+            <EstimatedMdeBadge
+              isSelectedOption={selectedSampleOption === PowerCheckOption.ENTER_OWN}
+              isEstimatingMde={isEstimatingMde}
+              estimatedMdePct={estimatedMdePct}
+              error={error}
+            />
+          </Flex>
+        </RadioCards.Item>
+      </Flex>
+    </RadioCards.Root>
+  );
+}

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -22,6 +22,14 @@ export type PowerCheckSampleOptionChange = {
   response: PowerResponseOutput | undefined;
 };
 
+/**
+ * `designSpec` is the payload sent in the power request that produced the response.
+ * Can be used to check for stale responses.
+ */
+export type PowerCheckResponseChange = PowerCheckSampleOptionChange & {
+  designSpec: AnyFrequentistDesignSpecInput;
+};
+
 interface PowerCheckSampleSizeSelectorProps {
   datasourceId: string;
   selectedSampleOption: PowerCheckOption;
@@ -45,7 +53,7 @@ interface PowerCheckSampleSizeSelectorProps {
    * Called on successful completion of any async MDE estimation request.
    * Parent is responsible for handling potentially stale responses.
    */
-  onEstimatedMDEChange: (change: PowerCheckSampleOptionChange) => void;
+  onEstimatedMDEChange: (change: PowerCheckResponseChange) => void;
 }
 
 interface EstimatedMdeBadgeProps {
@@ -131,7 +139,7 @@ export function PowerCheckSampleSizeSelector({
         // Stale requests that succeed will be handled by the parent.
         return;
       }
-      onEstimatedMDEChange({ sampleSizeOption, desiredN, response });
+      onEstimatedMDEChange({ sampleSizeOption, desiredN, response, designSpec });
     })();
   };
 

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -23,8 +23,9 @@ import { usePowerCheck } from '@/api/admin';
 import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
+import { useDebounced } from '@/providers/use-debounced';
 
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
@@ -64,7 +65,13 @@ function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProp
 
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
+  // Separate mutation with a distinct SWR key so it doesn't share cache or conflict with the
+  // main power-check mutation above.
+  const { trigger: triggerEstimatedMde, isMutating: isEstimatingMde } = usePowerCheck(data.datasourceId!, {
+    swr: { swrKey: `${data.datasourceId}/power/mde-estimate` },
+  });
   const [validationError, setValidationError] = useState<ZodError | null>(null);
+
   const primaryAnalysis = data.powerCheckResponse?.analyses.find(
     (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
   );
@@ -73,7 +80,40 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const allSamples = primaryAnalysis?.metric_spec.available_n ?? 0;
   const selectedSampleOption = data.sampleSizeOption ?? PowerCheckOption.USE_POWER_CHECK;
 
+  const debouncedDesiredN = useDebounced(data.desiredN, 400);
+  const shouldEstimateMde =
+    selectedSampleOption === PowerCheckOption.ENTER_OWN && debouncedDesiredN !== undefined && debouncedDesiredN > 0;
+
+  const customPrimaryAnalysis = data.customPowerCheckResponse?.analyses.find(
+    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+  );
+  const estimatedMdePct =
+    customPrimaryAnalysis?.pct_change_with_desired_n != null
+      ? (customPrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
+      : null;
+
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
+
+  // Keep a ref to the latest data so the effect below can read it without making `data` a
+  // reactive dependency. This is intentional: we only want to fire the estimate request when
+  // the debounced desiredN value commits, not on every unrelated form field change.
+  const dataRef = useRef(data);
+  dataRef.current = data;
+
+  // useEffect is the right tool here because firing the estimate API call is a side effect that
+  // must be triggered by the *debounced* committed desiredN — not by each raw keystroke. Running
+  // it after render also ensures React has delivered the latest reducer-backed desiredN, so
+  // `convertToFrequentistDesignSpec` receives the correct `desired_n` in the request body.
+  useEffect(() => {
+    if (!shouldEstimateMde || debouncedDesiredN === undefined) return;
+    void triggerEstimatedMde({
+      design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: debouncedDesiredN }),
+    }).then((response) => {
+      if (response) {
+        dispatch({ type: 'set-custom-power-check-response', response });
+      }
+    });
+  }, [debouncedDesiredN, shouldEstimateMde, triggerEstimatedMde, dispatch]);
 
   const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -83,18 +123,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
       return;
     }
 
-    // TODO: reimplement this to be simpler
     try {
-      const design_spec = convertToFrequentistDesignSpec(data);
-      const response = await trigger({ design_spec });
+      const response = await trigger({ design_spec: convertToFrequentistDesignSpec(data) });
 
       const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
-      let desiredN = undefined;
-      let sampleSizeOption = PowerCheckOption.NONE;
-      if (primary?.sufficient_n) {
-        desiredN = primary?.target_n ?? undefined;
-        sampleSizeOption = PowerCheckOption.USE_POWER_CHECK;
-      }
+      const desiredN = primary?.sufficient_n ? (primary.target_n ?? undefined) : undefined;
+      const sampleSizeOption = desiredN === undefined ? PowerCheckOption.NONE : PowerCheckOption.USE_POWER_CHECK;
       dispatch({ type: 'set-power-check-response', response, desiredN, sampleSizeOption });
     } catch (err) {
       if (err instanceof ZodError) {
@@ -342,24 +376,33 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                     value={PowerCheckOption.ENTER_OWN}
                     disabled={allSamples === undefined || allSamples === 0}
                   >
-                    <Flex align="center" direction={'row'} gap="2">
-                      <span>Use custom sample size:</span>
-                      <div style={{ pointerEvents: 'auto' }}>
-                        <TextField.Root
-                          style={{ width: '250px' }}
-                          size="2"
-                          type="number"
-                          max={allSamples ?? undefined}
-                          value={selectedSampleOption === PowerCheckOption.ENTER_OWN ? (data.desiredN ?? '') : ''}
-                          onChange={(e) =>
-                            dispatch({
-                              type: 'set-chosen-n',
-                              value: e.target.value === '' ? undefined : Number(e.target.value),
-                            })
-                          }
-                          placeholder="Type your own desired #."
-                        />
-                      </div>
+                    <Flex align="start" direction="column" gap="2">
+                      <Flex align="center" direction="row" gap="2">
+                        <span>Use custom sample size:</span>
+                        <div style={{ pointerEvents: 'auto' }}>
+                          <TextField.Root
+                            style={{ width: '200px' }}
+                            size="2"
+                            type="number"
+                            max={allSamples ?? undefined}
+                            value={selectedSampleOption === PowerCheckOption.ENTER_OWN ? (data.desiredN ?? '') : ''}
+                            onChange={(e) =>
+                              dispatch({
+                                type: 'set-chosen-n',
+                                value: e.target.value === '' ? undefined : Number(e.target.value),
+                              })
+                            }
+                            placeholder="Enter desired N"
+                          />
+                        </div>
+                      </Flex>
+                      {selectedSampleOption === PowerCheckOption.ENTER_OWN ? (
+                        isEstimatingMde ? (
+                          <Spinner size="1" loading={true} />
+                        ) : estimatedMdePct !== null ? (
+                          <Badge color="purple">Estimated MDE: {estimatedMdePct}%</Badge>
+                        ) : null
+                      ) : null}
                     </Flex>
                   </RadioCards.Item>
                 </Flex>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -15,7 +15,11 @@ import {
   TextField,
   Tooltip,
 } from '@radix-ui/themes';
-import { PowerCheckSampleOptionChange, PowerCheckSampleSizeSelector } from './power-check-sample-size-selector';
+import {
+  PowerCheckResponseChange,
+  PowerCheckSampleOptionChange,
+  PowerCheckSampleSizeSelector,
+} from './power-check-sample-size-selector';
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
 import { ExperimentFormData } from './experiment-form-types';
 import { PowerCheckOption } from './experiment-form-types';
@@ -30,7 +34,7 @@ export type PowerCheckSectionAction =
   | { type: 'set-confidence'; value: string }
   | { type: 'set-power'; value: string }
   | ({ type: 'set-chosen-n' } & PowerCheckSampleOptionChange)
-  | ({ type: 'set-power-check-response' } & PowerCheckSampleOptionChange);
+  | ({ type: 'set-power-check-response' } & PowerCheckResponseChange);
 
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
@@ -92,12 +96,13 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
 
     try {
-      const response = await triggerEstimateSampleSize({ design_spec: convertToFrequentistDesignSpec(data) });
+      const designSpec = convertToFrequentistDesignSpec(data);
+      const response = await triggerEstimateSampleSize({ design_spec: designSpec });
 
       const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
       const desiredN = primary?.sufficient_n ? (primary.target_n ?? undefined) : undefined;
       const sampleSizeOption = desiredN === undefined ? PowerCheckOption.NONE : PowerCheckOption.USE_POWER_CHECK;
-      dispatch({ type: 'set-power-check-response', response, desiredN, sampleSizeOption });
+      dispatch({ type: 'set-power-check-response', response, desiredN, sampleSizeOption, designSpec });
     } catch (err) {
       if (err instanceof ZodError) {
         setValidationError(err);
@@ -107,8 +112,8 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
   };
 
-  const handleEstimatedMDEChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
-    dispatch({ type: 'set-power-check-response', sampleSizeOption, desiredN, response });
+  const handleEstimatedMDEChange = ({ sampleSizeOption, desiredN, response, designSpec }: PowerCheckResponseChange) => {
+    dispatch({ type: 'set-power-check-response', sampleSizeOption, desiredN, response, designSpec });
   };
 
   const handleSampleOptionChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -18,8 +18,8 @@ import {
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
 import { ExperimentFormData } from './experiment-form-def';
 import { PowerCheckOption } from './experiment-form-types';
-import { ExperimentFreqStackScreenMessage } from './experiment-freq-stack-screen';
 import { usePowerCheck } from '@/api/admin';
+import { PowerResponseOutput } from '@/api/methods.schemas';
 import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
@@ -27,9 +27,26 @@ import { useEffect, useRef, useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { useDebounced } from '@/providers/use-debounced';
 
+export type PowerCheckSectionAction =
+  | { type: 'set-confidence'; value: string }
+  | { type: 'set-power'; value: string }
+  | {
+      type: 'set-power-check-response';
+      response: PowerResponseOutput;
+      desiredN?: number;
+      sampleSizeOption?: PowerCheckOption;
+    }
+  | {
+      type: 'set-chosen-n';
+      desiredN: number | undefined;
+      sampleSizeOption: PowerCheckOption;
+      mdePowerCheckResponse?: PowerResponseOutput;
+    }
+  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
+
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
-  dispatch: (msg: ExperimentFreqStackScreenMessage) => void;
+  dispatch: (action: PowerCheckSectionAction) => void;
 }
 
 const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData) => {

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -100,7 +100,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const estimatedMdePct =
     customPrimaryAnalysis?.pct_change_with_desired_n != null
       ? (customPrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
-      : null;
+      : 'N/A';
 
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
@@ -375,40 +375,57 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                     value={PowerCheckOption.USE_POWER_CHECK}
                     disabled={powerCheckTarget === undefined || powerCheckTarget === 0}
                   >
-                    Use minimum sample required: {powerCheckTarget ?? 'N/A'}
+                    <Flex align="center" direction="column" gap="2">
+                      <Text size="2">Use minimum sample required:</Text>
+                      <Text size="2">{powerCheckTarget ?? 'N/A'}</Text>
+                      <Flex align="center" style={{ minHeight: '24px' }}>
+                        {data.primaryMetric?.mde !== undefined && (
+                          <Badge color="purple" variant="soft" size="2">
+                            Target MDE: {data.primaryMetric.mde}%
+                          </Badge>
+                        )}
+                      </Flex>
+                    </Flex>
                   </RadioCards.Item>
                   <RadioCards.Item
                     value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
                     disabled={nonNullSamples === undefined || nonNullSamples === 0}
                   >
-                    Use all available non-null samples: {nonNullSamples}
+                    <Flex align="center" direction="column" gap="2">
+                      <Text size="2">Use all available non-null samples:</Text>
+                      <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
+                      <Flex align="center" style={{ minHeight: '24px' }}></Flex>
+                    </Flex>
                   </RadioCards.Item>
                   <RadioCards.Item
                     value={PowerCheckOption.ENTER_OWN}
                     disabled={allSamples === undefined || allSamples === 0}
                   >
-                    <Flex align="start" direction="column" gap="2">
-                      <Flex align="center" direction="row" gap="2">
-                        <span>Use custom sample size:</span>
-                        <div style={{ pointerEvents: 'auto' }}>
-                          <TextField.Root
-                            style={{ width: '200px' }}
-                            size="2"
-                            type="number"
-                            max={allSamples ?? undefined}
-                            value={selectedSampleOption === PowerCheckOption.ENTER_OWN ? draftN : ''}
-                            onChange={(e) => setDraftN(e.target.value)}
-                            placeholder="Enter desired N"
-                          />
-                        </div>
+                    <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
+                      <Text size="2">Use custom sample size:</Text>
+                      <TextField.Root
+                        style={{ width: '150px' }}
+                        size="2"
+                        type="number"
+                        min={1}
+                        max={allSamples ?? undefined}
+                        value={draftN}
+                        onChange={(e) => setDraftN(e.target.value)}
+                        placeholder="Enter your desired N"
+                      />
+                      <Flex align="center" style={{ minHeight: '24px' }}>
+                        {selectedSampleOption === PowerCheckOption.ENTER_OWN && isEstimatingMde && (
+                          <Badge color="purple" variant="soft" size="2">
+                            Estimated MDE: …
+                            <Spinner size="1" />
+                          </Badge>
+                        )}
+                        {!isEstimatingMde && draftN !== '' && (
+                          <Badge color="purple" variant="soft" size="2">
+                            Estimated MDE: {estimatedMdePct}%
+                          </Badge>
+                        )}
                       </Flex>
-                      {selectedSampleOption === PowerCheckOption.ENTER_OWN ? (
-                        isEstimatingMde ? (
-                          <Spinner size="1" loading={true} />
-                        ) : estimatedMdePct !== null ? (
-                          <Badge color="purple">Estimated MDE: {estimatedMdePct}%</Badge>
-                        ) : null
-                      ) : null}
                     </Flex>
                   </RadioCards.Item>
                 </Flex>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -63,14 +63,27 @@ function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProp
   );
 }
 
+function getValidDraftN(input: string): number | undefined {
+  const parsed = input === '' ? undefined : Number(input);
+  return parsed !== undefined && !isNaN(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
-  const { trigger, isMutating, error } = usePowerCheck(data.datasourceId!);
+  const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
   // Separate mutation with a distinct SWR key so it doesn't share cache or conflict with the
   // main power-check mutation above.
-  const { trigger: triggerEstimatedMde, isMutating: isEstimatingMde } = usePowerCheck(data.datasourceId!, {
+  const { trigger: triggerEstimateMde, isMutating: isEstimatingMde } = usePowerCheck(data.datasourceId!, {
     swr: { swrKey: `${data.datasourceId}/power/mde-estimate` },
   });
   const [validationError, setValidationError] = useState<ZodError | null>(null);
+  // Local draft state for the custom N input. Kept separate from data.desiredN so that the effect
+  // only fires after the debounce settles on a value the user actually typed, not immediately when
+  // the user switches to ENTER_OWN with a previously-committed value.
+  // Initialised from data.desiredN so the input is pre-filled when returning to this screen.
+  const [draftN, setDraftN] = useState<string>(
+    data.sampleSizeOption === PowerCheckOption.ENTER_OWN && data.desiredN !== undefined ? String(data.desiredN) : '',
+  );
+  const debouncedValidDraftN = useDebounced(getValidDraftN(draftN), 400);
 
   const primaryAnalysis = data.powerCheckResponse?.analyses.find(
     (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
@@ -79,10 +92,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const nonNullSamples = primaryAnalysis?.metric_spec.available_nonnull_n ?? 0;
   const allSamples = primaryAnalysis?.metric_spec.available_n ?? 0;
   const selectedSampleOption = data.sampleSizeOption ?? PowerCheckOption.USE_POWER_CHECK;
-
-  const debouncedDesiredN = useDebounced(data.desiredN, 400);
-  const shouldEstimateMde =
-    selectedSampleOption === PowerCheckOption.ENTER_OWN && debouncedDesiredN !== undefined && debouncedDesiredN > 0;
+  const shouldEstimateMde = selectedSampleOption === PowerCheckOption.ENTER_OWN && debouncedValidDraftN !== undefined;
 
   const customPrimaryAnalysis = data.customPowerCheckResponse?.analyses.find(
     (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
@@ -94,27 +104,27 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
-  // A ref so the effect always reads the latest form data without making `data` a reactive
-  // dependency. `data` changes whenever any field updates — including when the effect's own
-  // dispatch sets `customPowerCheckResponse` — so including it in deps would retrigger the
-  // effect after every successful estimate, producing an infinite request loop.
+  // A ref so our useEffect for triggering MDE mode always reads the latest form data without making
+  // `data` a reactive dependency. `data.customPowerCheckResponse` changes when the effect's own
+  // dispatch completes, so including `data` in deps would retrigger the effect after every
+  // successful estimate, producing an infinite request loop.
   const dataRef = useRef(data);
   dataRef.current = data;
 
-  // useEffect because we only want to estimate with the *debounced* committed desiredN — not by
-  // each raw keystroke. Running it after render also ensures we have the latest reducer-backed
-  // desiredN to use with `convertToFrequentistDesignSpec` for the request body.  `dispatch` is
-  // stable thanks to the Wizard's ScreenRenderer, while SWR gives us a stable `trigger` function.
+  // useEffect because we need a side effect (API call) triggered by the debounced draft value,
+  // not by each raw keystroke. `dispatch` is stable thanks to ScreenRenderer's useCallback in
+  // Wizard.tsx; `triggerEstimateMde` is stable from useSWRMutation.
   useEffect(() => {
-    if (!shouldEstimateMde || debouncedDesiredN === undefined) return;
-    void triggerEstimatedMde({
-      design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: debouncedDesiredN }),
-    }).then((response) => {
+    if (!shouldEstimateMde || debouncedValidDraftN === undefined) return;
+    void (async () => {
+      const response = await triggerEstimateMde({
+        design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: debouncedValidDraftN }),
+      });
       if (response) {
-        dispatch({ type: 'set-custom-power-check-response', response });
+        dispatch({ type: 'set-custom-power-check-response', response, desiredN: debouncedValidDraftN });
       }
-    });
-  }, [debouncedDesiredN, shouldEstimateMde, triggerEstimatedMde, dispatch]);
+    })();
+  }, [debouncedValidDraftN, shouldEstimateMde, triggerEstimateMde, dispatch]);
 
   const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -125,7 +135,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
 
     try {
-      const response = await trigger({ design_spec: convertToFrequentistDesignSpec(data) });
+      const response = await triggerEstimateSampleSize({ design_spec: convertToFrequentistDesignSpec(data) });
 
       const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
       const desiredN = primary?.sufficient_n ? (primary.target_n ?? undefined) : undefined;
@@ -386,13 +396,8 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             size="2"
                             type="number"
                             max={allSamples ?? undefined}
-                            value={selectedSampleOption === PowerCheckOption.ENTER_OWN ? (data.desiredN ?? '') : ''}
-                            onChange={(e) =>
-                              dispatch({
-                                type: 'set-chosen-n',
-                                value: e.target.value === '' ? undefined : Number(e.target.value),
-                              })
-                            }
+                            value={selectedSampleOption === PowerCheckOption.ENTER_OWN ? draftN : ''}
+                            onChange={(e) => setDraftN(e.target.value)}
                             placeholder="Enter desired N"
                           />
                         </div>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -164,22 +164,33 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
   };
 
-  const handleSampleOptionChange = (value: PowerCheckOption) => {
-    dispatch({ type: 'set-sample-size-option', value });
-    switch (value) {
+  const handleSampleOptionChange = (option: PowerCheckOption) => {
+    // For the MDE estimation options (USE_ALL_NON_NULL_SAMPLES and ENTER_OWN), we also reset the
+    // MDE response if the value selected differs from the current data.desiredN.
+    switch (option) {
       case PowerCheckOption.USE_POWER_CHECK:
-        dispatch({ type: 'set-chosen-n', value: powerCheckTargetN });
+        dispatch({ type: 'set-chosen-n', desiredN: powerCheckTargetN, sampleSizeOption: option });
         break;
       case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
-        dispatch({ type: 'set-chosen-n', value: nonNullSamples });
+        dispatch({
+          type: 'set-chosen-n',
+          desiredN: nonNullSamples,
+          sampleSizeOption: option,
+          mdePowerCheckResponse: data.desiredN !== nonNullSamples ? undefined : data.mdePowerCheckResponse,
+        });
         setDraftN(String(nonNullSamples));
         break;
       case PowerCheckOption.ENTER_OWN:
-        dispatch({ type: 'set-chosen-n', value: debouncedValidDraftN });
+        dispatch({
+          type: 'set-chosen-n',
+          desiredN: debouncedValidDraftN,
+          sampleSizeOption: option,
+          mdePowerCheckResponse: data.desiredN !== debouncedValidDraftN ? undefined : data.mdePowerCheckResponse,
+        });
         setDraftN(String(debouncedValidDraftN));
         break;
       case PowerCheckOption.NONE:
-        dispatch({ type: 'set-chosen-n', value: undefined });
+        dispatch({ type: 'set-chosen-n', desiredN: undefined, sampleSizeOption: option });
         break;
     }
   };

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -9,13 +9,12 @@ import {
   Flex,
   Grid,
   Heading,
-  RadioCards,
   Spinner,
   Table,
   Text,
   TextField,
 } from '@radix-ui/themes';
-import { PowerCheckDesiredNInput } from './power-check-desired-n-input';
+import { PowerCheckSampleOptionChange, PowerCheckSampleSizeSelector } from './power-check-sample-size-selector';
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
 import { ExperimentFormData } from './experiment-form-def';
 import { PowerCheckOption } from './experiment-form-types';
@@ -24,7 +23,7 @@ import { PowerResponseOutput } from '@/api/methods.schemas';
 import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
 
 export type PowerCheckSectionAction =
@@ -32,17 +31,10 @@ export type PowerCheckSectionAction =
   | { type: 'set-power'; value: string }
   | {
       type: 'set-power-check-response';
-      response: PowerResponseOutput;
-      desiredN?: number;
-      sampleSizeOption?: PowerCheckOption;
-    }
-  | {
-      type: 'set-chosen-n';
-      desiredN: number | undefined;
       sampleSizeOption: PowerCheckOption;
-      mdePowerCheckResponse?: PowerResponseOutput;
-    }
-  | { type: 'set-custom-power-check-response'; response: PowerResponseOutput; desiredN: number };
+      desiredN?: number;
+      response?: PowerResponseOutput;
+    };
 
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
@@ -82,75 +74,9 @@ function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProp
 
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
-  // Separate mutation with a distinct SWR key so it doesn't share cache or conflict with the
-  // main power-check mutation above. Reused for both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES:
-  // the two effects are mutually exclusive (only one option is active at a time).
-  const { trigger: triggerEstimateMde, isMutating: isEstimatingMde } = usePowerCheck(data.datasourceId!, {
-    swr: { swrKey: `${data.datasourceId}/power/mde-estimate` },
-  });
   const [validationError, setValidationError] = useState<ZodError | null>(null);
-  // Local draft state for the custom N input, separate from data.desiredN so that we can validate
-  // and debounce it before making our API call. Pre-filled from data.desiredN when returning to
-  // this screen (used for both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES since both commit desiredN).
-  const [draftN, setDraftN] = useState<string>(() => {
-    const isMdeMode =
-      data.sampleSizeOption === PowerCheckOption.ENTER_OWN ||
-      data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES;
-    return isMdeMode && data.desiredN !== undefined ? String(data.desiredN) : '';
-  });
-  const [debouncedValidDraftN, setDebouncedValidDraftN] = useState<number | undefined>(undefined);
-
-  const primaryAnalysis = data.powerCheckResponse?.analyses.find(
-    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-  );
-  const powerCheckTargetN = primaryAnalysis?.target_n ?? undefined;
-  const nonNullSamples = primaryAnalysis?.metric_spec.available_nonnull_n ?? 0;
-  const allSamples = primaryAnalysis?.metric_spec.available_n ?? 0;
-  const selectedSampleOption = data.sampleSizeOption ?? PowerCheckOption.USE_POWER_CHECK;
-  // Both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES flow through the same debounced estimate —
-  // USE_ALL_NON_NULL_SAMPLES just auto-populates draftN with its fixed value.
-  const shouldEstimateMde =
-    (selectedSampleOption === PowerCheckOption.ENTER_OWN ||
-      selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES) &&
-    debouncedValidDraftN !== undefined;
-
-  const mdePrimaryAnalysis = data.mdePowerCheckResponse?.analyses.find(
-    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-  );
-  const estimatedMdePct =
-    mdePrimaryAnalysis?.pct_change_with_desired_n != null
-      ? (mdePrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
-      : 'N/A';
 
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
-
-  // Maintain a ref to the latest form data for the MDE estimation useEffect to avoid making `data`
-  // a dependency, which otherwise would cause an infinite request loop, as the useEffect dispatches
-  // updates to `data.mdePowerCheckResponse`.
-  const dataRef = useRef(data);
-  dataRef.current = data;
-
-  // Triggers an MDE estimate with the debounced draftN (used by both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES).
-  // `dispatch` and `triggerEstimateMde` are stable references (useCallback / useSWRMutation).
-  useEffect(() => {
-    if (!shouldEstimateMde || debouncedValidDraftN === undefined) return;
-
-    let cancelled = false;
-    // Capture the active option so a response arriving after a mode switch is discarded.
-    const optionAtStart = dataRef.current.sampleSizeOption;
-    void (async () => {
-      const response = await triggerEstimateMde({
-        design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: debouncedValidDraftN }),
-      });
-      if (response && !cancelled && dataRef.current.sampleSizeOption === optionAtStart) {
-        dispatch({ type: 'set-custom-power-check-response', response, desiredN: debouncedValidDraftN });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [debouncedValidDraftN, shouldEstimateMde, triggerEstimateMde, dispatch]);
 
   const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -176,35 +102,8 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
   };
 
-  const handleSampleOptionChange = (option: PowerCheckOption) => {
-    // For the MDE estimation options (USE_ALL_NON_NULL_SAMPLES and ENTER_OWN), we also reset the
-    // MDE response if the value selected differs from the current data.desiredN.
-    switch (option) {
-      case PowerCheckOption.USE_POWER_CHECK:
-        dispatch({ type: 'set-chosen-n', desiredN: powerCheckTargetN, sampleSizeOption: option });
-        break;
-      case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
-        dispatch({
-          type: 'set-chosen-n',
-          desiredN: nonNullSamples,
-          sampleSizeOption: option,
-          mdePowerCheckResponse: data.desiredN !== nonNullSamples ? undefined : data.mdePowerCheckResponse,
-        });
-        setDraftN(String(nonNullSamples));
-        break;
-      case PowerCheckOption.ENTER_OWN:
-        dispatch({
-          type: 'set-chosen-n',
-          desiredN: debouncedValidDraftN,
-          sampleSizeOption: option,
-          mdePowerCheckResponse: data.desiredN !== debouncedValidDraftN ? undefined : data.mdePowerCheckResponse,
-        });
-        setDraftN(String(debouncedValidDraftN));
-        break;
-      case PowerCheckOption.NONE:
-        dispatch({ type: 'set-chosen-n', desiredN: undefined, sampleSizeOption: option });
-        break;
-    }
+  const handleSampleOptionChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
+    dispatch({ type: 'set-power-check-response', response, desiredN, sampleSizeOption });
   };
 
   const primaryPower =
@@ -410,83 +309,17 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                   </Callout.Text>
                 </Callout.Root>
               )}
-              <RadioCards.Root columns="1" value={selectedSampleOption} onValueChange={handleSampleOptionChange}>
-                <Flex direction={'row'} gap={'3'} justify={'between'}>
-                  <RadioCards.Item
-                    value={PowerCheckOption.USE_POWER_CHECK}
-                    disabled={powerCheckTargetN === undefined || powerCheckTargetN === 0}
-                  >
-                    <Flex align="center" direction="column" gap="2">
-                      <Text size="2">Use minimum sample required:</Text>
-                      <Flex height="32px" align="center">
-                        <Text size="2">{powerCheckTargetN ?? 'N/A'}</Text>
-                      </Flex>
-                      <Flex align="center" style={{ minHeight: '24px' }}>
-                        {data.primaryMetric?.mde !== undefined && (
-                          <Badge color="purple" variant="soft" size="2">
-                            Target MDE: {data.primaryMetric.mde}%
-                          </Badge>
-                        )}
-                      </Flex>
-                    </Flex>
-                  </RadioCards.Item>
-                  <RadioCards.Item
-                    value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-                    disabled={nonNullSamples === undefined || nonNullSamples === 0}
-                  >
-                    <Flex align="center" direction="column" gap="2">
-                      <Text size="2">Use all available non-null samples:</Text>
-                      <Flex height="32px" align="center">
-                        <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
-                      </Flex>
-
-                      <Flex align="center" style={{ minHeight: '24px' }}>
-                        {selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && isEstimatingMde && (
-                          <Badge color="purple" variant="soft" size="2">
-                            Estimated MDE: …
-                            <Spinner size="1" />
-                          </Badge>
-                        )}
-                        {selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
-                          !isEstimatingMde &&
-                          data.mdePowerCheckResponse !== undefined && (
-                            <Badge color="purple" variant="soft" size="2">
-                              Estimated MDE: {estimatedMdePct}%
-                            </Badge>
-                          )}
-                      </Flex>
-                    </Flex>
-                  </RadioCards.Item>
-                  <RadioCards.Item
-                    value={PowerCheckOption.ENTER_OWN}
-                    disabled={allSamples === undefined || allSamples === 0}
-                  >
-                    <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
-                      <Text size="2">Use custom sample size:</Text>
-                      <PowerCheckDesiredNInput
-                        value={draftN}
-                        onChange={setDebouncedValidDraftN}
-                        max={allSamples ?? undefined}
-                      />
-                      <Flex align="center" style={{ minHeight: '24px' }}>
-                        {selectedSampleOption === PowerCheckOption.ENTER_OWN && isEstimatingMde && (
-                          <Badge color="purple" variant="soft" size="2">
-                            Estimated MDE: …
-                            <Spinner size="1" />
-                          </Badge>
-                        )}
-                        {selectedSampleOption === PowerCheckOption.ENTER_OWN &&
-                          !isEstimatingMde &&
-                          data.mdePowerCheckResponse !== undefined && (
-                            <Badge color="purple" variant="soft" size="2">
-                              Estimated MDE: {estimatedMdePct}%
-                            </Badge>
-                          )}
-                      </Flex>
-                    </Flex>
-                  </RadioCards.Item>
-                </Flex>
-              </RadioCards.Root>
+              <PowerCheckSampleSizeSelector
+                datasourceId={data.datasourceId!}
+                powerCheckResponse={data.powerCheckResponse}
+                primaryMetricFieldName={data.primaryMetric!.metric.field_name}
+                targetMde={data.primaryMetric?.mde}
+                selectedSampleOption={data.sampleSizeOption ?? PowerCheckOption.USE_POWER_CHECK}
+                desiredN={data.desiredN}
+                mdePowerCheckResponse={data.mdePowerCheckResponse}
+                makeDesignSpec={(desiredN) => convertToFrequentistDesignSpec({ ...data, desiredN })}
+                onSampleOptionChange={handleSampleOptionChange}
+              />
             </Flex>
           </Flex>
         </SectionCard>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -312,17 +312,17 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 
       {data.powerCheckResponse !== undefined && !validationError && (
         <SectionCard title="Select Target Sample Size">
-          <Flex direction="column" gap="3" align="start">
-            <Text>Select target sample size to distribute across all arms:</Text>
-            <Flex direction="column" gap="2" align="center">
+          <Flex direction="column" gap="3" align="start" width="100%">
+            <Text>Choose the total number of participants to distribute across all arms:</Text>
+            <Flex direction="column" gap="2" align="center" width="100%">
               {!data.powerCheckResponse.analyses.map((a) => a.sufficient_n).every((sufficient) => sufficient) && (
                 <Callout.Root color="orange">
                   <Callout.Icon>
                     <CrossCircledIcon />
                   </Callout.Icon>
                   <Callout.Text>
-                    You don&apos;t have sufficient samples for one or more metrics. You can still proceed with a custom
-                    sample size, but consider adjusting your experiment design.
+                    You don&apos;t have a sufficient sample size for one or more metrics. You can still proceed with a
+                    custom sample size, but consider adjusting your experiment design.
                   </Callout.Text>
                 </Callout.Root>
               )}

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -94,16 +94,17 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
-  // Keep a ref to the latest data so the effect below can read it without making `data` a
-  // reactive dependency. This is intentional: we only want to fire the estimate request when
-  // the debounced desiredN value commits, not on every unrelated form field change.
+  // A ref so the effect always reads the latest form data without making `data` a reactive
+  // dependency. `data` changes whenever any field updates — including when the effect's own
+  // dispatch sets `customPowerCheckResponse` — so including it in deps would retrigger the
+  // effect after every successful estimate, producing an infinite request loop.
   const dataRef = useRef(data);
   dataRef.current = data;
 
-  // useEffect is the right tool here because firing the estimate API call is a side effect that
-  // must be triggered by the *debounced* committed desiredN — not by each raw keystroke. Running
-  // it after render also ensures React has delivered the latest reducer-backed desiredN, so
-  // `convertToFrequentistDesignSpec` receives the correct `desired_n` in the request body.
+  // useEffect because we only want to estimate with the *debounced* committed desiredN — not by
+  // each raw keystroke. Running it after render also ensures we have the latest reducer-backed
+  // desiredN to use with `convertToFrequentistDesignSpec` for the request body.  `dispatch` is
+  // stable thanks to the Wizard's ScreenRenderer, while SWR gives us a stable `trigger` function.
   useEffect(() => {
     if (!shouldEstimateMde || debouncedDesiredN === undefined) return;
     void triggerEstimatedMde({

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -77,85 +77,68 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     swr: { swrKey: `${data.datasourceId}/power/mde-estimate` },
   });
   const [validationError, setValidationError] = useState<ZodError | null>(null);
-  // Local draft state for the custom N input. Kept separate from data.desiredN so that the effect
-  // only fires after the debounce settles on a value the user actually typed, not immediately when
-  // the user switches to ENTER_OWN with a previously-committed value.
-  // Initialised from data.desiredN so the input is pre-filled when returning to this screen.
-  const [draftN, setDraftN] = useState<string>(
-    data.sampleSizeOption === PowerCheckOption.ENTER_OWN && data.desiredN !== undefined ? String(data.desiredN) : '',
-  );
+  // Local draft state for the custom N input, separate from data.desiredN so that we can validate
+  // and debounce it before making our API call. Pre-filled from data.desiredN when returning to
+  // this screen (used for both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES since both commit desiredN).
+  const [draftN, setDraftN] = useState<string>(() => {
+    const isMdeMode =
+      data.sampleSizeOption === PowerCheckOption.ENTER_OWN ||
+      data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES;
+    return isMdeMode && data.desiredN !== undefined ? String(data.desiredN) : '';
+  });
   const debouncedValidDraftN = useDebounced(getValidDraftN(draftN), 400);
 
   const primaryAnalysis = data.powerCheckResponse?.analyses.find(
     (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
   );
-  const powerCheckTarget = primaryAnalysis?.target_n ?? undefined;
+  const powerCheckTargetN = primaryAnalysis?.target_n ?? undefined;
   const nonNullSamples = primaryAnalysis?.metric_spec.available_nonnull_n ?? 0;
   const allSamples = primaryAnalysis?.metric_spec.available_n ?? 0;
   const selectedSampleOption = data.sampleSizeOption ?? PowerCheckOption.USE_POWER_CHECK;
-  const shouldEstimateMde = selectedSampleOption === PowerCheckOption.ENTER_OWN && debouncedValidDraftN !== undefined;
+  // Both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES flow through the same debounced estimate —
+  // USE_ALL_NON_NULL_SAMPLES just auto-populates draftN with its fixed value.
+  const shouldEstimateMde =
+    (selectedSampleOption === PowerCheckOption.ENTER_OWN ||
+      selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES) &&
+    debouncedValidDraftN !== undefined;
 
-  const customPrimaryAnalysis = data.customPowerCheckResponse?.analyses.find(
+  const mdePrimaryAnalysis = data.mdePowerCheckResponse?.analyses.find(
     (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
   );
   const estimatedMdePct =
-    customPrimaryAnalysis?.pct_change_with_desired_n != null
-      ? (customPrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
+    mdePrimaryAnalysis?.pct_change_with_desired_n != null
+      ? (mdePrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
       : 'N/A';
-
-  const nonNullPrimaryAnalysis = data.nonNullSamplesPowerCheckResponse?.analyses.find(
-    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
-  );
-  const estimatedNonNullMdePct =
-    nonNullPrimaryAnalysis?.pct_change_with_desired_n != null
-      ? (nonNullPrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
-      : 'N/A';
-
-  const shouldEstimateNonNullMde =
-    selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && nonNullSamples > 0;
 
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
-  // A ref so our useEffect for triggering MDE mode always reads the latest form data without making
-  // `data` a reactive dependency. `data.customPowerCheckResponse` changes when the effect's own
-  // dispatch completes, so including `data` in deps would retrigger the effect after every
-  // successful estimate, producing an infinite request loop.
+  // Maintain a ref to the latest form data for the MDE estimation useEffect to avoid making `data`
+  // a dependency, which otherwise would cause an infinite request loop, as the useEffect dispatches
+  // updates to `data.mdePowerCheckResponse`.
   const dataRef = useRef(data);
   dataRef.current = data;
 
-  // useEffect because we need a side effect (API call) triggered by the debounced draft value,
-  // not by each raw keystroke. `dispatch` is stable thanks to ScreenRenderer's useCallback in
-  // Wizard.tsx; `triggerEstimateMde` is stable from useSWRMutation.
+  // Triggers an MDE estimate with the debounced draftN (used by both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES).
+  // `dispatch` and `triggerEstimateMde` are stable references (useCallback / useSWRMutation).
   useEffect(() => {
     if (!shouldEstimateMde || debouncedValidDraftN === undefined) return;
 
+    let cancelled = false;
+    // Capture the active option so a response arriving after a mode switch is discarded.
+    const optionAtStart = dataRef.current.sampleSizeOption;
     void (async () => {
       const response = await triggerEstimateMde({
         design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: debouncedValidDraftN }),
       });
-      // Ok to update this pair of values because its use is dependent on sampleSizeOption.
-      if (response) {
+      if (response && !cancelled && dataRef.current.sampleSizeOption === optionAtStart) {
         dispatch({ type: 'set-custom-power-check-response', response, desiredN: debouncedValidDraftN });
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [debouncedValidDraftN, shouldEstimateMde, triggerEstimateMde, dispatch]);
-
-  // Same pattern for USE_ALL_NON_NULL_SAMPLES: estimate the MDE achievable with all non-null
-  // samples so we can display it inline. `nonNullSamples` is a stable number derived from the
-  // power-check response, so this only re-fires when the option changes or a new power check runs.
-  useEffect(() => {
-    if (!shouldEstimateNonNullMde) return;
-
-    void (async () => {
-      const response = await triggerEstimateMde({
-        design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: nonNullSamples }),
-      });
-      // Ok to update this pair of values because its use is dependent on sampleSizeOption.
-      if (response) {
-        dispatch({ type: 'set-non-null-samples-power-check-response', response });
-      }
-    })();
-  }, [nonNullSamples, shouldEstimateNonNullMde, triggerEstimateMde, dispatch]);
 
   const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -185,12 +168,16 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     dispatch({ type: 'set-sample-size-option', value });
     switch (value) {
       case PowerCheckOption.USE_POWER_CHECK:
-        dispatch({ type: 'set-chosen-n', value: powerCheckTarget });
+        dispatch({ type: 'set-chosen-n', value: powerCheckTargetN });
         break;
       case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
         dispatch({ type: 'set-chosen-n', value: nonNullSamples });
+        setDraftN(String(nonNullSamples));
         break;
       case PowerCheckOption.ENTER_OWN:
+        dispatch({ type: 'set-chosen-n', value: debouncedValidDraftN });
+        setDraftN(String(debouncedValidDraftN));
+        break;
       case PowerCheckOption.NONE:
         dispatch({ type: 'set-chosen-n', value: undefined });
         break;
@@ -404,12 +391,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                 <Flex direction={'row'} gap={'3'} justify={'between'}>
                   <RadioCards.Item
                     value={PowerCheckOption.USE_POWER_CHECK}
-                    disabled={powerCheckTarget === undefined || powerCheckTarget === 0}
+                    disabled={powerCheckTargetN === undefined || powerCheckTargetN === 0}
                   >
                     <Flex align="center" direction="column" gap="2">
                       <Text size="2">Use minimum sample required:</Text>
                       <Flex height="32px" align="center">
-                        <Text size="2">{powerCheckTarget ?? 'N/A'}</Text>
+                        <Text size="2">{powerCheckTargetN ?? 'N/A'}</Text>
                       </Flex>
                       <Flex align="center" style={{ minHeight: '24px' }}>
                         {data.primaryMetric?.mde !== undefined && (
@@ -437,10 +424,11 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             <Spinner size="1" />
                           </Badge>
                         )}
-                        {!(isEstimatingMde && nonNullPrimaryAnalysis !== undefined) &&
-                          data.nonNullSamplesPowerCheckResponse !== undefined && (
+                        {selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES &&
+                          !isEstimatingMde &&
+                          data.mdePowerCheckResponse !== undefined && (
                             <Badge color="purple" variant="soft" size="2">
-                              Estimated MDE: {estimatedNonNullMdePct}%
+                              Estimated MDE: {estimatedMdePct}%
                             </Badge>
                           )}
                       </Flex>
@@ -459,10 +447,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         min={1}
                         max={allSamples ?? undefined}
                         value={draftN}
-                        onChange={(e) => {
-                          setDraftN(e.target.value);
-                          dispatch({ type: 'clear-custom-power-check-response' });
-                        }}
+                        onChange={(e) => setDraftN(e.target.value)}
                         placeholder="Enter your desired N"
                       />
                       <Flex align="center" style={{ minHeight: '24px' }}>
@@ -472,11 +457,13 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             <Spinner size="1" />
                           </Badge>
                         )}
-                        {!isEstimatingMde && draftN !== '' && customPrimaryAnalysis !== undefined && (
-                          <Badge color="purple" variant="soft" size="2">
-                            Estimated MDE: {estimatedMdePct}%
-                          </Badge>
-                        )}
+                        {selectedSampleOption === PowerCheckOption.ENTER_OWN &&
+                          !isEstimatingMde &&
+                          data.mdePowerCheckResponse !== undefined && (
+                            <Badge color="purple" variant="soft" size="2">
+                              Estimated MDE: {estimatedMdePct}%
+                            </Badge>
+                          )}
                       </Flex>
                     </Flex>
                   </RadioCards.Item>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -28,6 +28,7 @@ import { SectionCard } from '@/components/ui/cards/section-card';
 export type PowerCheckSectionAction =
   | { type: 'set-confidence'; value: string }
   | { type: 'set-power'; value: string }
+  | ({ type: 'set-chosen-n' } & PowerCheckSampleOptionChange)
   | ({ type: 'set-power-check-response' } & PowerCheckSampleOptionChange);
 
 interface PowerCheckSectionProps {
@@ -97,6 +98,10 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   };
 
   const handleSampleOptionChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
+    dispatch({ type: 'set-chosen-n', response, desiredN, sampleSizeOption });
+  };
+
+  const handleEstimatedMDEChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
     dispatch({ type: 'set-power-check-response', response, desiredN, sampleSizeOption });
   };
 
@@ -313,6 +318,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                 mdePowerCheckResponse={data.mdePowerCheckResponse}
                 makeDesignSpec={(desiredN) => convertToFrequentistDesignSpec({ ...data, desiredN })}
                 onOptionChange={handleSampleOptionChange}
+                onEstimatedMDEChange={handleEstimatedMDEChange}
               />
             </Flex>
           </Flex>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -19,7 +19,6 @@ import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui
 import { ExperimentFormData } from './experiment-form-def';
 import { PowerCheckOption } from './experiment-form-types';
 import { usePowerCheck } from '@/api/admin';
-import { PowerResponseOutput } from '@/api/methods.schemas';
 import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
@@ -29,12 +28,7 @@ import { SectionCard } from '@/components/ui/cards/section-card';
 export type PowerCheckSectionAction =
   | { type: 'set-confidence'; value: string }
   | { type: 'set-power'; value: string }
-  | {
-      type: 'set-power-check-response';
-      sampleSizeOption: PowerCheckOption;
-      desiredN?: number;
-      response?: PowerResponseOutput;
-    };
+  | ({ type: 'set-power-check-response' } & PowerCheckSampleOptionChange);
 
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
@@ -318,7 +312,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                 desiredN={data.desiredN}
                 mdePowerCheckResponse={data.mdePowerCheckResponse}
                 makeDesignSpec={(desiredN) => convertToFrequentistDesignSpec({ ...data, desiredN })}
-                onSampleOptionChange={handleSampleOptionChange}
+                onOptionChange={handleSampleOptionChange}
               />
             </Flex>
           </Flex>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   TextField,
 } from '@radix-ui/themes';
+import { PowerCheckDesiredNInput } from './power-check-desired-n-input';
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
 import { ExperimentFormData } from './experiment-form-def';
 import { PowerCheckOption } from './experiment-form-types';
@@ -25,7 +26,6 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
 import { useEffect, useRef, useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
-import { useDebounced } from '@/providers/use-debounced';
 
 export type PowerCheckSectionAction =
   | { type: 'set-confidence'; value: string }
@@ -80,11 +80,6 @@ function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProp
   );
 }
 
-function getValidDraftN(input: string): number | undefined {
-  const parsed = input === '' ? undefined : Number(input);
-  return parsed !== undefined && !isNaN(parsed) && parsed > 0 ? parsed : undefined;
-}
-
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
   // Separate mutation with a distinct SWR key so it doesn't share cache or conflict with the
@@ -103,7 +98,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
       data.sampleSizeOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES;
     return isMdeMode && data.desiredN !== undefined ? String(data.desiredN) : '';
   });
-  const debouncedValidDraftN = useDebounced(getValidDraftN(draftN), 400);
+  const [debouncedValidDraftN, setDebouncedValidDraftN] = useState<number | undefined>(undefined);
 
   const primaryAnalysis = data.powerCheckResponse?.analyses.find(
     (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
@@ -468,15 +463,10 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                   >
                     <Flex align="center" direction="column" gap="2" style={{ pointerEvents: 'auto' }}>
                       <Text size="2">Use custom sample size:</Text>
-                      <TextField.Root
-                        style={{ width: '150px' }}
-                        size="2"
-                        type="number"
-                        min={1}
-                        max={allSamples ?? undefined}
+                      <PowerCheckDesiredNInput
                         value={draftN}
-                        onChange={(e) => setDraftN(e.target.value)}
-                        placeholder="Enter your desired N"
+                        onChange={setDebouncedValidDraftN}
+                        max={allSamples ?? undefined}
                       />
                       <Flex align="center" style={{ minHeight: '24px' }}>
                         {selectedSampleOption === PowerCheckOption.ENTER_OWN && isEstimatingMde && (

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -53,14 +53,14 @@ const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData
 
 interface PowerCheckButtonProps {
   enabled: boolean;
-  onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
+  onClick: () => Promise<void>;
   loading: boolean;
   disabledReason?: string;
 }
 
 function RunPowerCheckButton({ enabled, onClick, loading, disabledReason }: PowerCheckButtonProps) {
   const button = (
-    <Button disabled={!enabled} onClick={onClick} style={{ minWidth: '25%' }}>
+    <Button type="button" disabled={!enabled} onClick={onClick} style={{ minWidth: '25%' }}>
       <Spinner loading={loading}>
         <LightningBoltIcon />
       </Spinner>
@@ -84,8 +84,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
   const { enabled, reason } = isPowerCheckButtonEnabled(isMutating, data);
 
-  const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
+  const handlePowerCheck = async () => {
     setValidationError(null);
 
     if (!data.tableName || !data.primaryKey || !data.primaryMetric) {
@@ -116,11 +115,14 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     dispatch({ type: 'set-chosen-n', sampleSizeOption, desiredN, response });
   };
 
+  const primaryMetricFieldName = data.primaryMetric?.metric.field_name ?? '';
   const primaryPower =
-    data.powerCheckResponse !== undefined && !validationError ? data.powerCheckResponse.analyses[0] : undefined;
+    data.powerCheckResponse !== undefined && !validationError
+      ? data.powerCheckResponse.analyses.find((a) => a.metric_spec.field_name === primaryMetricFieldName)
+      : undefined;
   const restPower =
-    data.powerCheckResponse !== undefined && !validationError && data.powerCheckResponse.analyses.length > 1
-      ? data.powerCheckResponse.analyses.slice(1)
+    data.powerCheckResponse !== undefined && !validationError
+      ? data.powerCheckResponse.analyses.filter((a) => a.metric_spec.field_name !== primaryMetricFieldName)
       : undefined;
 
   return (
@@ -327,7 +329,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
               <PowerCheckSampleSizeSelector
                 datasourceId={data.datasourceId!}
                 powerCheckResponse={data.powerCheckResponse}
-                primaryMetricFieldName={data.primaryMetric!.metric.field_name}
+                primaryMetricFieldName={primaryMetricFieldName}
                 targetMde={data.primaryMetric?.mde}
                 selectedSampleOption={data.sampleSizeOption ?? PowerCheckOption.USE_POWER_CHECK}
                 desiredN={data.desiredN}

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -58,7 +58,7 @@ function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProp
       <Spinner loading={loading}>
         <LightningBoltIcon />
       </Spinner>
-      Run Power Check
+      Estimate Sample Size
     </Button>
   );
 }
@@ -287,7 +287,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                       </DataList.Item>
                       {primaryPower.pct_change_possible !== null && primaryPower.pct_change_possible !== undefined && (
                         <DataList.Item>
-                          <DataList.Label>MME</DataList.Label>
+                          <DataList.Label>MDE</DataList.Label>
                           <DataList.Value>{(primaryPower.pct_change_possible * 100).toFixed(4)}%</DataList.Value>
                         </DataList.Item>
                       )}

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -13,6 +13,7 @@ import {
   Table,
   Text,
   TextField,
+  Tooltip,
 } from '@radix-ui/themes';
 import { PowerCheckSampleOptionChange, PowerCheckSampleSizeSelector } from './power-check-sample-size-selector';
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
@@ -54,10 +55,11 @@ interface PowerCheckButtonProps {
   enabled: boolean;
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
   loading: boolean;
+  disabledReason?: string;
 }
 
-function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProps) {
-  return (
+function RunPowerCheckButton({ enabled, onClick, loading, disabledReason }: PowerCheckButtonProps) {
+  const button = (
     <Button disabled={!enabled} onClick={onClick} style={{ minWidth: '25%' }}>
       <Spinner loading={loading}>
         <LightningBoltIcon />
@@ -65,13 +67,22 @@ function RunPowerCheckButton({ enabled, onClick, loading }: PowerCheckButtonProp
       Estimate Sample Size
     </Button>
   );
+
+  const tooltipContent = !enabled
+    ? disabledReason
+    : "Calculates the minimum number of participants needed to be able to detect your primary metric's minimum effect.";
+
+  return (
+    <Tooltip content={tooltipContent} side="top" align="center">
+      {button}
+    </Tooltip>
+  );
 }
 
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
-  const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
   const [validationError, setValidationError] = useState<ZodError | null>(null);
-
-  const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
+  const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
+  const { enabled, reason } = isPowerCheckButtonEnabled(isMutating, data);
 
   const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -97,12 +108,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
   };
 
-  const handleSampleOptionChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
-    dispatch({ type: 'set-chosen-n', response, desiredN, sampleSizeOption });
+  const handleEstimatedMDEChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
+    dispatch({ type: 'set-power-check-response', sampleSizeOption, desiredN, response });
   };
 
-  const handleEstimatedMDEChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
-    dispatch({ type: 'set-power-check-response', response, desiredN, sampleSizeOption });
+  const handleSampleOptionChange = ({ sampleSizeOption, desiredN, response }: PowerCheckSampleOptionChange) => {
+    dispatch({ type: 'set-chosen-n', sampleSizeOption, desiredN, response });
   };
 
   const primaryPower =
@@ -145,7 +156,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
 
       <SectionCard title="Analysis">
         <Flex direction="column" gap="3" align="center">
-          <RunPowerCheckButton enabled={enabled} onClick={handlePowerCheck} loading={isMutating} />
+          <RunPowerCheckButton
+            enabled={enabled}
+            onClick={handlePowerCheck}
+            loading={isMutating}
+            disabledReason={reason}
+          />
 
           {error && (
             <Flex align="center" gap="2">

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -96,7 +96,8 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     }
 
     try {
-      const designSpec = convertToFrequentistDesignSpec(data);
+      // We always estimate the minimum sample size with this handler, so clear out desiredN.
+      const designSpec = convertToFrequentistDesignSpec({ ...data, desiredN: undefined });
       const response = await triggerEstimateSampleSize({ design_spec: designSpec });
 
       const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -71,7 +71,8 @@ function getValidDraftN(input: string): number | undefined {
 export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   const { trigger: triggerEstimateSampleSize, isMutating, error } = usePowerCheck(data.datasourceId!);
   // Separate mutation with a distinct SWR key so it doesn't share cache or conflict with the
-  // main power-check mutation above.
+  // main power-check mutation above. Reused for both ENTER_OWN and USE_ALL_NON_NULL_SAMPLES:
+  // the two effects are mutually exclusive (only one option is active at a time).
   const { trigger: triggerEstimateMde, isMutating: isEstimatingMde } = usePowerCheck(data.datasourceId!, {
     swr: { swrKey: `${data.datasourceId}/power/mde-estimate` },
   });
@@ -102,6 +103,17 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
       ? (customPrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
       : 'N/A';
 
+  const nonNullPrimaryAnalysis = data.nonNullSamplesPowerCheckResponse?.analyses.find(
+    (a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name,
+  );
+  const estimatedNonNullMdePct =
+    nonNullPrimaryAnalysis?.pct_change_with_desired_n != null
+      ? (nonNullPrimaryAnalysis.pct_change_with_desired_n * 100).toFixed(1)
+      : 'N/A';
+
+  const shouldEstimateNonNullMde =
+    selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && nonNullSamples > 0;
+
   const { enabled } = isPowerCheckButtonEnabled(isMutating, data); // TODO: present reason field
 
   // A ref so our useEffect for triggering MDE mode always reads the latest form data without making
@@ -116,15 +128,34 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
   // Wizard.tsx; `triggerEstimateMde` is stable from useSWRMutation.
   useEffect(() => {
     if (!shouldEstimateMde || debouncedValidDraftN === undefined) return;
+
     void (async () => {
       const response = await triggerEstimateMde({
         design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: debouncedValidDraftN }),
       });
+      // Ok to update this pair of values because its use is dependent on sampleSizeOption.
       if (response) {
         dispatch({ type: 'set-custom-power-check-response', response, desiredN: debouncedValidDraftN });
       }
     })();
   }, [debouncedValidDraftN, shouldEstimateMde, triggerEstimateMde, dispatch]);
+
+  // Same pattern for USE_ALL_NON_NULL_SAMPLES: estimate the MDE achievable with all non-null
+  // samples so we can display it inline. `nonNullSamples` is a stable number derived from the
+  // power-check response, so this only re-fires when the option changes or a new power check runs.
+  useEffect(() => {
+    if (!shouldEstimateNonNullMde) return;
+
+    void (async () => {
+      const response = await triggerEstimateMde({
+        design_spec: convertToFrequentistDesignSpec({ ...dataRef.current, desiredN: nonNullSamples }),
+      });
+      // Ok to update this pair of values because its use is dependent on sampleSizeOption.
+      if (response) {
+        dispatch({ type: 'set-non-null-samples-power-check-response', response });
+      }
+    })();
+  }, [nonNullSamples, shouldEstimateNonNullMde, triggerEstimateMde, dispatch]);
 
   const handlePowerCheck = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -377,7 +408,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                   >
                     <Flex align="center" direction="column" gap="2">
                       <Text size="2">Use minimum sample required:</Text>
-                      <Text size="2">{powerCheckTarget ?? 'N/A'}</Text>
+                      <Flex height="32px" align="center">
+                        <Text size="2">{powerCheckTarget ?? 'N/A'}</Text>
+                      </Flex>
                       <Flex align="center" style={{ minHeight: '24px' }}>
                         {data.primaryMetric?.mde !== undefined && (
                           <Badge color="purple" variant="soft" size="2">
@@ -393,8 +426,24 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                   >
                     <Flex align="center" direction="column" gap="2">
                       <Text size="2">Use all available non-null samples:</Text>
-                      <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
-                      <Flex align="center" style={{ minHeight: '24px' }}></Flex>
+                      <Flex height="32px" align="center">
+                        <Text size="2">{nonNullSamples ?? 'N/A'}</Text>
+                      </Flex>
+
+                      <Flex align="center" style={{ minHeight: '24px' }}>
+                        {selectedSampleOption === PowerCheckOption.USE_ALL_NON_NULL_SAMPLES && isEstimatingMde && (
+                          <Badge color="purple" variant="soft" size="2">
+                            Estimated MDE: …
+                            <Spinner size="1" />
+                          </Badge>
+                        )}
+                        {!(isEstimatingMde && nonNullPrimaryAnalysis !== undefined) &&
+                          data.nonNullSamplesPowerCheckResponse !== undefined && (
+                            <Badge color="purple" variant="soft" size="2">
+                              Estimated MDE: {estimatedNonNullMdePct}%
+                            </Badge>
+                          )}
+                      </Flex>
                     </Flex>
                   </RadioCards.Item>
                   <RadioCards.Item
@@ -410,7 +459,10 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         min={1}
                         max={allSamples ?? undefined}
                         value={draftN}
-                        onChange={(e) => setDraftN(e.target.value)}
+                        onChange={(e) => {
+                          setDraftN(e.target.value);
+                          dispatch({ type: 'clear-custom-power-check-response' });
+                        }}
                         placeholder="Enter your desired N"
                       />
                       <Flex align="center" style={{ minHeight: '24px' }}>
@@ -420,7 +472,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             <Spinner size="1" />
                           </Badge>
                         )}
-                        {!isEstimatingMde && draftN !== '' && (
+                        {!isEstimatingMde && draftN !== '' && customPrimaryAnalysis !== undefined && (
                           <Badge color="purple" variant="soft" size="2">
                             Estimated MDE: {estimatedMdePct}%
                           </Badge>

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -13,7 +13,7 @@ export function MdeBadge({ value, size = '2' }: MdeBadgeProps) {
   return (
     <Badge size={size}>
       <Flex gap="4" align="center">
-        <Heading size={size}>MME:</Heading>
+        <Heading size={size}>MDE:</Heading>
         <Flex gap="2" align="center">
           <Text>{displayValue}%</Text>
           <RadixTooltip content="This metric's minimum meaningful effect as defined in the experiment's design that meets the confidence and power requirements.">

--- a/src/services/wizard/Wizard.tsx
+++ b/src/services/wizard/Wizard.tsx
@@ -159,6 +159,7 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
   // Use CPS pattern to render the screen with full type safety
   return currentPackedScreen.withScreen((screen) => {
     const handleDispatch = (message: Parameters<typeof screen.reducer>[1]) => {
+      console.log('handleDispatch', message);
       setData((prev) => screen.reducer(prev, message));
     };
 

--- a/src/services/wizard/Wizard.tsx
+++ b/src/services/wizard/Wizard.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { Fragment, useCallback, useState } from 'react';
-import { BreadcrumbInfo, NavigationSource, NavigationTask, Screen, WizardForm } from './wizard-types';
+import { Fragment, useState } from 'react';
+import { BreadcrumbInfo, NavigationSource, NavigationTask, WizardForm } from './wizard-types';
 import { DebugDrawer } from './wizard-debug-drawer';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import { WizardBreadcrumbs, WizardBreadcrumbsProvider } from './wizard-breadcrumbs-context';
@@ -142,202 +142,6 @@ type WizardProps<FormData, ScreenId extends string, InputData> = {
  }
  ```
  */
-// Props passed down from Wizard into ScreenRenderer. Kept separate from WizardProps so the
-// generic Message type can be introduced here without polluting the public Wizard API.
-type ScreenRendererProps<FormData, Message, ScreenId extends string, InputData> = {
-  screen: Screen<FormData, Message, ScreenId>;
-  data: FormData;
-  setData: React.Dispatch<React.SetStateAction<FormData>>;
-  currentScreenId: ScreenId;
-  setCurrentScreenId: React.Dispatch<React.SetStateAction<ScreenId>>;
-  isTransitioning: boolean;
-  setIsTransitioning: React.Dispatch<React.SetStateAction<boolean>>;
-  form: WizardForm<FormData, ScreenId, InputData>;
-  onSubmit?: (data: FormData) => void;
-  onPrev?: (data: FormData) => void;
-  debug?: boolean;
-};
-
-/**
- * ScreenRenderer is a proper React component that owns all per-screen rendering and navigation
- * logic. Separating it from the CPS `withScreen` callback is essential: hooks (including
- * `useCallback`) cannot be called inside a plain callback, even a synchronously-invoked one.
- * Here, `dispatch` is stabilised with `useCallback`, so screen components can safely list
- * `dispatch` in `useEffect` dependency arrays without producing infinite loops.
- */
-function ScreenRenderer<FormData, Message, ScreenId extends string, InputData>({
-  screen,
-  data,
-  setData,
-  currentScreenId,
-  setCurrentScreenId,
-  isTransitioning,
-  setIsTransitioning,
-  form,
-  onSubmit,
-  onPrev,
-  debug,
-}: ScreenRendererProps<FormData, Message, ScreenId, InputData>) {
-  // Stable dispatch: setData is guaranteed stable by useState, and screen.reducer is a
-  // module-level constant — so these deps never change after mount. Screen components can
-  // safely include dispatch in useEffect dependency arrays.
-  const dispatch = useCallback(
-    (message: Message) => {
-      console.log('handleDispatch', message);
-      setData((prev) => screen.reducer(prev, message));
-    },
-    [screen, setData],
-  );
-
-  const screenIdBreadcrumbs = screen.breadcrumbs
-    ? screen.breadcrumbs(data)
-    : form.breadcrumbs
-      ? form.breadcrumbs(data)
-      : [];
-
-  const resolvePrevScreen = (): PrevTask<ScreenId> => {
-    if (screen.prevScreen) {
-      return screen.prevScreen(data);
-    }
-    return prevFromFlow(screenIdBreadcrumbs, currentScreenId);
-  };
-
-  const resolveNextScreen = (): NextTask<ScreenId> => {
-    if (screen.nextScreen) {
-      return screen.nextScreen(data);
-    }
-    return nextFromFlow(screenIdBreadcrumbs, currentScreenId);
-  };
-
-  const runBeforeNavigateAway = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
-    if (!screen.beforeNavigateAway) {
-      return true;
-    }
-    const result = await screen.beforeNavigateAway(data, {
-      source,
-      fromScreenId: currentScreenId,
-      target,
-    });
-    return result !== false;
-  };
-
-  const executeNavigationTask = (task: Exclude<NavigationTask<ScreenId>, null>) => {
-    switch (task.type) {
-      case 'screen':
-        setCurrentScreenId(task.id);
-        break;
-      case 'submit':
-        if (onSubmit) {
-          onSubmit(data);
-        }
-        break;
-      case 'wizard-exit-left':
-        if (onPrev) {
-          onPrev(data);
-        }
-        break;
-    }
-  };
-
-  const navigateWithGuard = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
-    if (target === null || isTransitioning) {
-      return;
-    }
-
-    setIsTransitioning(true);
-    try {
-      const shouldContinue = await runBeforeNavigateAway(source, target);
-      if (!shouldContinue) {
-        return;
-      }
-      executeNavigationTask(target);
-    } finally {
-      setIsTransitioning(false);
-    }
-  };
-
-  const handleNext = async () => {
-    const task = resolveNextScreen();
-    await navigateWithGuard('next', task);
-  };
-
-  const handlePrev = async () => {
-    const task = resolvePrevScreen();
-    await navigateWithGuard('prev', task);
-  };
-
-  const handleNavigate = async (screenId: string) => {
-    await navigateWithGuard('breadcrumb', { type: 'screen', id: screenId as ScreenId });
-  };
-
-  const handleNavigateTo = async (screenId: ScreenId) => {
-    await navigateWithGuard('navigate-to', { type: 'screen', id: screenId });
-  };
-
-  const isPrevEnabled = screen.isPrevEnabled === undefined ? true : screen.isPrevEnabled(data);
-  const prevScreen = resolvePrevScreen();
-  const isNextEnabled = screen.isNextEnabled === undefined ? true : screen.isNextEnabled(data);
-  const nextScreen = resolveNextScreen();
-
-  // Determine button labels
-  const nextLabel = screen.nextButtonLabel
-    ? screen.nextButtonLabel(data)
-    : nextScreen.type === 'submit'
-      ? 'Submit'
-      : 'Next';
-  const prevLabel = screen.prevButtonLabel ? screen.prevButtonLabel(data) : 'Back';
-
-  // Check if navigation should be hidden
-  const hideNav = screen.hideNavigation?.(data) ?? false;
-
-  // Get tooltip message for next button
-  const nextButtonTooltip = screen.nextButtonTooltip?.(data) ?? undefined;
-
-  const breadcrumbs: Array<BreadcrumbInfo> = screenIdBreadcrumbs.map((v): BreadcrumbInfo => {
-    return form.screens[v].withScreen((s) => ({
-      type: 'screen',
-      screenId: v,
-      label: s.breadcrumbTitle ?? v,
-      clickable: s.isBreadcrumbClickable === undefined ? true : s.isBreadcrumbClickable(data),
-    }));
-  });
-
-  return (
-    <Box style={{ paddingBottom: debug ? '45vh' : undefined }}>
-      <WizardBreadcrumbsProvider
-        breadcrumbs={breadcrumbs}
-        currentScreenId={currentScreenId}
-        onNavigate={handleNavigate}
-      >
-        <Fragment key={currentScreenId}>
-          <Flex direction={'column'} gap={'3'}>
-            <WizardBreadcrumbs />
-            <screen.render
-              data={data}
-              dispatch={dispatch}
-              navigateNext={handleNext}
-              navigatePrev={handlePrev}
-              navigateTo={handleNavigateTo}
-            />
-            {!hideNav && (
-              <NavigationButtons
-                onPrev={prevScreen ? handlePrev : undefined}
-                onNext={nextScreen ? handleNext : undefined}
-                prevLabel={prevLabel}
-                nextLabel={nextLabel}
-                prevDisabled={!isPrevEnabled || isTransitioning}
-                nextDisabled={!isNextEnabled || isTransitioning}
-                nextTooltipContent={nextButtonTooltip}
-              />
-            )}
-          </Flex>
-        </Fragment>
-      </WizardBreadcrumbsProvider>
-      {debug && <DebugDrawer data={data} breadcrumbs={breadcrumbs} currentScreenId={currentScreenId} />}
-    </Box>
-  );
-}
-
 export function Wizard<FormData, ScreenId extends string, InputData>({
   form,
   onSubmit,
@@ -349,24 +153,159 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
   const [currentScreenId, setCurrentScreenId] = useState<ScreenId>(() => form.initialScreenId(data));
   const [isTransitioning, setIsTransitioning] = useState(false);
 
+  // Get current packed screen by id (direct object access instead of array.find)
   const currentPackedScreen = form.screens[currentScreenId];
 
-  // withScreen is used here only to unwrap the CPS-encoded existential type so TypeScript knows
-  // the Message type of the current screen. All rendering and state logic lives in ScreenRenderer,
-  // which is a proper React component where hooks (e.g. useCallback for dispatch) work correctly.
-  return currentPackedScreen.withScreen((screen) => (
-    <ScreenRenderer
-      screen={screen}
-      data={data}
-      setData={setData}
-      currentScreenId={currentScreenId}
-      setCurrentScreenId={setCurrentScreenId}
-      isTransitioning={isTransitioning}
-      setIsTransitioning={setIsTransitioning}
-      form={form}
-      onSubmit={onSubmit}
-      onPrev={onPrev}
-      debug={debug}
-    />
-  ));
+  // Use CPS pattern to render the screen with full type safety
+  return currentPackedScreen.withScreen((screen) => {
+    const handleDispatch = (message: Parameters<typeof screen.reducer>[1]) => {
+      setData((prev) => screen.reducer(prev, message));
+    };
+
+    const screenIdBreadcrumbs = screen.breadcrumbs
+      ? screen.breadcrumbs(data)
+      : form.breadcrumbs
+        ? form.breadcrumbs(data)
+        : [];
+    const resolvePrevScreen = (): PrevTask<ScreenId> => {
+      if (screen.prevScreen) {
+        return screen.prevScreen(data);
+      }
+      return prevFromFlow(screenIdBreadcrumbs, currentScreenId);
+    };
+    const resolveNextScreen = (): NextTask<ScreenId> => {
+      if (screen.nextScreen) {
+        return screen.nextScreen(data);
+      }
+      return nextFromFlow(screenIdBreadcrumbs, currentScreenId);
+    };
+
+    const runBeforeNavigateAway = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
+      if (!screen.beforeNavigateAway) {
+        return true;
+      }
+      const result = await screen.beforeNavigateAway(data, {
+        source,
+        fromScreenId: currentScreenId,
+        target,
+      });
+      return result !== false;
+    };
+
+    const executeNavigationTask = (task: Exclude<NavigationTask<ScreenId>, null>) => {
+      switch (task.type) {
+        case 'screen':
+          setCurrentScreenId(task.id);
+          break;
+        case 'submit':
+          if (onSubmit) {
+            onSubmit(data);
+          }
+          break;
+        case 'wizard-exit-left':
+          if (onPrev) {
+            onPrev(data);
+          }
+          break;
+      }
+    };
+
+    const navigateWithGuard = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
+      if (target === null || isTransitioning) {
+        return;
+      }
+
+      setIsTransitioning(true);
+      try {
+        const shouldContinue = await runBeforeNavigateAway(source, target);
+        if (!shouldContinue) {
+          return;
+        }
+        executeNavigationTask(target);
+      } finally {
+        setIsTransitioning(false);
+      }
+    };
+
+    const handleNext = async () => {
+      const task = resolveNextScreen();
+      await navigateWithGuard('next', task);
+    };
+
+    const handlePrev = async () => {
+      const task = resolvePrevScreen();
+      await navigateWithGuard('prev', task);
+    };
+
+    const handleNavigate = async (screenId: string) => {
+      await navigateWithGuard('breadcrumb', { type: 'screen', id: screenId as ScreenId });
+    };
+
+    const handleNavigateTo = async (screenId: ScreenId) => {
+      await navigateWithGuard('navigate-to', { type: 'screen', id: screenId });
+    };
+
+    const isPrevEnabled = screen.isPrevEnabled === undefined ? true : screen.isPrevEnabled(data);
+    const prevScreen = resolvePrevScreen();
+    const isNextEnabled = screen.isNextEnabled === undefined ? true : screen.isNextEnabled(data);
+    const nextScreen = resolveNextScreen();
+
+    // Determine button labels
+    const nextLabel = screen.nextButtonLabel
+      ? screen.nextButtonLabel(data)
+      : nextScreen.type === 'submit'
+        ? 'Submit'
+        : 'Next';
+    const prevLabel = screen.prevButtonLabel ? screen.prevButtonLabel(data) : 'Back';
+
+    // Check if navigation should be hidden
+    const hideNav = screen.hideNavigation?.(data) ?? false;
+
+    // Get tooltip message for next button
+    const nextButtonTooltip = screen.nextButtonTooltip?.(data) ?? undefined;
+
+    const breadcrumbs: Array<BreadcrumbInfo> = screenIdBreadcrumbs.map((v): BreadcrumbInfo => {
+      return form.screens[v].withScreen((s) => ({
+        type: 'screen',
+        screenId: v,
+        label: s.breadcrumbTitle ?? v,
+        clickable: s.isBreadcrumbClickable === undefined ? true : s.isBreadcrumbClickable(data),
+      }));
+    });
+
+    return (
+      <Box style={{ paddingBottom: debug ? '45vh' : undefined }}>
+        <WizardBreadcrumbsProvider
+          breadcrumbs={breadcrumbs}
+          currentScreenId={currentScreenId}
+          onNavigate={handleNavigate}
+        >
+          <Fragment key={currentScreenId}>
+            <Flex direction={'column'} gap={'3'}>
+              <WizardBreadcrumbs />
+              <screen.render
+                data={data}
+                dispatch={handleDispatch}
+                navigateNext={handleNext}
+                navigatePrev={handlePrev}
+                navigateTo={handleNavigateTo}
+              />
+              {!hideNav && (
+                <NavigationButtons
+                  onPrev={prevScreen ? handlePrev : undefined}
+                  onNext={nextScreen ? handleNext : undefined}
+                  prevLabel={prevLabel}
+                  nextLabel={nextLabel}
+                  prevDisabled={!isPrevEnabled || isTransitioning}
+                  nextDisabled={!isNextEnabled || isTransitioning}
+                  nextTooltipContent={nextButtonTooltip}
+                />
+              )}
+            </Flex>
+          </Fragment>
+        </WizardBreadcrumbsProvider>
+        {debug && <DebugDrawer data={data} breadcrumbs={breadcrumbs} currentScreenId={currentScreenId} />}
+      </Box>
+    );
+  });
 }

--- a/src/services/wizard/Wizard.tsx
+++ b/src/services/wizard/Wizard.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { Fragment, useState } from 'react';
-import { BreadcrumbInfo, NavigationSource, NavigationTask, WizardForm } from './wizard-types';
+import { Fragment, useCallback, useState } from 'react';
+import { BreadcrumbInfo, NavigationSource, NavigationTask, Screen, WizardForm } from './wizard-types';
 import { DebugDrawer } from './wizard-debug-drawer';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import { WizardBreadcrumbs, WizardBreadcrumbsProvider } from './wizard-breadcrumbs-context';
@@ -142,6 +142,202 @@ type WizardProps<FormData, ScreenId extends string, InputData> = {
  }
  ```
  */
+// Props passed down from Wizard into ScreenRenderer. Kept separate from WizardProps so the
+// generic Message type can be introduced here without polluting the public Wizard API.
+type ScreenRendererProps<FormData, Message, ScreenId extends string, InputData> = {
+  screen: Screen<FormData, Message, ScreenId>;
+  data: FormData;
+  setData: React.Dispatch<React.SetStateAction<FormData>>;
+  currentScreenId: ScreenId;
+  setCurrentScreenId: React.Dispatch<React.SetStateAction<ScreenId>>;
+  isTransitioning: boolean;
+  setIsTransitioning: React.Dispatch<React.SetStateAction<boolean>>;
+  form: WizardForm<FormData, ScreenId, InputData>;
+  onSubmit?: (data: FormData) => void;
+  onPrev?: (data: FormData) => void;
+  debug?: boolean;
+};
+
+/**
+ * ScreenRenderer is a proper React component that owns all per-screen rendering and navigation
+ * logic. Separating it from the CPS `withScreen` callback is essential: hooks (including
+ * `useCallback`) cannot be called inside a plain callback, even a synchronously-invoked one.
+ * Here, `dispatch` is stabilised with `useCallback`, so screen components can safely list
+ * `dispatch` in `useEffect` dependency arrays without producing infinite loops.
+ */
+function ScreenRenderer<FormData, Message, ScreenId extends string, InputData>({
+  screen,
+  data,
+  setData,
+  currentScreenId,
+  setCurrentScreenId,
+  isTransitioning,
+  setIsTransitioning,
+  form,
+  onSubmit,
+  onPrev,
+  debug,
+}: ScreenRendererProps<FormData, Message, ScreenId, InputData>) {
+  // Stable dispatch: setData is guaranteed stable by useState, and screen.reducer is a
+  // module-level constant — so these deps never change after mount. Screen components can
+  // safely include dispatch in useEffect dependency arrays.
+  const dispatch = useCallback(
+    (message: Message) => {
+      console.log('handleDispatch', message);
+      setData((prev) => screen.reducer(prev, message));
+    },
+    [screen, setData],
+  );
+
+  const screenIdBreadcrumbs = screen.breadcrumbs
+    ? screen.breadcrumbs(data)
+    : form.breadcrumbs
+      ? form.breadcrumbs(data)
+      : [];
+
+  const resolvePrevScreen = (): PrevTask<ScreenId> => {
+    if (screen.prevScreen) {
+      return screen.prevScreen(data);
+    }
+    return prevFromFlow(screenIdBreadcrumbs, currentScreenId);
+  };
+
+  const resolveNextScreen = (): NextTask<ScreenId> => {
+    if (screen.nextScreen) {
+      return screen.nextScreen(data);
+    }
+    return nextFromFlow(screenIdBreadcrumbs, currentScreenId);
+  };
+
+  const runBeforeNavigateAway = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
+    if (!screen.beforeNavigateAway) {
+      return true;
+    }
+    const result = await screen.beforeNavigateAway(data, {
+      source,
+      fromScreenId: currentScreenId,
+      target,
+    });
+    return result !== false;
+  };
+
+  const executeNavigationTask = (task: Exclude<NavigationTask<ScreenId>, null>) => {
+    switch (task.type) {
+      case 'screen':
+        setCurrentScreenId(task.id);
+        break;
+      case 'submit':
+        if (onSubmit) {
+          onSubmit(data);
+        }
+        break;
+      case 'wizard-exit-left':
+        if (onPrev) {
+          onPrev(data);
+        }
+        break;
+    }
+  };
+
+  const navigateWithGuard = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
+    if (target === null || isTransitioning) {
+      return;
+    }
+
+    setIsTransitioning(true);
+    try {
+      const shouldContinue = await runBeforeNavigateAway(source, target);
+      if (!shouldContinue) {
+        return;
+      }
+      executeNavigationTask(target);
+    } finally {
+      setIsTransitioning(false);
+    }
+  };
+
+  const handleNext = async () => {
+    const task = resolveNextScreen();
+    await navigateWithGuard('next', task);
+  };
+
+  const handlePrev = async () => {
+    const task = resolvePrevScreen();
+    await navigateWithGuard('prev', task);
+  };
+
+  const handleNavigate = async (screenId: string) => {
+    await navigateWithGuard('breadcrumb', { type: 'screen', id: screenId as ScreenId });
+  };
+
+  const handleNavigateTo = async (screenId: ScreenId) => {
+    await navigateWithGuard('navigate-to', { type: 'screen', id: screenId });
+  };
+
+  const isPrevEnabled = screen.isPrevEnabled === undefined ? true : screen.isPrevEnabled(data);
+  const prevScreen = resolvePrevScreen();
+  const isNextEnabled = screen.isNextEnabled === undefined ? true : screen.isNextEnabled(data);
+  const nextScreen = resolveNextScreen();
+
+  // Determine button labels
+  const nextLabel = screen.nextButtonLabel
+    ? screen.nextButtonLabel(data)
+    : nextScreen.type === 'submit'
+      ? 'Submit'
+      : 'Next';
+  const prevLabel = screen.prevButtonLabel ? screen.prevButtonLabel(data) : 'Back';
+
+  // Check if navigation should be hidden
+  const hideNav = screen.hideNavigation?.(data) ?? false;
+
+  // Get tooltip message for next button
+  const nextButtonTooltip = screen.nextButtonTooltip?.(data) ?? undefined;
+
+  const breadcrumbs: Array<BreadcrumbInfo> = screenIdBreadcrumbs.map((v): BreadcrumbInfo => {
+    return form.screens[v].withScreen((s) => ({
+      type: 'screen',
+      screenId: v,
+      label: s.breadcrumbTitle ?? v,
+      clickable: s.isBreadcrumbClickable === undefined ? true : s.isBreadcrumbClickable(data),
+    }));
+  });
+
+  return (
+    <Box style={{ paddingBottom: debug ? '45vh' : undefined }}>
+      <WizardBreadcrumbsProvider
+        breadcrumbs={breadcrumbs}
+        currentScreenId={currentScreenId}
+        onNavigate={handleNavigate}
+      >
+        <Fragment key={currentScreenId}>
+          <Flex direction={'column'} gap={'3'}>
+            <WizardBreadcrumbs />
+            <screen.render
+              data={data}
+              dispatch={dispatch}
+              navigateNext={handleNext}
+              navigatePrev={handlePrev}
+              navigateTo={handleNavigateTo}
+            />
+            {!hideNav && (
+              <NavigationButtons
+                onPrev={prevScreen ? handlePrev : undefined}
+                onNext={nextScreen ? handleNext : undefined}
+                prevLabel={prevLabel}
+                nextLabel={nextLabel}
+                prevDisabled={!isPrevEnabled || isTransitioning}
+                nextDisabled={!isNextEnabled || isTransitioning}
+                nextTooltipContent={nextButtonTooltip}
+              />
+            )}
+          </Flex>
+        </Fragment>
+      </WizardBreadcrumbsProvider>
+      {debug && <DebugDrawer data={data} breadcrumbs={breadcrumbs} currentScreenId={currentScreenId} />}
+    </Box>
+  );
+}
+
 export function Wizard<FormData, ScreenId extends string, InputData>({
   form,
   onSubmit,
@@ -153,160 +349,24 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
   const [currentScreenId, setCurrentScreenId] = useState<ScreenId>(() => form.initialScreenId(data));
   const [isTransitioning, setIsTransitioning] = useState(false);
 
-  // Get current packed screen by id (direct object access instead of array.find)
   const currentPackedScreen = form.screens[currentScreenId];
 
-  // Use CPS pattern to render the screen with full type safety
-  return currentPackedScreen.withScreen((screen) => {
-    const handleDispatch = (message: Parameters<typeof screen.reducer>[1]) => {
-      console.log('handleDispatch', message);
-      setData((prev) => screen.reducer(prev, message));
-    };
-
-    const screenIdBreadcrumbs = screen.breadcrumbs
-      ? screen.breadcrumbs(data)
-      : form.breadcrumbs
-        ? form.breadcrumbs(data)
-        : [];
-    const resolvePrevScreen = (): PrevTask<ScreenId> => {
-      if (screen.prevScreen) {
-        return screen.prevScreen(data);
-      }
-      return prevFromFlow(screenIdBreadcrumbs, currentScreenId);
-    };
-    const resolveNextScreen = (): NextTask<ScreenId> => {
-      if (screen.nextScreen) {
-        return screen.nextScreen(data);
-      }
-      return nextFromFlow(screenIdBreadcrumbs, currentScreenId);
-    };
-
-    const runBeforeNavigateAway = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
-      if (!screen.beforeNavigateAway) {
-        return true;
-      }
-      const result = await screen.beforeNavigateAway(data, {
-        source,
-        fromScreenId: currentScreenId,
-        target,
-      });
-      return result !== false;
-    };
-
-    const executeNavigationTask = (task: Exclude<NavigationTask<ScreenId>, null>) => {
-      switch (task.type) {
-        case 'screen':
-          setCurrentScreenId(task.id);
-          break;
-        case 'submit':
-          if (onSubmit) {
-            onSubmit(data);
-          }
-          break;
-        case 'wizard-exit-left':
-          if (onPrev) {
-            onPrev(data);
-          }
-          break;
-      }
-    };
-
-    const navigateWithGuard = async (source: NavigationSource, target: NavigationTask<ScreenId>) => {
-      if (target === null || isTransitioning) {
-        return;
-      }
-
-      setIsTransitioning(true);
-      try {
-        const shouldContinue = await runBeforeNavigateAway(source, target);
-        if (!shouldContinue) {
-          return;
-        }
-        executeNavigationTask(target);
-      } finally {
-        setIsTransitioning(false);
-      }
-    };
-
-    const handleNext = async () => {
-      const task = resolveNextScreen();
-      await navigateWithGuard('next', task);
-    };
-
-    const handlePrev = async () => {
-      const task = resolvePrevScreen();
-      await navigateWithGuard('prev', task);
-    };
-
-    const handleNavigate = async (screenId: string) => {
-      await navigateWithGuard('breadcrumb', { type: 'screen', id: screenId as ScreenId });
-    };
-
-    const handleNavigateTo = async (screenId: ScreenId) => {
-      await navigateWithGuard('navigate-to', { type: 'screen', id: screenId });
-    };
-
-    const isPrevEnabled = screen.isPrevEnabled === undefined ? true : screen.isPrevEnabled(data);
-    const prevScreen = resolvePrevScreen();
-    const isNextEnabled = screen.isNextEnabled === undefined ? true : screen.isNextEnabled(data);
-    const nextScreen = resolveNextScreen();
-
-    // Determine button labels
-    const nextLabel = screen.nextButtonLabel
-      ? screen.nextButtonLabel(data)
-      : nextScreen.type === 'submit'
-        ? 'Submit'
-        : 'Next';
-    const prevLabel = screen.prevButtonLabel ? screen.prevButtonLabel(data) : 'Back';
-
-    // Check if navigation should be hidden
-    const hideNav = screen.hideNavigation?.(data) ?? false;
-
-    // Get tooltip message for next button
-    const nextButtonTooltip = screen.nextButtonTooltip?.(data) ?? undefined;
-
-    const breadcrumbs: Array<BreadcrumbInfo> = screenIdBreadcrumbs.map((v): BreadcrumbInfo => {
-      return form.screens[v].withScreen((s) => ({
-        type: 'screen',
-        screenId: v,
-        label: s.breadcrumbTitle ?? v,
-        clickable: s.isBreadcrumbClickable === undefined ? true : s.isBreadcrumbClickable(data),
-      }));
-    });
-
-    return (
-      <Box style={{ paddingBottom: debug ? '45vh' : undefined }}>
-        <WizardBreadcrumbsProvider
-          breadcrumbs={breadcrumbs}
-          currentScreenId={currentScreenId}
-          onNavigate={handleNavigate}
-        >
-          <Fragment key={currentScreenId}>
-            <Flex direction={'column'} gap={'3'}>
-              <WizardBreadcrumbs />
-              <screen.render
-                data={data}
-                dispatch={handleDispatch}
-                navigateNext={handleNext}
-                navigatePrev={handlePrev}
-                navigateTo={handleNavigateTo}
-              />
-              {!hideNav && (
-                <NavigationButtons
-                  onPrev={prevScreen ? handlePrev : undefined}
-                  onNext={nextScreen ? handleNext : undefined}
-                  prevLabel={prevLabel}
-                  nextLabel={nextLabel}
-                  prevDisabled={!isPrevEnabled || isTransitioning}
-                  nextDisabled={!isNextEnabled || isTransitioning}
-                  nextTooltipContent={nextButtonTooltip}
-                />
-              )}
-            </Flex>
-          </Fragment>
-        </WizardBreadcrumbsProvider>
-        {debug && <DebugDrawer data={data} breadcrumbs={breadcrumbs} currentScreenId={currentScreenId} />}
-      </Box>
-    );
-  });
+  // withScreen is used here only to unwrap the CPS-encoded existential type so TypeScript knows
+  // the Message type of the current screen. All rendering and state logic lives in ScreenRenderer,
+  // which is a proper React component where hooks (e.g. useCallback for dispatch) work correctly.
+  return currentPackedScreen.withScreen((screen) => (
+    <ScreenRenderer
+      screen={screen}
+      data={data}
+      setData={setData}
+      currentScreenId={currentScreenId}
+      setCurrentScreenId={setCurrentScreenId}
+      isTransitioning={isTransitioning}
+      setIsTransitioning={setIsTransitioning}
+      form={form}
+      onSubmit={onSubmit}
+      onPrev={onPrev}
+      debug={debug}
+    />
+  ));
 }


### PR DESCRIPTION
## Description

Computes an estimated MDE given a user-specified desired_n, the core change for issue https://github.com/agency-fund/evidential-be/issues/216. 

In the process, refactors the frequentist experiment power analysis workflow, splitting the "power check" into two distinct operations: 
1. an initial sample size estimation (run once via the "Estimate Sample Size" button) and 
2. an optional separate MDE estimation fired automatically when the user selects a custom sample size.

It extracts two new components (PowerCheckSampleSizeSelector and PowerCheckDesiredNInput) and begins updating async state management to prevent stale API responses (MDE estimates only for now).

Key changes:

* New mdePowerCheckResponse field in form state — separate from the initial power-check result (powerCheckResponse, used for min sample size etc.)
* Extracted PowerCheckSampleSizeSelector component — owns the radio-card UI for selecting sample size (min required / all non-null / custom), triggers MDE re-estimation automatically on option change or debounced input, while delegating stale respons handling to the parent (reducer).
* Extracted PowerCheckDesiredNInput component — semi-controlled number input to isolate input debouncing and execution of the onChange prop using the latest ref pattern.
* guard against some async stale responses in the reducer _for MDE estimates_ — `set-power-check-response` messages  (ENTER_OWN and USE_ALL_NON_NULL_SAMPLES) are discarded if the selected option or desiredN have changed from the time the request was kicked off.
* createExperimentError cleared on more events — metric changes, MDE changes, filter changes, confidence/power changes, and datasource changes all now also clear createExperimentError, so a visible previous error is cleared.
* Reverted naming of MME → MDE to be consistent with commonly accepted terminology, rather than try to teach a new acronym only we use.
* "Estimate Sample Size" button now has a disabled-reason tooltip — surfaces why the button is unavailable (e.g. missing primary metric) instead of silently being greyed out.
* More Next button tooltip additions and cleanup so the disabled status and tips are aligned.

### Future Tasks

* [x] Guard against stale min sample size calculations (e.g. with a dirty flag that is cleared upon pressing "Estimate Sample Size", but re-set whenever a field is modified whose action also does a `powerCheckResponse: undefined` today.
* [x] Improve BE API power check to be more strict on error handling [EVE-34]
* [optimization] Overhaul power_check() sample size mode behavior to always include a `pct_change_with_desired_n` value for desired_n=available_n. (This is sort of done only in the INSUFFICIENT case, setting target_possible & pct_change_possible.) [EVE-35]
* [optimization] update `PowerRequest` to reuse dwh-derived stats (so MDE requests can reuse the min sample size stats and avoid re-hitting the dwh unnecessarily if they don't need to) [EVE-36]
also re: https://github.com/agency-fund/evidential-be/pull/143#issuecomment-3791279274, https://github.com/agency-fund/evidential-be/pull/163#discussion_r3163312350, https://github.com/agency-fund/evidential-be/pull/163#discussion_r3163210582

## How has this been tested?

Manually: Using table a_dwh, metrics `current_income` and `is_onboarded_onetime` with filter `baseline_income <= 14000` gives a nice starting point to see different sufficient/insufficient scenarios. E.g. updating current_income's MDE from 10% to 1% moves it into an insufficient state. 
Also with network throttling for testing of stale requests.

<img width="1066" height="278" alt="image" src="https://github.com/user-attachments/assets/30d8541e-7af1-442e-8c44-47b8d0acb4bd" />
<img width="316" height="88" alt="image" src="https://github.com/user-attachments/assets/8c9b8d0d-1124-448e-8c14-fda344d0a6b3" />
<img width="1301" height="294" alt="image" src="https://github.com/user-attachments/assets/88744356-214a-405f-bc99-4eab64870993" />
<img width="553" height="221" alt="image" src="https://github.com/user-attachments/assets/b9af9936-d98b-4def-9b22-7faacc48ba2b" />

