### PR TITLE
Add a useFeatureFlag hook and demonstrate its use guarding a new cluster_key field during experiment creation

### DIFF
--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -357,7 +357,6 @@ export default function ExperimentViewPage() {
   if (!experiment) {
     return <Text>No experiment data found</Text>;
   }
-
   const { design_spec, assign_summary, decision, impact } = experiment.config;
   const { alpha, power } = getAlphaAndPower(experiment.config); // undefined for non-frequentist experiments
   const { experiment_name, description, start_date, end_date, arms, design_url } = design_spec;

--- a/src/app/experiments/create/datasource-form/datasource-form-def.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-form-def.tsx
@@ -12,6 +12,7 @@ export type DatasourceFormInputData = {
   datasourceId?: string;
   tableName?: string;
   primaryKey?: string;
+  clusterKey?: string;
 };
 // Form data for the datasource selection/creation wizard
 export type DatasourceFormData = {
@@ -21,6 +22,8 @@ export type DatasourceFormData = {
   tableName?: string;
   // Selected primary key field
   primaryKey?: string;
+  // Optional cluster key field for cluster-randomized experiments
+  clusterKey?: string;
   // Selection mode: existing or create
   selectionMode: 'existing' | 'create';
   // Create datasource form state (reuse existing interface)
@@ -39,6 +42,7 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
     datasourceId: inputData?.datasourceId,
     tableName: inputData?.tableName,
     primaryKey: inputData?.primaryKey,
+    clusterKey: inputData?.clusterKey,
     selectionMode: 'existing',
   }),
   initialScreenId: () => 'select-datasource',
@@ -49,7 +53,13 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
       render: SelectDatasourceScreen,
       reducer: (data, msg) => {
         if (msg.type === 'set-datasource') {
-          return { ...data, datasourceId: msg.value, tableName: undefined, primaryKey: undefined };
+          return {
+            ...data,
+            datasourceId: msg.value,
+            tableName: undefined,
+            primaryKey: undefined,
+            clusterKey: undefined,
+          };
         }
         if (msg.type === 'set-mode') {
           if (msg.value === 'create') {
@@ -64,6 +74,7 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             selectionMode: 'existing',
             tableName: undefined,
             primaryKey: undefined,
+            clusterKey: undefined,
             createForm: defaultDatasourceFormData(),
           };
         }
@@ -78,10 +89,17 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
       render: SelectTableScreen,
       reducer: (data, msg) => {
         if (msg.type === 'set-table') {
-          return { ...data, tableName: msg.value, primaryKey: undefined };
+          return { ...data, tableName: msg.value, primaryKey: undefined, clusterKey: undefined };
         }
         if (msg.type === 'set-primary-key') {
-          return { ...data, primaryKey: msg.value };
+          return {
+            ...data,
+            primaryKey: msg.value,
+            clusterKey: data.clusterKey === msg.value ? undefined : data.clusterKey, // Can't be the same as the primary key
+          };
+        }
+        if (msg.type === 'set-cluster-key') {
+          return { ...data, clusterKey: msg.value };
         }
         return data;
       },

--- a/src/app/experiments/create/datasource-form/datasource-form-def.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-form-def.tsx
@@ -7,12 +7,14 @@ import {
   DatasourceFormData as CreateDatasourceFormData,
   defaultDatasourceFormData,
 } from '@/components/features/datasources/add-datasource-form';
+import { ExperimentType } from '@/app/experiments/create/experiment-form/experiment-form-types';
 
 export type DatasourceFormInputData = {
   datasourceId?: string;
   tableName?: string;
   primaryKey?: string;
   clusterKey?: string;
+  experimentType?: ExperimentType;
 };
 // Form data for the datasource selection/creation wizard
 export type DatasourceFormData = {
@@ -24,6 +26,8 @@ export type DatasourceFormData = {
   primaryKey?: string;
   // Optional cluster key field for cluster-randomized experiments
   clusterKey?: string;
+  // Experiment type context from the parent wizard (read-only)
+  experimentType?: ExperimentType;
   // Selection mode: existing or create
   selectionMode: 'existing' | 'create';
   // Create datasource form state (reuse existing interface)
@@ -43,6 +47,7 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
     tableName: inputData?.tableName,
     primaryKey: inputData?.primaryKey,
     clusterKey: inputData?.clusterKey,
+    experimentType: inputData?.experimentType,
     selectionMode: 'existing',
   }),
   initialScreenId: () => 'select-datasource',

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -5,13 +5,15 @@ import { useInspectDatasource, useInspectTableInDatasource } from '@/api/admin';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { SelectClusterKey } from '@/app/experiments/create/experiment-form/select-cluster-key';
 import { SelectPrimaryKey } from '@/app/experiments/create/experiment-form/select-primary-key';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 
 type SelectTableMessages =
   | { type: 'set-table'; value: string }
-  | { type: 'set-primary-key'; value: string | undefined };
+  | { type: 'set-primary-key'; value: string | undefined }
+  | { type: 'set-cluster-key'; value: string | undefined };
 
 export const SelectTableScreen = ({
   data,
@@ -127,6 +129,17 @@ export const SelectTableScreen = ({
           value={data.primaryKey}
           onChange={(value) => dispatch({ type: 'set-primary-key', value })}
           disabled={primaryKeyDisabled}
+        />
+      </Box>
+
+      <Box maxWidth={'50%'}>
+        <SelectClusterKey
+          tableData={tableData}
+          isLoading={isLoadingTable}
+          value={data.clusterKey}
+          onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
+          disabled={primaryKeyDisabled}
+          excludeFieldName={data.primaryKey}
         />
       </Box>
     </Flex>

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -2,11 +2,11 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { DatasourceFormData, DatasourceScreenId } from './datasource-form-def';
 import { useInspectDatasource, useInspectTableInDatasource } from '@/api/admin';
+import { PreassignedFrequentistExperimentSpecInputExperimentType } from '@/api/methods.schemas';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { SelectClusterKey } from '@/app/experiments/create/experiment-form/select-cluster-key';
-import { isFreqExperimentType } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { SelectPrimaryKey } from '@/app/experiments/create/experiment-form/select-primary-key';
 import { useFeatureFlag } from '@/services/feature-flags/use-feature-flag';
 import { ReloadIcon } from '@radix-ui/react-icons';
@@ -135,18 +135,19 @@ export const SelectTableScreen = ({
         />
       </Box>
 
-      {ffClusterExperimentsEnabled && isFreqExperimentType(data.experimentType) && (
-        <Box maxWidth={'50%'}>
-          <SelectClusterKey
-            tableData={tableData}
-            isLoading={isLoadingTable}
-            value={data.clusterKey}
-            onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
-            disabled={primaryKeyDisabled}
-            excludeFieldName={data.primaryKey}
-          />
-        </Box>
-      )}
+      {ffClusterExperimentsEnabled &&
+        data.experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned && (
+          <Box maxWidth={'50%'}>
+            <SelectClusterKey
+              tableData={tableData}
+              isLoading={isLoadingTable}
+              value={data.clusterKey}
+              onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
+              disabled={primaryKeyDisabled}
+              excludeFieldName={data.primaryKey}
+            />
+          </Box>
+        )}
     </Flex>
   );
 };

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -6,6 +6,7 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { SelectClusterKey } from '@/app/experiments/create/experiment-form/select-cluster-key';
+import { isFreqExperimentType } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { SelectPrimaryKey } from '@/app/experiments/create/experiment-form/select-primary-key';
 import { useFeatureFlag } from '@/services/feature-flags/use-feature-flag';
 import { ReloadIcon } from '@radix-ui/react-icons';
@@ -134,7 +135,7 @@ export const SelectTableScreen = ({
         />
       </Box>
 
-      {ffClusterExperimentsEnabled && (
+      {ffClusterExperimentsEnabled && isFreqExperimentType(data.experimentType) && (
         <Box maxWidth={'50%'}>
           <SelectClusterKey
             tableData={tableData}

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -23,6 +23,9 @@ export const SelectTableScreen = ({
 }: ScreenProps<DatasourceFormData, SelectTableMessages, DatasourceScreenId>) => {
   const ffClusterExperimentsEnabled = useFeatureFlag('cluster_experiments');
   const [refresh, setRefresh] = useState(false);
+  const [selectPrimaryKeyInput, setSelectPrimaryKeyInput] = useState(data.primaryKey ?? '');
+  const [selectClusterKeyInput, setSelectClusterKeyInput] = useState(data.clusterKey ?? '');
+
   const {
     data: inspectData,
     isValidating: validatingDatasource,
@@ -36,7 +39,7 @@ export const SelectTableScreen = ({
           setRefresh(false);
         }
         if (!data.tableName && response.tables.length > 0) {
-          dispatch({ type: 'set-table', value: response.tables[0] });
+          handleTableChange(response.tables[0]);
         }
       },
     },
@@ -51,10 +54,9 @@ export const SelectTableScreen = ({
         enabled: !!data.datasourceId && !!data.tableName,
         onSuccess: (response) => {
           if (!data.primaryKey) {
-            if (response.primary_key_fields.length > 0) {
-              dispatch({ type: 'set-primary-key', value: response.primary_key_fields[0] });
-            } else if (response.detected_unique_id_fields.length > 0) {
-              dispatch({ type: 'set-primary-key', value: response.detected_unique_id_fields[0] });
+            const detectedPrimaryKey = response.primary_key_fields[0] ?? response.detected_unique_id_fields[0];
+            if (detectedPrimaryKey) {
+              handlePrimaryKeyChange(detectedPrimaryKey, detectedPrimaryKey);
             }
           }
         },
@@ -64,6 +66,25 @@ export const SelectTableScreen = ({
 
   const tables = inspectData?.tables ?? [];
   const primaryKeyDisabled = !data.tableName || !inspectData;
+  const showClusterKeyField =
+    ffClusterExperimentsEnabled &&
+    data.experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned;
+
+  function handleTableChange(tableName: string) {
+    setSelectPrimaryKeyInput('');
+    setSelectClusterKeyInput('');
+    dispatch({ type: 'set-table', value: tableName });
+  }
+
+  function handlePrimaryKeyChange(inputText: string, selectedKey?: string) {
+    setSelectPrimaryKeyInput(inputText);
+    dispatch({ type: 'set-primary-key', value: selectedKey });
+  }
+
+  function handleClusterKeyChange(inputText: string, selectedKey?: string) {
+    setSelectClusterKeyInput(inputText);
+    dispatch({ type: 'set-cluster-key', value: selectedKey });
+  }
 
   if (isLoading) {
     return <XSpinner message="Loading tables..." />;
@@ -93,10 +114,7 @@ export const SelectTableScreen = ({
             Select a table
           </Text>
           <Flex direction={'row'} gap={'3'}>
-            <Select.Root
-              value={data.tableName}
-              onValueChange={(tableName) => dispatch({ type: 'set-table', value: tableName })}
-            >
+            <Select.Root value={data.tableName} onValueChange={handleTableChange}>
               <Select.Trigger placeholder="Select a table" />
               <Select.Content>
                 {tables.map((table) => (
@@ -129,25 +147,24 @@ export const SelectTableScreen = ({
         <SelectPrimaryKey
           tableData={tableData}
           isLoading={isLoadingTable}
-          value={data.primaryKey}
-          onChange={(value) => dispatch({ type: 'set-primary-key', value })}
+          inputValue={selectPrimaryKeyInput}
+          onChange={handlePrimaryKeyChange}
           disabled={primaryKeyDisabled}
         />
       </Box>
 
-      {ffClusterExperimentsEnabled &&
-        data.experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned && (
-          <Box maxWidth={'50%'}>
-            <SelectClusterKey
-              tableData={tableData}
-              isLoading={isLoadingTable}
-              value={data.clusterKey}
-              onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
-              disabled={primaryKeyDisabled}
-              excludeFieldName={data.primaryKey}
-            />
-          </Box>
-        )}
+      {showClusterKeyField && (
+        <Box maxWidth={'50%'}>
+          <SelectClusterKey
+            tableData={tableData}
+            isLoading={isLoadingTable}
+            inputValue={selectClusterKeyInput}
+            onChange={handleClusterKeyChange}
+            disabled={primaryKeyDisabled}
+            excludeFieldName={data.primaryKey}
+          />
+        </Box>
+      )}
     </Flex>
   );
 };

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -7,6 +7,7 @@ import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { SelectClusterKey } from '@/app/experiments/create/experiment-form/select-cluster-key';
 import { SelectPrimaryKey } from '@/app/experiments/create/experiment-form/select-primary-key';
+import { useFeatureFlag } from '@/services/feature-flags/use-feature-flag';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 
@@ -19,6 +20,7 @@ export const SelectTableScreen = ({
   data,
   dispatch,
 }: ScreenProps<DatasourceFormData, SelectTableMessages, DatasourceScreenId>) => {
+  const ffClusterExperimentsEnabled = useFeatureFlag('clusterExperiments');
   const [refresh, setRefresh] = useState(false);
   const {
     data: inspectData,
@@ -132,16 +134,18 @@ export const SelectTableScreen = ({
         />
       </Box>
 
-      <Box maxWidth={'50%'}>
-        <SelectClusterKey
-          tableData={tableData}
-          isLoading={isLoadingTable}
-          value={data.clusterKey}
-          onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
-          disabled={primaryKeyDisabled}
-          excludeFieldName={data.primaryKey}
-        />
-      </Box>
+      {ffClusterExperimentsEnabled && (
+        <Box maxWidth={'50%'}>
+          <SelectClusterKey
+            tableData={tableData}
+            isLoading={isLoadingTable}
+            value={data.clusterKey}
+            onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
+            disabled={primaryKeyDisabled}
+            excludeFieldName={data.primaryKey}
+          />
+        </Box>
+      )}
     </Flex>
   );
 };

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -20,7 +20,7 @@ export const SelectTableScreen = ({
   data,
   dispatch,
 }: ScreenProps<DatasourceFormData, SelectTableMessages, DatasourceScreenId>) => {
-  const ffClusterExperimentsEnabled = useFeatureFlag('clusterExperiments');
+  const ffClusterExperimentsEnabled = useFeatureFlag('cluster_experiments');
   const [refresh, setRefresh] = useState(false);
   const {
     data: inspectData,

--- a/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
+++ b/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { Button, Flex, Grid, Text, TextField, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { ExperimentFormData } from './experiment-form-types';
+import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
+
+export type ClusterStatisticsSectionAction =
+  | { type: 'set-cluster-icc'; value: number | undefined }
+  | { type: 'set-cluster-cv'; value: number | undefined }
+  | { type: 'set-cluster-avg-size'; value: number | undefined }
+  | { type: 'clear-cluster-stats' };
+
+const parseStatValue = (input: string, { min, max }: { min?: number; max?: number } = {}): number | undefined => {
+  const parsed = input === '' ? undefined : Number(input);
+  if (parsed === undefined || isNaN(parsed)) return undefined;
+  if (min !== undefined && parsed < min) return min;
+  if (max !== undefined && parsed > max) return max;
+  return parsed;
+};
+
+const formatStatValue = (value: number | undefined, decimalPlaces?: number): string => {
+  if (value === undefined) return '';
+  return decimalPlaces !== undefined ? value.toFixed(decimalPlaces) : String(value);
+};
+
+const formatStatDisplay = (value: number | undefined, decimalPlaces: number = 2): string => {
+  if (value === undefined) return '—';
+  return value.toFixed(decimalPlaces);
+};
+
+interface LabelWithTooltipProps {
+  label: string;
+  tooltip: string;
+}
+
+function LabelWithTooltip({ label, tooltip }: LabelWithTooltipProps) {
+  return (
+    <Flex align="center" gap="1">
+      <Text as="label" size="2" weight="bold">
+        {label}
+      </Text>
+      <Tooltip content={tooltip}>
+        <InfoCircledIcon />
+      </Tooltip>
+    </Flex>
+  );
+}
+
+interface ClusterStatisticsSectionProps {
+  data: ExperimentFormData;
+  dispatch: (action: ClusterStatisticsSectionAction) => void;
+}
+
+export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSectionProps) {
+  const hasClusterStatValues =
+    data.clusterIcc !== undefined || data.clusterCv !== undefined || data.clusterAvgClusterSize !== undefined;
+
+  return (
+    <Flex direction="column" gap="3">
+      <Text size="2" color="gray">
+        Cluster statistics are needed to estimate sample size. These will be derived from your data source, but you can
+        enter your own values below. The Intracluster Correlation Coefficient (ICC) from the primary metric or entered
+        here is also applied to all other metrics.
+      </Text>
+
+      <Flex align="center" gap="2">
+        <Text as="label" size="2" weight="bold">
+          Cluster ID field:
+        </Text>
+        <TextField.Root value={data.clusterKey ?? ''} readOnly />
+        <Button
+          type="button"
+          variant="soft"
+          disabled={!hasClusterStatValues}
+          onClick={() => dispatch({ type: 'clear-cluster-stats' })}
+        >
+          Reset stats
+        </Button>
+      </Flex>
+
+      <Grid columns={{ initial: '1', sm: '3' }} gap="4">
+        <Flex direction="column" gap="1">
+          <LabelWithTooltip label="Average Cluster Size" tooltip="The average number of participants per cluster." />
+          <EditableTextField
+            value={formatStatValue(data.clusterAvgClusterSize, 2)}
+            onSubmit={(value) => {
+              dispatch({ type: 'set-cluster-avg-size', value: parseStatValue(value, { min: 0 }) });
+            }}
+            type="number"
+            min={0}
+            size="2"
+          >
+            <Text size="2">{formatStatDisplay(data.clusterAvgClusterSize)}</Text>
+          </EditableTextField>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <LabelWithTooltip
+            label="Intracluster Correlation Coefficient"
+            tooltip="How similar individual primary metric values are within the same cluster. Values range from 0 to 1; higher values mean more similarity within clusters, which increases the total sample size you need."
+          />
+          <EditableTextField
+            value={formatStatValue(data.clusterIcc, 3)}
+            onSubmit={(value) => {
+              dispatch({ type: 'set-cluster-icc', value: parseStatValue(value, { min: 0, max: 1 }) });
+            }}
+            type="number"
+            min={0}
+            max={1}
+            step={0.005}
+            size="2"
+            minWidth="7ch"
+          >
+            <Text size="2">{formatStatDisplay(data.clusterIcc, 3)}</Text>
+          </EditableTextField>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <LabelWithTooltip
+            label="Coefficient of Variation"
+            tooltip="How much your cluster sizes vary from one another. Higher values mean more variability, which increases the total sample size you need."
+          />
+          <EditableTextField
+            value={formatStatValue(data.clusterCv, 2)}
+            onSubmit={(value) => {
+              dispatch({ type: 'set-cluster-cv', value: parseStatValue(value, { min: 0 }) });
+            }}
+            type="number"
+            min={0}
+            step={0.05}
+            size="2"
+          >
+            <Text size="2">{formatStatDisplay(data.clusterCv)}</Text>
+          </EditableTextField>
+        </Flex>
+      </Grid>
+    </Flex>
+  );
+}

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -179,6 +179,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             datasourceId: msg.datasourceId,
             tableName: msg.tableName,
             primaryKey: msg.primaryKey,
+            clusterKey: msg.clusterKey,
 
             // Clear metrics and filters if the datasource ID or table have changed. This could be improved by retain
             // entries based on the inspection results.

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -23,6 +23,7 @@ import {
 import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-freq-screen';
 import {
   convertToFrequentistDesignSpec,
+  getClusterStatsFromPowerCheckResponse,
   getReasonableEndDate,
   getReasonableStartDate,
   removeFieldByName,
@@ -173,6 +174,11 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       render: ExperimentSelectDatasourceScreen,
       reducer: (data, msg) => {
         const shouldClearDependents = data.datasourceId !== msg.datasourceId || data.tableName !== msg.tableName;
+        const shouldClearClusterStats =
+          shouldClearDependents ||
+          !msg.clusterKey ||
+          data.clusterKey !== msg.clusterKey ||
+          data.primaryKey !== msg.primaryKey;
         if (msg.type === 'set-datasource') {
           return {
             ...data,
@@ -187,6 +193,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
             filters: shouldClearDependents ? undefined : data.filters,
             strata: shouldClearDependents ? undefined : removeFieldByName(data.strata, msg.primaryKey),
+
+            clusterIcc: shouldClearClusterStats ? undefined : data.clusterIcc,
+            clusterCv: shouldClearClusterStats ? undefined : data.clusterCv,
+            clusterAvgClusterSize: shouldClearClusterStats ? undefined : data.clusterAvgClusterSize,
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
@@ -371,6 +381,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             primaryMetric: msg.primaryMetric,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -383,6 +396,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -395,6 +411,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -442,6 +461,56 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             filters: msg.filters,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+
+        if (msg.type === 'set-cluster-icc') {
+          return {
+            ...data,
+            clusterIcc: msg.value,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-cv') {
+          return {
+            ...data,
+            clusterCv: msg.value,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-avg-size') {
+          return {
+            ...data,
+            clusterAvgClusterSize: msg.value,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'clear-cluster-stats') {
+          return {
+            ...data,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -485,6 +554,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-chosen-n' || msg.type === 'set-power-check-response') {
+          const clusterStatsFromPowerCheck =
+            msg.type === 'set-power-check-response' && msg.response
+              ? getClusterStatsFromPowerCheckResponse(data, msg.response)
+              : undefined;
           switch (msg.sampleSizeOption) {
             case PowerCheckOption.NONE:
             case PowerCheckOption.USE_POWER_CHECK:
@@ -506,6 +579,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 desiredN: msg.desiredN,
                 powerCheckResponse: msg.response,
                 createExperimentError: undefined,
+                ...clusterStatsFromPowerCheck,
               };
             case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
             case PowerCheckOption.ENTER_OWN:
@@ -522,6 +596,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 desiredN: msg.desiredN,
                 mdePowerCheckResponse: msg.response,
                 createExperimentError: undefined,
+                ...clusterStatsFromPowerCheck,
               };
             default:
               return data;

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -105,6 +105,7 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     design_spec: {
       ...commonFields,
       experiment_type: data.experimentType,
+      ...(data.experimentType === 'freq_preassigned' && data.clusterKey ? { cluster_key: data.clusterKey } : {}),
       ...(data.experimentType === 'freq_preassigned' && data.desiredN !== undefined
         ? { desired_n: data.desiredN }
         : {}),

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -7,6 +7,7 @@ import {
   DesignSpecMetricRequest,
   MABExperimentSpecInputExperimentType,
   OnlineFrequentistExperimentSpecInputExperimentType,
+  PowerResponseOutput,
   PreassignedFrequentistExperimentSpecInputExperimentType,
   Stratum,
 } from '@/api/methods.schemas';
@@ -55,6 +56,32 @@ const zodNumberFromForm = (configure?: (num: z.ZodNumber) => z.ZodNumber) =>
 
 const zodMde = zodNumberFromForm((num) => num.int().safe().min(0).max(100));
 
+const getPrimaryMetricClusterStats = (data: ExperimentFormData) => {
+  if (!data.clusterKey) return undefined;
+  const icc = data.clusterIcc;
+  const cv = data.clusterCv;
+  const avgClusterSize = data.clusterAvgClusterSize;
+  if (icc === undefined && cv === undefined && avgClusterSize === undefined) return undefined;
+  return { icc, cv, avg_cluster_size: avgClusterSize };
+};
+
+export const getClusterStatsFromPowerCheckResponse = (
+  data: ExperimentFormData,
+  response: PowerResponseOutput,
+): Pick<ExperimentFormData, 'clusterIcc' | 'clusterCv' | 'clusterAvgClusterSize'> | undefined => {
+  if (!data.clusterKey || !data.primaryMetric) return undefined;
+
+  const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
+  const metricSpec = primary?.metric_spec;
+  if (!metricSpec) return undefined;
+
+  return {
+    clusterIcc: metricSpec.icc ?? undefined,
+    clusterCv: metricSpec.cv ?? undefined,
+    clusterAvgClusterSize: metricSpec.avg_cluster_size ?? undefined,
+  };
+};
+
 export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFrequentistDesignSpecInput {
   if (!isFreqExperimentType(data.experimentType)) {
     throw new Error('Frequentist configuration is required.');
@@ -65,11 +92,20 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
 
   const metrics: DesignSpecMetricRequest[] = [];
 
+  const primaryClusterStats = getPrimaryMetricClusterStats(data);
+
   if (data.primaryMetric?.metric.field_name) {
     zodMde.parse(data.primaryMetric.mde, { path: ['primaryMetric', 'mde'] });
     metrics.push({
       field_name: data.primaryMetric.metric.field_name,
       metric_pct_change: Number(data.primaryMetric.mde) / 100.0,
+      ...(primaryClusterStats
+        ? {
+            icc: primaryClusterStats.icc ?? null,
+            cv: primaryClusterStats.cv ?? null,
+            avg_cluster_size: primaryClusterStats.avg_cluster_size ?? null,
+          }
+        : {}),
     });
   }
 
@@ -85,7 +121,7 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     field_name: f.field_name,
   }));
 
-  const commonFields = {
+  const designSpec: Record<string, unknown> = {
     experiment_name: data.name,
     description: data.hypothesis ?? '',
     design_url: data.designUrl ?? null,
@@ -99,19 +135,16 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     filters: data.filters ?? [],
     power: data.power ? Number(data.power) / 100.0 : 0.8,
     alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
+    experiment_type: data.experimentType,
   };
+  if (data.experimentType === 'freq_preassigned' && data.clusterKey) {
+    designSpec.cluster_key = data.clusterKey;
+  }
+  if (data.experimentType === 'freq_preassigned' && data.desiredN !== undefined) {
+    designSpec.desired_n = data.desiredN;
+  }
 
-  const spec = createExperimentBody.strict().parse({
-    design_spec: {
-      ...commonFields,
-      experiment_type: data.experimentType,
-      ...(data.experimentType === 'freq_preassigned' && data.clusterKey ? { cluster_key: data.clusterKey } : {}),
-      ...(data.experimentType === 'freq_preassigned' && data.desiredN !== undefined
-        ? { desired_n: data.desiredN }
-        : {}),
-    },
-  }).design_spec;
-
+  const spec = createExperimentBody.strict().parse({ design_spec: designSpec }).design_spec;
   if (!isFrequentistSpec(spec)) {
     throw new Error('Frequentist configuration is required.');
   }

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -101,9 +101,10 @@ export type ExperimentFormData = {
   // experiment-select-datasource-screen
   datasourceId?: string;
   tableName?: string;
+  primaryKey?: string;
+  clusterKey?: string;
 
   // experiment-freq-stack-screen
-  primaryKey?: string;
   primaryMetric?: MetricWithMDE;
   secondaryMetrics?: MetricWithMDE[];
   filters?: FilterInput[];

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -123,6 +123,10 @@ export type ExperimentFormData = {
   mdePowerCheckResponse?: PowerResponseOutput;
   createExperimentResponse?: CreateExperimentResponse;
   createExperimentError?: ErrorType<unknown>;
+  // Values needed for cluster-randomized experiments
+  clusterAvgClusterSize?: number;
+  clusterIcc?: number;
+  clusterCv?: number;
 
   // experiment-describe-webhooks-screen
   selectedWebhookIds?: string[];

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -8,6 +8,7 @@ import { StrataBuilder } from '@/components/features/experiments/strata-builder'
 import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
 import { CreateExperimentResponse, FieldMetadata, FilterInput } from '@/api/methods.schemas';
 import { PowerCheckSection, PowerCheckSectionAction } from './power-check-section';
+import { ClusterStatisticsSectionAction } from './cluster-statistics-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import {
   convertToFrequentistDesignSpec,
@@ -20,6 +21,7 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 export type ExperimentFreqStackScreenMessage =
   | MetricBuilderAction
   | PowerCheckSectionAction
+  | ClusterStatisticsSectionAction
   | { type: 'set-filters'; filters: FilterInput[] }
   | { type: 'set-strata'; strata: FieldMetadata[] }
   | { type: 'set-create-response'; response: CreateExperimentResponse }
@@ -169,6 +171,7 @@ export const ExperimentFreqStackScreen = ({
             secondaryMetrics={data.secondaryMetrics ?? []}
             dispatch={dispatch}
             metricFields={metricFields}
+            excludeKeys={[data.primaryKey, data.clusterKey].filter((key): key is string => key !== undefined)}
           />
         </Card>
 
@@ -183,16 +186,20 @@ export const ExperimentFreqStackScreen = ({
           />
         </Card>
 
-        <Heading as="h3" size="3">
-          Strata
-        </Heading>
-        <Card>
-          <StrataBuilder
-            availableStrata={availableStrata}
-            selectedStrata={selectedStrata}
-            onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
-          />
-        </Card>
+        {!data.clusterKey && (
+          <>
+            <Heading as="h3" size="3">
+              Strata
+            </Heading>
+            <Card>
+              <StrataBuilder
+                availableStrata={availableStrata}
+                selectedStrata={selectedStrata}
+                onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
+              />
+            </Card>
+          </>
+        )}
 
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>

--- a/src/app/experiments/create/experiment-form/experiment-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-datasource-screen.tsx
@@ -37,8 +37,9 @@ export const ExperimentSelectDatasourceScreen = ({
       tableName: data.tableName,
       primaryKey: data.primaryKey,
       clusterKey: data.clusterKey,
+      experimentType: data.experimentType,
     }),
-    [data.clusterKey, data.datasourceId, data.primaryKey, data.tableName],
+    [data.clusterKey, data.datasourceId, data.experimentType, data.primaryKey, data.tableName],
   );
 
   return (

--- a/src/app/experiments/create/experiment-form/experiment-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-datasource-screen.tsx
@@ -11,6 +11,7 @@ type ExperimentSelectDatasourceMessages = {
   datasourceId: string;
   tableName: string;
   primaryKey?: string;
+  clusterKey?: string;
 };
 
 export const ExperimentSelectDatasourceScreen = ({
@@ -25,6 +26,7 @@ export const ExperimentSelectDatasourceScreen = ({
       datasourceId: formData.datasourceId!,
       tableName: formData.tableName!,
       primaryKey: formData.primaryKey,
+      clusterKey: formData.clusterKey,
     });
     navigateNext();
   };
@@ -34,8 +36,9 @@ export const ExperimentSelectDatasourceScreen = ({
       datasourceId: data.datasourceId,
       tableName: data.tableName,
       primaryKey: data.primaryKey,
+      clusterKey: data.clusterKey,
     }),
-    [data.datasourceId, data.primaryKey, data.tableName],
+    [data.clusterKey, data.datasourceId, data.primaryKey, data.tableName],
   );
 
   return (

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -29,6 +29,7 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
 import { useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
+import { ClusterStatisticsSection, ClusterStatisticsSectionAction } from './cluster-statistics-section';
 
 export type PowerCheckSectionAction =
   | { type: 'set-confidence'; value: string }
@@ -38,7 +39,7 @@ export type PowerCheckSectionAction =
 
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
-  dispatch: (action: PowerCheckSectionAction) => void;
+  dispatch: (action: PowerCheckSectionAction | ClusterStatisticsSectionAction) => void;
 }
 
 const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData) => {
@@ -161,6 +162,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
           />
         </Flex>
       </Flex>
+
+      {data.clusterKey && (
+        <SectionCard title="Cluster Statistics">
+          <ClusterStatisticsSection data={data} dispatch={dispatch} />
+        </SectionCard>
+      )}
 
       <SectionCard title="Analysis">
         <Flex direction="column" gap="3" align="center">

--- a/src/app/experiments/create/experiment-form/select-cluster-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-cluster-key.tsx
@@ -4,27 +4,30 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
 import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
 import { Combobox } from '@/components/ui/combobox';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 interface ComboboxRowProps {
   data_type: DataType;
   field_name: string;
 }
 
-const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => {
-  return (
-    <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
-      <Text size="2">{field_name}</Text>
-      <DataTypeBadge type={data_type} />
-    </Flex>
-  );
-};
+const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => (
+  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+    <Text size="2">{field_name}</Text>
+    <DataTypeBadge type={data_type} />
+  </Flex>
+);
 
 interface SelectClusterKeyProps {
   tableData: InspectDatasourceTableResponse | undefined;
-  value: string | undefined;
+  /** Input text owned by the parent component. */
+  inputValue: string;
   isLoading: boolean;
-  onChange: (value: string | undefined) => void;
+  /**
+   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
+   * exact unique field-name match (same as Combobox), otherwise undefined.
+   */
+  onChange: (inputText: string, selectedKey?: string) => void;
   disabled?: boolean;
   excludeFieldName?: string; // to prevent the cluster key from being the same as the primary key
 }
@@ -32,12 +35,11 @@ interface SelectClusterKeyProps {
 export const SelectClusterKey = ({
   tableData,
   isLoading,
-  value,
+  inputValue,
   onChange,
   disabled,
   excludeFieldName,
 }: SelectClusterKeyProps) => {
-  const [inputValue, setInputValue] = useState<string>(value ?? '');
   const orderedFields = useMemo(() => {
     const fields = tableData?.fields ?? [];
     return fields
@@ -46,10 +48,6 @@ export const SelectClusterKey = ({
   }, [excludeFieldName, tableData]);
   const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
   const showSpinner = isLoading && !disabled;
-
-  useEffect(() => {
-    setInputValue(value ?? '');
-  }, [value]);
 
   return (
     <Flex direction="column" gap={'3'}>
@@ -73,10 +71,7 @@ export const SelectClusterKey = ({
       ) : (
         <Combobox
           value={inputValue}
-          onChange={(value, key) => {
-            setInputValue(value);
-            onChange(key);
-          }}
+          onChange={onChange}
           options={orderedFields}
           rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
           dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}

--- a/src/app/experiments/create/experiment-form/select-cluster-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-cluster-key.tsx
@@ -1,0 +1,90 @@
+import { Flex, Text, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
+import { Combobox } from '@/components/ui/combobox';
+import { useEffect, useMemo, useState } from 'react';
+
+interface ComboboxRowProps {
+  data_type: DataType;
+  field_name: string;
+}
+
+const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => {
+  return (
+    <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+      <Text size="2">{field_name}</Text>
+      <DataTypeBadge type={data_type} />
+    </Flex>
+  );
+};
+
+interface SelectClusterKeyProps {
+  tableData: InspectDatasourceTableResponse | undefined;
+  value: string | undefined;
+  isLoading: boolean;
+  onChange: (value: string | undefined) => void;
+  disabled?: boolean;
+  excludeFieldName?: string; // to prevent the cluster key from being the same as the primary key
+}
+
+export const SelectClusterKey = ({
+  tableData,
+  isLoading,
+  value,
+  onChange,
+  disabled,
+  excludeFieldName,
+}: SelectClusterKeyProps) => {
+  const [inputValue, setInputValue] = useState<string>(value ?? '');
+  const orderedFields = useMemo(() => {
+    const fields = tableData?.fields ?? [];
+    return fields
+      .filter((field) => field.field_name !== excludeFieldName)
+      .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
+  }, [excludeFieldName, tableData]);
+  const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
+  const showSpinner = isLoading && !disabled;
+
+  useEffect(() => {
+    setInputValue(value ?? '');
+  }, [value]);
+
+  return (
+    <Flex direction="column" gap={'3'}>
+      <Flex align="center" gap="1">
+        <Text as="label" size="2" weight="bold">
+          Cluster key (optional)
+        </Text>
+        <Tooltip
+          content={
+            'If your treatment is naturally delivered at a group level (such as schools, clinics, ' +
+            'or districts), but you will track metrics at the participant level, set this to ' +
+            'randomly assign whole groups of participants together to your arms. ' +
+            'Select the field that identifies each group.'
+          }
+        >
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+      {showSpinner ? (
+        <XSpinner message="Loading fields..." />
+      ) : (
+        <Combobox
+          value={inputValue}
+          onChange={(value, key) => {
+            setInputValue(value);
+            onChange(key);
+          }}
+          options={orderedFields}
+          rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
+          dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}
+          getDisplayTextForOption={(v) => v.field_name}
+          getKeyForOption={(v) => v.field_name}
+          disabled={disabled}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/src/app/experiments/create/experiment-form/select-primary-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-primary-key.tsx
@@ -1,9 +1,10 @@
-import { Badge, Flex, Text } from '@radix-ui/themes';
+import { Badge, Flex, Text, Tooltip } from '@radix-ui/themes';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
 import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
 import { Combobox } from '@/components/ui/combobox';
 import { useEffect, useMemo, useState } from 'react';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 interface RightBadgesProps {
   primary_key: boolean;
@@ -71,9 +72,15 @@ export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabl
 
   return (
     <Flex direction="column" gap={'3'}>
-      <Text as="label" size="2" weight="bold">
-        Unique ID
-      </Text>
+      <Flex align="center" gap="1">
+        <Text as="label" size="2" weight="bold">
+          Unique ID
+        </Text>
+        <Tooltip content="Select the field that will uniquely identify each individual participant in the experiment.">
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+
       {showSpinner ? (
         <XSpinner message="Loading fields..." />
       ) : (

--- a/src/app/experiments/create/experiment-form/select-primary-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-primary-key.tsx
@@ -3,7 +3,7 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
 import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
 import { Combobox } from '@/components/ui/combobox';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 interface RightBadgesProps {
@@ -29,25 +29,27 @@ interface ComboboxRowProps {
   recommended: boolean;
 }
 
-const ComboboxRow = ({ field_name, data_type, recommended, primary_key }: ComboboxRowProps) => {
-  return (
-    <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
-      <Text size="2">{field_name}</Text>
-      <RightBadges recommended={recommended} type={data_type} primary_key={primary_key} />
-    </Flex>
-  );
-};
+const ComboboxRow = ({ field_name, data_type, recommended, primary_key }: ComboboxRowProps) => (
+  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+    <Text size="2">{field_name}</Text>
+    <RightBadges recommended={recommended} type={data_type} primary_key={primary_key} />
+  </Flex>
+);
 
 interface SelectPrimaryKeyProps {
   tableData: InspectDatasourceTableResponse | undefined;
-  value: string | undefined;
+  /** Input text owned by the parent component. */
+  inputValue: string;
   isLoading: boolean;
-  onChange: (value: string | undefined) => void;
+  /**
+   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
+   * exact unique field-name match (same as Combobox), otherwise undefined.
+   */
+  onChange: (inputText: string, selectedKey?: string) => void;
   disabled?: boolean;
 }
 
-export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabled }: SelectPrimaryKeyProps) => {
-  const [inputValue, setInputValue] = useState<string>(value ?? '');
+export const SelectPrimaryKey = ({ tableData, isLoading, inputValue, onChange, disabled }: SelectPrimaryKeyProps) => {
   const primaryKeyFields = useMemo(() => new Set(tableData?.primary_key_fields ?? []), [tableData]);
   const uniqueIdFields = useMemo(() => new Set(tableData?.detected_unique_id_fields ?? []), [tableData]);
   const orderedFields = useMemo(() => {
@@ -66,10 +68,6 @@ export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabl
   const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
   const showSpinner = isLoading && !disabled;
 
-  useEffect(() => {
-    setInputValue(value ?? '');
-  }, [value]);
-
   return (
     <Flex direction="column" gap={'3'}>
       <Flex align="center" gap="1">
@@ -85,20 +83,17 @@ export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabl
         <XSpinner message="Loading fields..." />
       ) : (
         <Combobox
-          value={inputValue ?? ''}
-          onChange={(value, key) => {
-            setInputValue(value);
-            onChange(key);
-          }}
+          value={inputValue}
+          onChange={onChange}
           options={orderedFields}
           rightSlot={
-            exactMatchField && (
+            exactMatchField ? (
               <RightBadges
                 primary_key={primaryKeyFields.has(exactMatchField.field_name)}
                 recommended={uniqueIdFields.has(exactMatchField.field_name)}
                 type={exactMatchField.data_type}
               />
-            )
+            ) : null
           }
           dropdownRow={({ option }) => (
             <ComboboxRow

--- a/src/components/features/experiments/metric-builder.tsx
+++ b/src/components/features/experiments/metric-builder.tsx
@@ -22,9 +22,16 @@ type MetricBuilderProps = {
   secondaryMetrics: MetricWithMDE[];
   dispatch: (action: MetricBuilderAction) => void;
   metricFields: GetMetricsResponseElement[];
+  excludeKeys?: string[];
 };
 
-export function MetricBuilder({ primaryMetric, secondaryMetrics, dispatch, metricFields }: MetricBuilderProps) {
+export function MetricBuilder({
+  primaryMetric,
+  secondaryMetrics,
+  dispatch,
+  metricFields,
+  excludeKeys,
+}: MetricBuilderProps) {
   const handlePrimaryMetricSelect = (metric: GetMetricsResponseElement) => {
     dispatch({ type: 'primary-metric-select', primaryMetric: { metric, mde: DEFAULT_MDE } });
   };
@@ -90,18 +97,17 @@ export function MetricBuilder({ primaryMetric, secondaryMetrics, dispatch, metri
     }
   };
 
-  // Determine metrics available for primary selection (all metrics not in secondaryMetrics)
+  const isExcludedMetric = (fieldName: string) =>
+    excludeKeys?.includes(fieldName) || secondaryMetrics.some((sm) => sm.metric.field_name === fieldName);
+
+  // Determine metrics available for primary selection
   const availablePrimaryMetricBadges = metricFields
-    .filter((m) => !secondaryMetrics.some((sm) => sm.metric.field_name === m.field_name))
+    .filter((m) => !isExcludedMetric(m.field_name))
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
 
   // Determine metrics available for secondary selection
   const availableSecondaryMetricBadges = metricFields
-    .filter(
-      (m) =>
-        m.field_name !== primaryMetric?.metric.field_name &&
-        !secondaryMetrics.some((sm) => sm.metric.field_name === m.field_name),
-    )
+    .filter((m) => m.field_name !== primaryMetric?.metric.field_name && !isExcludedMetric(m.field_name))
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
 
   return (

--- a/src/components/radix-custom/editable/editable-root.tsx
+++ b/src/components/radix-custom/editable/editable-root.tsx
@@ -38,11 +38,6 @@ export function EditableRoot({ children, value, onSubmit }: EditableRootProps) {
 
   const edit = () => setIsEditing(true);
   const submit = async () => {
-    if (inputValue.trim() === '') {
-      cancel();
-      return;
-    }
-
     if (onSubmit) {
       try {
         await onSubmit(inputValue);

--- a/src/components/ui/inputs/editable-text-field.tsx
+++ b/src/components/ui/inputs/editable-text-field.tsx
@@ -15,9 +15,25 @@ interface EditableTextFieldProps {
   onSubmit: (value: string) => Promise<void> | void;
   children: ReactNode;
   size?: '1' | '2' | '3';
+  type?: 'text' | 'number';
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Minimum width for the edit input (not the preview). */
+  minWidth?: string;
 }
 
-export function EditableTextField({ value, onSubmit, children, size = '2' }: EditableTextFieldProps) {
+export function EditableTextField({
+  value,
+  onSubmit,
+  children,
+  size = '2',
+  type = 'text',
+  min,
+  max,
+  step,
+  minWidth,
+}: EditableTextFieldProps) {
   const [error, setError] = useState<boolean>();
 
   const handleSubmit = async (value: string) => {
@@ -43,6 +59,10 @@ export function EditableTextField({ value, onSubmit, children, size = '2' }: Edi
               <EditableInput>
                 {({ value, onChange, onKeyDown }) => (
                   <TextField.Root
+                    type={type}
+                    min={min}
+                    max={max}
+                    step={step}
                     value={value}
                     onChange={(e) => {
                       onChange(e);
@@ -52,6 +72,7 @@ export function EditableTextField({ value, onSubmit, children, size = '2' }: Edi
                     size={size}
                     variant={error ? 'soft' : 'surface'}
                     color={error ? 'red' : undefined}
+                    style={minWidth ? { minWidth } : undefined}
                     autoFocus
                   />
                 )}

--- a/src/services/feature-flags/feature-flags.ts
+++ b/src/services/feature-flags/feature-flags.ts
@@ -1,0 +1,82 @@
+type BooleanFeatureFlagDef = {
+  storageKey: string;
+  envValue: string | undefined;
+  defaultValue: boolean;
+};
+
+type NumberFeatureFlagDef = {
+  storageKey: string;
+  envValue: string | undefined;
+  defaultValue: number;
+};
+
+type FeatureFlagDef = BooleanFeatureFlagDef | NumberFeatureFlagDef;
+
+/**
+ * Registry of client-side feature flags.
+ *
+ * Add new flags here. Each flag needs:
+ * - a unique localStorage `storageKey` (dev override via DevTools)
+ * - an explicit `process.env.NEXT_PUBLIC_*` reference (required for Next.js inlining)
+ * - a hard-coded `defaultValue` when the env var is unset
+ */
+export const FEATURE_FLAGS = {
+  clusterExperiments: {
+    storageKey: 'ff_cluster_experiments',
+    envValue: process.env.NEXT_PUBLIC_FF_CLUSTER_EXPERIMENTS,
+    defaultValue: false,
+  },
+  exampleNumericFlag: {
+    storageKey: 'ff_example_numeric_flag',
+    envValue: process.env.NEXT_PUBLIC_FF_EXAMPLE_NUMERIC_FLAG,
+    defaultValue: 0,
+  },
+} as const satisfies Record<string, FeatureFlagDef>;
+
+export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
+
+export type FeatureFlagValue<K extends FeatureFlagKey> = (typeof FEATURE_FLAGS)[K]['defaultValue'];
+
+function resolveBooleanEnv(envValue: string | undefined, defaultValue: boolean): boolean {
+  if (envValue === undefined || envValue === '') {
+    return defaultValue;
+  }
+  return envValue === 'true' || envValue === '1';
+}
+
+function resolveNumberEnv(envValue: string | undefined, defaultValue: number): number {
+  if (envValue === undefined || envValue === '') {
+    return defaultValue;
+  }
+  const parsed = Number(envValue);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+export function parseFeatureFlagStoredValue<K extends FeatureFlagKey>(
+  stored: unknown,
+  key: K,
+): FeatureFlagValue<K> | undefined {
+  if (stored === null) {
+    return undefined;
+  }
+
+  const def = FEATURE_FLAGS[key];
+
+  if (typeof def.defaultValue === 'boolean' && (typeof stored === 'boolean' || typeof stored === 'number')) {
+    return (stored === true || stored === 1) as FeatureFlagValue<K>;
+  }
+
+  if (typeof def.defaultValue === 'number' && typeof stored === 'number' && !Number.isNaN(stored)) {
+    return stored as FeatureFlagValue<K>;
+  }
+
+  return undefined;
+}
+
+export function getFeatureFlagDefault<K extends FeatureFlagKey>(key: K): FeatureFlagValue<K> {
+  const def = FEATURE_FLAGS[key];
+  if (typeof def.defaultValue === 'boolean') {
+    return resolveBooleanEnv(def.envValue, def.defaultValue) as FeatureFlagValue<K>;
+  }
+  return resolveNumberEnv(def.envValue, def.defaultValue) as FeatureFlagValue<K>;
+}

--- a/src/services/feature-flags/feature-flags.ts
+++ b/src/services/feature-flags/feature-flags.ts
@@ -1,82 +1,19 @@
-type BooleanFeatureFlagDef = {
-  storageKey: string;
-  envValue: string | undefined;
-  defaultValue: boolean;
-};
+/** Feature flags for the application are all defined in this file. Only boolean flags support. */
+export const FLAGS = {
+  CLUSTER_EXPERIMENTS: 'cluster_experiments',
+} as const;
 
-type NumberFeatureFlagDef = {
-  storageKey: string;
-  envValue: string | undefined;
-  defaultValue: number;
-};
+// Extract the union type of the FLAGS keys
+export type FlagKey = (typeof FLAGS)[keyof typeof FLAGS];
 
-type FeatureFlagDef = BooleanFeatureFlagDef | NumberFeatureFlagDef;
+function isTrue(val: string | undefined | null): boolean {
+  return val === 'true' || val === '1';
+}
 
 /**
- * Registry of client-side feature flags.
- *
- * Add new flags here. Each flag needs:
- * - a unique localStorage `storageKey` (dev override via DevTools)
- * - an explicit `process.env.NEXT_PUBLIC_*` reference (required for Next.js inlining)
- * - a hard-coded `defaultValue` when the env var is unset
+ * Require FLAG_DEFAULTS to include every key defined in FlagKey.
+ * To permanently enable a feature, we require a code change that sets the default to true.
  */
-export const FEATURE_FLAGS = {
-  clusterExperiments: {
-    storageKey: 'ff_cluster_experiments',
-    envValue: process.env.NEXT_PUBLIC_FF_CLUSTER_EXPERIMENTS,
-    defaultValue: false,
-  },
-  exampleNumericFlag: {
-    storageKey: 'ff_example_numeric_flag',
-    envValue: process.env.NEXT_PUBLIC_FF_EXAMPLE_NUMERIC_FLAG,
-    defaultValue: 0,
-  },
-} as const satisfies Record<string, FeatureFlagDef>;
-
-export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;
-
-export type FeatureFlagValue<K extends FeatureFlagKey> = (typeof FEATURE_FLAGS)[K]['defaultValue'];
-
-function resolveBooleanEnv(envValue: string | undefined, defaultValue: boolean): boolean {
-  if (envValue === undefined || envValue === '') {
-    return defaultValue;
-  }
-  return envValue === 'true' || envValue === '1';
-}
-
-function resolveNumberEnv(envValue: string | undefined, defaultValue: number): number {
-  if (envValue === undefined || envValue === '') {
-    return defaultValue;
-  }
-  const parsed = Number(envValue);
-  return Number.isNaN(parsed) ? defaultValue : parsed;
-}
-
-export function parseFeatureFlagStoredValue<K extends FeatureFlagKey>(
-  stored: unknown,
-  key: K,
-): FeatureFlagValue<K> | undefined {
-  if (stored === null) {
-    return undefined;
-  }
-
-  const def = FEATURE_FLAGS[key];
-
-  if (typeof def.defaultValue === 'boolean' && (typeof stored === 'boolean' || typeof stored === 'number')) {
-    return (stored === true || stored === 1) as FeatureFlagValue<K>;
-  }
-
-  if (typeof def.defaultValue === 'number' && typeof stored === 'number' && !Number.isNaN(stored)) {
-    return stored as FeatureFlagValue<K>;
-  }
-
-  return undefined;
-}
-
-export function getFeatureFlagDefault<K extends FeatureFlagKey>(key: K): FeatureFlagValue<K> {
-  const def = FEATURE_FLAGS[key];
-  if (typeof def.defaultValue === 'boolean') {
-    return resolveBooleanEnv(def.envValue, def.defaultValue) as FeatureFlagValue<K>;
-  }
-  return resolveNumberEnv(def.envValue, def.defaultValue) as FeatureFlagValue<K>;
-}
+export const FLAG_DEFAULTS: Record<FlagKey, boolean> = {
+  [FLAGS.CLUSTER_EXPERIMENTS]: isTrue(process.env.NEXT_PUBLIC_FF_CLUSTER_EXPERIMENTS),
+};

--- a/src/services/feature-flags/use-feature-flag.ts
+++ b/src/services/feature-flags/use-feature-flag.ts
@@ -1,30 +1,46 @@
 'use client';
 
+import { FLAG_DEFAULTS, FlagKey } from './feature-flags';
 import { useLocalStorage } from '@/providers/use-local-storage';
 
-import {
-  type FeatureFlagKey,
-  type FeatureFlagValue,
-  FEATURE_FLAGS,
-  getFeatureFlagDefault,
-  parseFeatureFlagStoredValue,
-} from './feature-flags';
-
 /**
- * Basic developer feature flag hook.
+ * Returns whether a feature flag is enabled.
  *
- * To set a feature flag in dev tools:
- *   localStorage.setItem('my_flag_storagekey', 'true');
- * Then refresh the page, or send the custom event with key defined by userLocalStorage e.g.:
- *   window.dispatchEvent(new StorageEvent('uls_my_flag_storagekey_event'));
+ * Resolution order:
+ * 1. `localStorage` override at `ff_<flagKey>` (developer tooling)
+ * 2. Build-time default from `FLAG_DEFAULTS` (env vars)
+ *
+ * @example
+ * ```tsx
+ * import { FLAGS } from './feature-flags';
+ *
+ * const clusterExperimentsEnabled = useFeatureFlag(FLAGS.CLUSTER_EXPERIMENTS);
+ * ```
+ *
+ * Override a flag from the browser console without refreshing:
+ *
+ * @example
+ * ```js
+ * const key = 'ff_cluster_experiments';
+ * const eventKey = `uls_${key}_event`;
+ *
+ * localStorage.setItem(key, true); // or false
+ * window.dispatchEvent(new StorageEvent(eventKey));
+ * ```
+ *
+ * Remove the override to fall back to the env default:
+ *
+ * @example
+ * ```js
+ * localStorage.removeItem(key);
+ * window.dispatchEvent(new StorageEvent(eventKey));
+ * ```
  */
-export function useFeatureFlag<K extends FeatureFlagKey>(key: K): FeatureFlagValue<K> {
-  const { storageKey } = FEATURE_FLAGS[key];
-  const [stored] = useLocalStorage<FeatureFlagValue<K>>(storageKey);
+export function useFeatureFlag(flagKey: FlagKey): boolean {
+  const [storedValue] = useLocalStorage<boolean>(`ff_${flagKey}`);
 
-  const override = parseFeatureFlagStoredValue(stored, key);
-  if (override !== undefined) {
-    return override;
+  if (storedValue !== undefined && storedValue !== null) {
+    return storedValue;
   }
-  return getFeatureFlagDefault(key);
+  return FLAG_DEFAULTS[flagKey];
 }

--- a/src/services/feature-flags/use-feature-flag.ts
+++ b/src/services/feature-flags/use-feature-flag.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useLocalStorage } from '@/providers/use-local-storage';
+
+import {
+  type FeatureFlagKey,
+  type FeatureFlagValue,
+  FEATURE_FLAGS,
+  getFeatureFlagDefault,
+  parseFeatureFlagStoredValue,
+} from './feature-flags';
+
+/**
+ * Basic developer feature flag hook.
+ *
+ * To set a feature flag in dev tools:
+ *   localStorage.setItem('my_flag_storagekey', 'true');
+ * Then refresh the page, or send the custom event with key defined by userLocalStorage e.g.:
+ *   window.dispatchEvent(new StorageEvent('uls_my_flag_storagekey_event'));
+ */
+export function useFeatureFlag<K extends FeatureFlagKey>(key: K): FeatureFlagValue<K> {
+  const { storageKey } = FEATURE_FLAGS[key];
+  const [stored] = useLocalStorage<FeatureFlagValue<K>>(storageKey);
+
+  const override = parseFeatureFlagStoredValue(stored, key);
+  if (override !== undefined) {
+    return override;
+  }
+  return getFeatureFlagDefault(key);
+}


### PR DESCRIPTION
## Ticket

As an initial setup for https://github.com/agency-fund/evidential-be/issues/217, this ticket introduces basic boolean feature flag support meant for developer use, via a useFeatureFlag hook and pre-defined flag constants that work with it.

Also adds a cluster_key to the datasource selection step preassigned freq exps, with a new SelectClusterKey component inspired by the SelectPrimaryKey. We guard it with a feature flag, such that only if this field is set will any downstream UI additions be enabled. So the only place that we should ever need to guard with a flag cluster-related WIP components should be at this point.

### Future Tasks 

Build out the rest of the cluster experiment UI.

## How has this been tested?

Manually with various combinations of the following:
```
localStorage.setItem('ff_cluster_experiments', 1)
localStorage.setItem('ff_cluster_experiments', true)
localStorage.setItem('ff_cluster_experiments', false)
localStorage.removeItem('ff_cluster_experiments')
window.dispatchEvent(new StorageEvent('uls_ff_cluster_experiments_event'));
```
and running the server with `NEXT_PUBLIC_FF_CLUSTER_EXPERIMENTS=1 task start-airplane`. 
<img width="603" height="401" alt="image" src="https://github.com/user-attachments/assets/62b3447f-0e58-4d0c-9e1e-31fcbcff10ca" />
