### PR TITLE
Refactor: move types out of experiment-form-def.tsx into experiment-form-types.ts

### DIFF
--- a/src/app/experiments/create/experiment-form/experiment-describe-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-arms-screen.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Badge, Box, Button, Card, Flex, Heading, IconButton, Text, TextArea, TextField } from '@radix-ui/themes';
 import { PlusIcon, TrashIcon } from '@radix-ui/react-icons';
 import { ArmWeightsDialog } from '@/components/features/experiments/arm-weights-dialog';

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import {
   Badge,
   Box,

--- a/src/app/experiments/create/experiment-form/experiment-describe-contexts-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-contexts-screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Box, Button, Card, Flex, Heading, IconButton, RadioCards, Text, TextArea, TextField } from '@radix-ui/themes';
 import { PlusIcon, TrashIcon } from '@radix-ui/react-icons';
 

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -37,15 +37,9 @@ import {
   ExperimentScreenId,
   ExperimentType,
   isBanditExperimentType,
+  isCmabExperimentType,
+  isFreqExperimentType,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
-
-const isFreq = (experimentType: ExperimentType) => {
-  return experimentType === 'freq_online' || experimentType === 'freq_preassigned';
-};
-
-const isCmab = (experimentType: ExperimentType) => {
-  return experimentType === 'cmab_online';
-};
 
 // Helper to create screens with proper type inference
 const screen = packScreen<ExperimentFormData, ExperimentScreenId>();
@@ -79,9 +73,9 @@ const MAB_BREADCRUMBS: Array<ExperimentScreenId> = [
 const breadcrumbs = ({ experimentType }: { experimentType?: ExperimentType }) => {
   if (experimentType === undefined) {
     return [];
-  } else if (isFreq(experimentType)) {
+  } else if (isFreqExperimentType(experimentType)) {
     return FREQUENTIST_BREADCRUMBS;
-  } else if (isCmab(experimentType)) {
+  } else if (isCmabExperimentType(experimentType)) {
     return CMAB_BREADCRUMBS;
   } else {
     return MAB_BREADCRUMBS;

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -5,16 +5,7 @@ import {
   ExperimentMetadataScreen,
 } from '@/app/experiments/create/experiment-form/experiment-metadata-screen';
 import { ExperimentTypeScreen } from '@/app/experiments/create/experiment-form/experiment-type-screen';
-import {
-  Arm,
-  ContextType,
-  CreateExperimentResponse,
-  DesignSpecInput,
-  FieldMetadata,
-  FilterInput,
-  GetFiltersResponseElement,
-  PowerResponseOutput,
-} from '@/api/methods.schemas';
+import { ContextType } from '@/api/methods.schemas';
 import { abandonExperiment } from '@/api/admin';
 import { ExperimentSelectDatasourceScreen } from '@/app/experiments/create/experiment-form/experiment-select-datasource-screen';
 import { ExperimentSelectBinaryOrRealOutcomes } from '@/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes';
@@ -41,64 +32,12 @@ import {
   toCmabBanditParams,
   toMabBanditParams,
 } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
-import { ErrorType } from '@/services/orval-fetch';
 import {
-  BanditParams,
+  ExperimentFormData,
+  ExperimentScreenId,
+  ExperimentType,
   isBanditExperimentType,
-  MetricWithMDE,
-  PowerCheckOption,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
-
-export type ExperimentType = DesignSpecInput['experiment_type'];
-
-// Defines the entirety of the editable data collected via this wizard flow.
-export type ExperimentFormData = {
-  // experiment-metadata-screen
-  name?: string;
-  hypothesis?: string;
-  designUrl?: string;
-  startDate?: string;
-  endDate?: string;
-
-  // experiment-type-screen
-  experimentType?: ExperimentType;
-
-  // experiment-select-datasource-screen
-  datasourceId?: string;
-  tableName?: string;
-
-  // experiment-freq-stack-screen
-  primaryKey?: string;
-  primaryMetric?: MetricWithMDE;
-  secondaryMetrics?: MetricWithMDE[];
-  filters?: FilterInput[];
-  // Cache of available filter fields (and their data types) for lookup/display/search
-  availableFilterFields?: GetFiltersResponseElement[];
-  strata?: FieldMetadata[];
-  // These next 2 Experiment Parameters are strings to allow for empty values,
-  // which should be converted to numbers when making power or experiment creation requests.
-  confidence?: string;
-  power?: string;
-  // Populated when user clicks "Power Check" on DesignForm
-  desiredN?: number;
-  sampleSizeOption?: PowerCheckOption;
-  powerCheckResponse?: PowerResponseOutput;
-  createExperimentResponse?: CreateExperimentResponse;
-  createExperimentError?: ErrorType<unknown>;
-
-  // experiment-describe-webhooks-screen
-  selectedWebhookIds?: string[];
-
-  // experiment-describe-arms-screen
-  arms?: Omit<Arm, 'arm_id'>[];
-
-  // bandit flow config
-  bandit?: BanditParams;
-
-  // experiment-summarize-freq-screen (populated after createExperiment API call)
-  experimentId?: string;
-  commitError?: ErrorType<unknown>;
-};
 
 const isFreq = (experimentType: ExperimentType) => {
   return experimentType === 'freq_online' || experimentType === 'freq_preassigned';
@@ -107,20 +46,6 @@ const isFreq = (experimentType: ExperimentType) => {
 const isCmab = (experimentType: ExperimentType) => {
   return experimentType === 'cmab_online';
 };
-
-// Defines a type for all known screen IDs for the experiment form. This type is used with screen() to
-// type-check the ids returned by nextScreen and prevScreen.
-export type ExperimentScreenId =
-  | 'metadata'
-  | 'experiment-type'
-  | 'freq-select-datasource'
-  | 'bandit-binary-or-real'
-  | 'describe-contexts'
-  | 'describe-arms'
-  | 'describe-bandit-arms'
-  | 'freq-stack'
-  | 'summarize-freq'
-  | 'summarize-bandit';
 
 // Helper to create screens with proper type inference
 const screen = packScreen<ExperimentFormData, ExperimentScreenId>();

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -11,7 +11,7 @@ import {
   Stratum,
 } from '@/api/methods.schemas';
 import { createExperimentBody } from '@/api/admin.zod';
-import { ExperimentFormData } from './experiment-form-def';
+import { ExperimentFormData } from './experiment-form-types';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 import { isFreqExperimentType, isFrequentistSpec } from './experiment-form-types';
 

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -3,18 +3,25 @@ import {
   CMABExperimentSpecInputExperimentType,
   CMABExperimentSpecOutput,
   ContextType,
+  CreateExperimentResponse,
+  DesignSpecInput,
   DesignSpecOutput,
   ExperimentConfig,
+  FieldMetadata,
+  FilterInput,
   GetExperimentResponse,
+  GetFiltersResponseElement,
   GetMetricsResponseElement,
   MABExperimentSpecInput,
   MABExperimentSpecInputExperimentType,
   MABExperimentSpecOutput,
   OnlineFrequentistExperimentSpecInputExperimentType,
   OnlineFrequentistExperimentSpecOutput,
+  PowerResponseOutput,
   PreassignedFrequentistExperimentSpecInputExperimentType,
   PreassignedFrequentistExperimentSpecOutput,
 } from '@/api/methods.schemas';
+import { ErrorType } from '@/services/orval-fetch';
 
 // export type ContextVariableType2 = ContextSpec['value_type'];
 export type ContextVariableType = ContextType;
@@ -75,6 +82,71 @@ export type MetricWithMDE = {
   metric: GetMetricsResponseElement;
   mde: string; // desired minimum detectable effect as a percentage of the metric's baseline value
 };
+
+export type ExperimentType = DesignSpecInput['experiment_type'];
+
+// Defines the entirety of the editable data collected via this wizard flow.
+export type ExperimentFormData = {
+  // experiment-metadata-screen
+  name?: string;
+  hypothesis?: string;
+  designUrl?: string;
+  startDate?: string;
+  endDate?: string;
+
+  // experiment-type-screen
+  experimentType?: ExperimentType;
+
+  // experiment-select-datasource-screen
+  datasourceId?: string;
+  tableName?: string;
+
+  // experiment-freq-stack-screen
+  primaryKey?: string;
+  primaryMetric?: MetricWithMDE;
+  secondaryMetrics?: MetricWithMDE[];
+  filters?: FilterInput[];
+  // Cache of available filter fields (and their data types) for lookup/display/search
+  availableFilterFields?: GetFiltersResponseElement[];
+  strata?: FieldMetadata[];
+  // These next 2 Experiment Parameters are strings to allow for empty values,
+  // which should be converted to numbers when making power or experiment creation requests.
+  confidence?: string;
+  power?: string;
+  // Populated when user clicks "Power Check" on DesignForm
+  desiredN?: number;
+  sampleSizeOption?: PowerCheckOption;
+  powerCheckResponse?: PowerResponseOutput;
+  createExperimentResponse?: CreateExperimentResponse;
+  createExperimentError?: ErrorType<unknown>;
+
+  // experiment-describe-webhooks-screen
+  selectedWebhookIds?: string[];
+
+  // experiment-describe-arms-screen
+  arms?: Omit<Arm, 'arm_id'>[];
+
+  // bandit flow config
+  bandit?: BanditParams;
+
+  // experiment-summarize-freq-screen (populated after createExperiment API call)
+  experimentId?: string;
+  commitError?: ErrorType<unknown>;
+};
+
+// All known screen IDs for the experiment form wizard. Used with screen() to type-check ids
+// returned by nextScreen and prevScreen.
+export type ExperimentScreenId =
+  | 'metadata'
+  | 'experiment-type'
+  | 'freq-select-datasource'
+  | 'bandit-binary-or-real'
+  | 'describe-contexts'
+  | 'describe-arms'
+  | 'describe-bandit-arms'
+  | 'freq-stack'
+  | 'summarize-freq'
+  | 'summarize-bandit';
 
 // Define the type alias using imported types
 export function isFreqExperimentType(type: string | undefined): boolean {

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -1,4 +1,5 @@
 import {
+  AnyFrequentistDesignSpecInputExperimentType,
   Arm,
   CMABExperimentSpecInputExperimentType,
   CMABExperimentSpecOutput,
@@ -149,13 +150,20 @@ export type ExperimentScreenId =
   | 'summarize-bandit';
 
 // Define the type alias using imported types
-export function isFreqExperimentType(type: string | undefined): boolean {
-  return (
-    !!type &&
-    (type in PreassignedFrequentistExperimentSpecInputExperimentType ||
-      type in OnlineFrequentistExperimentSpecInputExperimentType)
-  );
-}
+export const isFreqExperimentType = (
+  experimentType?: ExperimentType,
+): experimentType is AnyFrequentistDesignSpecInputExperimentType =>
+  experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned ||
+  experimentType === OnlineFrequentistExperimentSpecInputExperimentType.freq_online;
+
+export const isCmabExperimentType = (
+  experimentType?: ExperimentType,
+): experimentType is CMABExperimentSpecInputExperimentType =>
+  experimentType === CMABExperimentSpecInputExperimentType.cmab_online;
+
+export const isBanditExperimentType = (experimentType?: ExperimentType): experimentType is BanditExperimentType =>
+  experimentType === MABExperimentSpecInputExperimentType.mab_online ||
+  experimentType === CMABExperimentSpecInputExperimentType.cmab_online;
 
 export const isFrequentistSpec = (
   spec: DesignSpecOutput | undefined,
@@ -172,7 +180,3 @@ export function isCmabSpec(spec: DesignSpecOutput | undefined): spec is CMABExpe
 
 export const isCmabExperiment = (experiment: GetExperimentResponse | ExperimentConfig | undefined): boolean =>
   !!experiment && isCmabSpec(experiment.design_spec);
-
-export const isBanditExperimentType = (experimentType?: string): experimentType is BanditExperimentType =>
-  experimentType === MABExperimentSpecInputExperimentType.mab_online ||
-  experimentType === CMABExperimentSpecInputExperimentType.cmab_online;

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -1,5 +1,5 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { PowerCheckOption } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Card, Flex, Heading } from '@radix-ui/themes';
 import { MetricBuilder, MetricBuilderAction } from '@/components/features/experiments/metric-builder';

--- a/src/app/experiments/create/experiment-form/experiment-metadata-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-metadata-screen.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Box, Flex, Separator, Text, TextArea, TextField } from '@radix-ui/themes';
 import { SelectWebhooksSection } from '@/app/experiments/create/experiment-form/select-webhooks-section';
 

--- a/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
@@ -1,5 +1,5 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Flex, Heading, RadioCards, Text } from '@radix-ui/themes';
 import { FormOutcomeType } from '@/app/experiments/create/experiment-form/experiment-form-types';
 

--- a/src/app/experiments/create/experiment-form/experiment-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-datasource-screen.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Wizard } from '@/services/wizard/Wizard';
 import { DatasourceForm, DatasourceFormData, DatasourceFormInputData } from '../datasource-form/datasource-form-def';
 import { Card, Flex } from '@radix-ui/themes';

--- a/src/app/experiments/create/experiment-form/experiment-summarize-bandit-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-bandit-screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { ErrorType } from '@/services/orval-fetch';
 import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';
 

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { ErrorType } from '@/services/orval-fetch';
 import { ExperimentConfirmationDisplayProps } from '@/components/features/experiments/experiment-confirmation-display';
 import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';

--- a/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
@@ -11,7 +11,7 @@ import {
   ExperimentConfirmationDisplay,
   ExperimentConfirmationDisplayProps,
 } from '@/components/features/experiments/experiment-confirmation-display';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-def';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 
 // The "Edit" buttons on the confirmation screen are temporarily disabled pending further UX effort.
 const FEATURE_EDIT_BUTTONS_ENABLED = false;

--- a/src/app/experiments/create/experiment-form/experiment-type-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-type-screen.tsx
@@ -3,7 +3,7 @@ import {
   ExperimentFormData,
   ExperimentScreenId,
   ExperimentType,
-} from '@/app/experiments/create/experiment-form/experiment-form-def';
+} from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Badge, Flex, RadioCards, Text } from '@radix-ui/themes';
 import { ExperimentTypeOptions } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -16,7 +16,7 @@ import {
   TextField,
 } from '@radix-ui/themes';
 import { CheckCircledIcon, CrossCircledIcon, LightningBoltIcon } from '@radix-ui/react-icons';
-import { ExperimentFormData } from './experiment-form-def';
+import { ExperimentFormData } from './experiment-form-types';
 import { PowerCheckOption } from './experiment-form-types';
 import { ExperimentFreqStackScreenMessage } from './experiment-freq-stack-screen';
 import { usePowerCheck } from '@/api/admin';


### PR DESCRIPTION
This moves ExperimentType, ExperimentFormData, and ExperimentScreenId into experiment-form-types.ts, and removes isFreq and isCmab in favor of using a standardized set of helpers in experiment-form-types.ts.