### PR TITLE
Clustered experiments UI: add a ClusterStatisticsSection to the experiment creation flow

### DIFF
--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -23,6 +23,8 @@ export const SelectTableScreen = ({
 }: ScreenProps<DatasourceFormData, SelectTableMessages, DatasourceScreenId>) => {
   const ffClusterExperimentsEnabled = useFeatureFlag('cluster_experiments');
   const [refresh, setRefresh] = useState(false);
+  const [selectClusterKeyInput, setSelectClusterKeyInput] = useState(data.clusterKey ?? '');
+
   const {
     data: inspectData,
     isValidating: validatingDatasource,
@@ -36,7 +38,7 @@ export const SelectTableScreen = ({
           setRefresh(false);
         }
         if (!data.tableName && response.tables.length > 0) {
-          dispatch({ type: 'set-table', value: response.tables[0] });
+          handleTableChange(response.tables[0]);
         }
       },
     },
@@ -64,6 +66,19 @@ export const SelectTableScreen = ({
 
   const tables = inspectData?.tables ?? [];
   const primaryKeyDisabled = !data.tableName || !inspectData;
+  const showClusterKeyField =
+    ffClusterExperimentsEnabled &&
+    data.experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned;
+
+  function handleTableChange(tableName: string) {
+    setSelectClusterKeyInput('');
+    dispatch({ type: 'set-table', value: tableName });
+  }
+
+  function handleClusterKeyChange(inputText: string, selectedKey?: string) {
+    setSelectClusterKeyInput(inputText);
+    dispatch({ type: 'set-cluster-key', value: selectedKey });
+  }
 
   if (isLoading) {
     return <XSpinner message="Loading tables..." />;
@@ -93,10 +108,7 @@ export const SelectTableScreen = ({
             Select a table
           </Text>
           <Flex direction={'row'} gap={'3'}>
-            <Select.Root
-              value={data.tableName}
-              onValueChange={(tableName) => dispatch({ type: 'set-table', value: tableName })}
-            >
+            <Select.Root value={data.tableName} onValueChange={handleTableChange}>
               <Select.Trigger placeholder="Select a table" />
               <Select.Content>
                 {tables.map((table) => (
@@ -135,19 +147,18 @@ export const SelectTableScreen = ({
         />
       </Box>
 
-      {ffClusterExperimentsEnabled &&
-        data.experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned && (
-          <Box maxWidth={'50%'}>
-            <SelectClusterKey
-              tableData={tableData}
-              isLoading={isLoadingTable}
-              value={data.clusterKey}
-              onChange={(value) => dispatch({ type: 'set-cluster-key', value })}
-              disabled={primaryKeyDisabled}
-              excludeFieldName={data.primaryKey}
-            />
-          </Box>
-        )}
+      {showClusterKeyField && (
+        <Box maxWidth={'50%'}>
+          <SelectClusterKey
+            tableData={tableData}
+            isLoading={isLoadingTable}
+            inputValue={selectClusterKeyInput}
+            onChange={handleClusterKeyChange}
+            disabled={primaryKeyDisabled}
+            excludeFieldName={data.primaryKey}
+          />
+        </Box>
+      )}
     </Flex>
   );
 };

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -23,6 +23,7 @@ export const SelectTableScreen = ({
 }: ScreenProps<DatasourceFormData, SelectTableMessages, DatasourceScreenId>) => {
   const ffClusterExperimentsEnabled = useFeatureFlag('cluster_experiments');
   const [refresh, setRefresh] = useState(false);
+  const [selectPrimaryKeyInput, setSelectPrimaryKeyInput] = useState(data.primaryKey ?? '');
   const [selectClusterKeyInput, setSelectClusterKeyInput] = useState(data.clusterKey ?? '');
 
   const {
@@ -53,10 +54,9 @@ export const SelectTableScreen = ({
         enabled: !!data.datasourceId && !!data.tableName,
         onSuccess: (response) => {
           if (!data.primaryKey) {
-            if (response.primary_key_fields.length > 0) {
-              dispatch({ type: 'set-primary-key', value: response.primary_key_fields[0] });
-            } else if (response.detected_unique_id_fields.length > 0) {
-              dispatch({ type: 'set-primary-key', value: response.detected_unique_id_fields[0] });
+            const detectedPrimaryKey = response.primary_key_fields[0] ?? response.detected_unique_id_fields[0];
+            if (detectedPrimaryKey) {
+              handlePrimaryKeyChange(detectedPrimaryKey, detectedPrimaryKey);
             }
           }
         },
@@ -71,8 +71,14 @@ export const SelectTableScreen = ({
     data.experimentType === PreassignedFrequentistExperimentSpecInputExperimentType.freq_preassigned;
 
   function handleTableChange(tableName: string) {
+    setSelectPrimaryKeyInput('');
     setSelectClusterKeyInput('');
     dispatch({ type: 'set-table', value: tableName });
+  }
+
+  function handlePrimaryKeyChange(inputText: string, selectedKey?: string) {
+    setSelectPrimaryKeyInput(inputText);
+    dispatch({ type: 'set-primary-key', value: selectedKey });
   }
 
   function handleClusterKeyChange(inputText: string, selectedKey?: string) {
@@ -141,8 +147,8 @@ export const SelectTableScreen = ({
         <SelectPrimaryKey
           tableData={tableData}
           isLoading={isLoadingTable}
-          value={data.primaryKey}
-          onChange={(value) => dispatch({ type: 'set-primary-key', value })}
+          inputValue={selectPrimaryKeyInput}
+          onChange={handlePrimaryKeyChange}
           disabled={primaryKeyDisabled}
         />
       </Box>

--- a/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
+++ b/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { Button, Flex, Grid, Spinner, Text, TextField, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon, Share1Icon } from '@radix-ui/react-icons';
+import { ExperimentFormData } from './experiment-form-types';
+import { usePowerCheck } from '@/api/admin';
+import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
+import { ZodError } from 'zod';
+import { useState } from 'react';
+
+export type ClusterStatisticsSectionAction =
+  | { type: 'set-cluster-icc'; value: number | undefined }
+  | { type: 'set-cluster-cv'; value: number | undefined }
+  | { type: 'set-cluster-avg-size'; value: number | undefined }
+  | {
+      type: 'set-cluster-stats-from-datasource';
+      icc?: number;
+      cv?: number;
+      avgClusterSize?: number;
+    };
+
+const parseStatValue = (input: string): number | undefined => {
+  const parsed = input === '' ? undefined : Number(input);
+  return parsed !== undefined && !isNaN(parsed) ? parsed : undefined;
+};
+
+const formatStatValue = (value: number | undefined, decimalPlaces?: number): string => {
+  if (value === undefined) return '';
+  return decimalPlaces !== undefined ? value.toFixed(decimalPlaces) : String(value);
+};
+
+const formatStatDisplay = (value: number | undefined, decimalPlaces: number = 2): string => {
+  if (value === undefined) return '—';
+  return value.toFixed(decimalPlaces);
+};
+
+interface LabelWithTooltipProps {
+  label: string;
+  tooltip: string;
+}
+
+function LabelWithTooltip({ label, tooltip }: LabelWithTooltipProps) {
+  return (
+    <Flex align="center" gap="1">
+      <Text as="label" size="2" weight="bold">
+        {label}
+      </Text>
+      <Tooltip content={tooltip}>
+        <InfoCircledIcon />
+      </Tooltip>
+    </Flex>
+  );
+}
+
+interface CalculateFromDatasourceButtonProps {
+  onClick: () => Promise<void>;
+  loading: boolean;
+  disabledReason?: string;
+}
+
+function CalculateFromDatasourceButton({ onClick, loading, disabledReason }: CalculateFromDatasourceButtonProps) {
+  const disabled = disabledReason !== undefined;
+  const button = (
+    <Button type="button" disabled={disabled || loading} onClick={onClick}>
+      <Spinner loading={loading}>
+        <Share1Icon />
+      </Spinner>
+      Calculate from your Datasource
+    </Button>
+  );
+
+  return disabled ? (
+    <Tooltip content={disabledReason} side="top" align="start">
+      {button}
+    </Tooltip>
+  ) : (
+    button
+  );
+}
+
+interface ClusterStatisticsSectionProps {
+  data: ExperimentFormData;
+  dispatch: (action: ClusterStatisticsSectionAction) => void;
+}
+
+export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSectionProps) {
+  const [validationError, setValidationError] = useState<ZodError | null>(null);
+  const { trigger: triggerPowerCheck, isMutating, error } = usePowerCheck(data.datasourceId!);
+
+  const handleCalculate = async () => {
+    setValidationError(null);
+
+    if (!data.clusterKey || !data.primaryMetric) {
+      return;
+    }
+
+    try {
+      const designSpec = convertToFrequentistDesignSpec({ ...data, desiredN: undefined });
+      const response = await triggerPowerCheck({ design_spec: designSpec });
+      const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
+      const metricSpec = primary?.metric_spec;
+
+      dispatch({
+        type: 'set-cluster-stats-from-datasource',
+        icc: metricSpec?.icc ?? undefined,
+        cv: metricSpec?.cv ?? undefined,
+        avgClusterSize: metricSpec?.avg_cluster_size ?? undefined,
+      });
+    } catch (err) {
+      if (err instanceof ZodError) {
+        setValidationError(err);
+        return;
+      }
+      throw err;
+    }
+  };
+
+  return (
+    <Flex direction="column" gap="3">
+      <Text size="2" color="gray">
+        Information on how your data is clustered is required to estimate sample size. Enter estimates or derive them
+        from your data source. (NOTE: The ICC estimate entered or derived from the primary metric will also be applied
+        to all other metrics whether appropriate or not!)
+      </Text>
+
+      <Flex align="center" gap="2">
+        <Text as="label" size="2" weight="bold">
+          Cluster ID field:
+        </Text>
+        <TextField.Root value={data.clusterKey ?? ''} readOnly />
+        <CalculateFromDatasourceButton
+          onClick={handleCalculate}
+          loading={isMutating}
+          disabledReason={data.primaryMetric === undefined ? 'Select a primary metric.' : undefined}
+        />
+      </Flex>
+
+      {error && <GenericErrorCallout title="Failed to calculate cluster statistics" error={error} />}
+
+      {validationError && (
+        <GenericErrorCallout
+          title="Validation failed"
+          message={validationError.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('\n')}
+        />
+      )}
+
+      <Grid columns={{ initial: '1', sm: '3' }} gap="4">
+        <Flex direction="column" gap="1">
+          <LabelWithTooltip label="Avg cluster size" tooltip="The average number of participants per cluster." />
+          <EditableTextField
+            value={formatStatValue(data.clusterAvgClusterSize, 2)}
+            onSubmit={(value) => {
+              dispatch({ type: 'set-cluster-avg-size', value: parseStatValue(value) });
+            }}
+            type="number"
+            min={0}
+            size="2"
+          >
+            <Text size="2">{formatStatDisplay(data.clusterAvgClusterSize)}</Text>
+          </EditableTextField>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <LabelWithTooltip
+            label="Intracluster Correlation Coefficient"
+            tooltip="How similar individual Primary Metric values are within the same cluster, ranging from [0, 1]. Higher ICC means participants in a cluster tend to have similar results, which increases the total sample size you need."
+          />
+          <EditableTextField
+            value={formatStatValue(data.clusterIcc, 3)}
+            onSubmit={(value) => {
+              dispatch({ type: 'set-cluster-icc', value: parseStatValue(value) });
+            }}
+            type="number"
+            min={0}
+            max={1}
+            step={0.005}
+            size="2"
+            minWidth="7ch"
+          >
+            <Text size="2">{formatStatDisplay(data.clusterIcc, 3)}</Text>
+          </EditableTextField>
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <LabelWithTooltip
+            label="Coefficient of Variation"
+            tooltip="How much your cluster sizes vary from one another, ranging from [0, infinity]. Higher CV means more variability, which increases the total sample size you need."
+          />
+          <EditableTextField
+            value={formatStatValue(data.clusterCv, 2)}
+            onSubmit={(value) => {
+              dispatch({ type: 'set-cluster-cv', value: parseStatValue(value) });
+            }}
+            type="number"
+            min={0}
+            step={0.05}
+            size="2"
+          >
+            <Text size="2">{formatStatDisplay(data.clusterCv)}</Text>
+          </EditableTextField>
+        </Flex>
+      </Grid>
+    </Flex>
+  );
+}

--- a/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
+++ b/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
@@ -11,9 +11,12 @@ export type ClusterStatisticsSectionAction =
   | { type: 'set-cluster-avg-size'; value: number | undefined }
   | { type: 'clear-cluster-stats' };
 
-const parseStatValue = (input: string): number | undefined => {
+const parseStatValue = (input: string, { min, max }: { min?: number; max?: number } = {}): number | undefined => {
   const parsed = input === '' ? undefined : Number(input);
-  return parsed !== undefined && !isNaN(parsed) ? parsed : undefined;
+  if (parsed === undefined || isNaN(parsed)) return undefined;
+  if (min !== undefined && parsed < min) return min;
+  if (max !== undefined && parsed > max) return max;
+  return parsed;
 };
 
 const formatStatValue = (value: number | undefined, decimalPlaces?: number): string => {
@@ -56,9 +59,9 @@ export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSe
   return (
     <Flex direction="column" gap="3">
       <Text size="2" color="gray">
-        Information on how your data is clustered is required to estimate sample size. We will derive them from your
-        data source, but you can enter your own below if desired. (NOTE: The ICC estimate entered or derived from the
-        primary metric will also be applied to all other metrics whether appropriate or not!)
+        Cluster statistics are needed to estimate sample size. These will be derived from your data source, but you can
+        enter your own values below. The Intracluster Correlation Coefficient (ICC) from the primary metric or entered
+        here is also applied to all other metrics.
       </Text>
 
       <Flex align="center" gap="2">
@@ -78,11 +81,11 @@ export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSe
 
       <Grid columns={{ initial: '1', sm: '3' }} gap="4">
         <Flex direction="column" gap="1">
-          <LabelWithTooltip label="Avg cluster size" tooltip="The average number of participants per cluster." />
+          <LabelWithTooltip label="Average Cluster Size" tooltip="The average number of participants per cluster." />
           <EditableTextField
             value={formatStatValue(data.clusterAvgClusterSize, 2)}
             onSubmit={(value) => {
-              dispatch({ type: 'set-cluster-avg-size', value: parseStatValue(value) });
+              dispatch({ type: 'set-cluster-avg-size', value: parseStatValue(value, { min: 0 }) });
             }}
             type="number"
             min={0}
@@ -95,12 +98,12 @@ export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSe
         <Flex direction="column" gap="1">
           <LabelWithTooltip
             label="Intracluster Correlation Coefficient"
-            tooltip="How similar individual Primary Metric values are within the same cluster, ranging from [0, 1]. Higher ICC means participants in a cluster tend to have similar results, which increases the total sample size you need."
+            tooltip="How similar individual primary metric values are within the same cluster. Values range from 0 to 1; higher values mean more similarity within clusters, which increases the total sample size you need."
           />
           <EditableTextField
             value={formatStatValue(data.clusterIcc, 3)}
             onSubmit={(value) => {
-              dispatch({ type: 'set-cluster-icc', value: parseStatValue(value) });
+              dispatch({ type: 'set-cluster-icc', value: parseStatValue(value, { min: 0, max: 1 }) });
             }}
             type="number"
             min={0}
@@ -116,12 +119,12 @@ export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSe
         <Flex direction="column" gap="1">
           <LabelWithTooltip
             label="Coefficient of Variation"
-            tooltip="How much your cluster sizes vary from one another, ranging from [0, infinity]. Higher CV means more variability, which increases the total sample size you need."
+            tooltip="How much your cluster sizes vary from one another. Higher values mean more variability, which increases the total sample size you need."
           />
           <EditableTextField
             value={formatStatValue(data.clusterCv, 2)}
             onSubmit={(value) => {
-              dispatch({ type: 'set-cluster-cv', value: parseStatValue(value) });
+              dispatch({ type: 'set-cluster-cv', value: parseStatValue(value, { min: 0 }) });
             }}
             type="number"
             min={0}

--- a/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
+++ b/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
@@ -1,25 +1,15 @@
 'use client';
 
-import { Button, Flex, Grid, Spinner, Text, TextField, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon, Share1Icon } from '@radix-ui/react-icons';
+import { Button, Flex, Grid, Text, TextField, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 import { ExperimentFormData } from './experiment-form-types';
-import { usePowerCheck } from '@/api/admin';
-import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { EditableTextField } from '@/components/ui/inputs/editable-text-field';
-import { ZodError } from 'zod';
-import { useState } from 'react';
 
 export type ClusterStatisticsSectionAction =
   | { type: 'set-cluster-icc'; value: number | undefined }
   | { type: 'set-cluster-cv'; value: number | undefined }
   | { type: 'set-cluster-avg-size'; value: number | undefined }
-  | {
-      type: 'set-cluster-stats-from-datasource';
-      icc?: number;
-      cv?: number;
-      avgClusterSize?: number;
-    };
+  | { type: 'clear-cluster-stats' };
 
 const parseStatValue = (input: string): number | undefined => {
   const parsed = input === '' ? undefined : Number(input);
@@ -54,68 +44,14 @@ function LabelWithTooltip({ label, tooltip }: LabelWithTooltipProps) {
   );
 }
 
-interface CalculateFromDatasourceButtonProps {
-  onClick: () => Promise<void>;
-  loading: boolean;
-  disabledReason?: string;
-}
-
-function CalculateFromDatasourceButton({ onClick, loading, disabledReason }: CalculateFromDatasourceButtonProps) {
-  const disabled = disabledReason !== undefined;
-  const button = (
-    <Button type="button" disabled={disabled || loading} onClick={onClick}>
-      <Spinner loading={loading}>
-        <Share1Icon />
-      </Spinner>
-      Calculate from your Datasource
-    </Button>
-  );
-
-  return disabled ? (
-    <Tooltip content={disabledReason} side="top" align="start">
-      {button}
-    </Tooltip>
-  ) : (
-    button
-  );
-}
-
 interface ClusterStatisticsSectionProps {
   data: ExperimentFormData;
   dispatch: (action: ClusterStatisticsSectionAction) => void;
 }
 
 export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSectionProps) {
-  const [validationError, setValidationError] = useState<ZodError | null>(null);
-  const { trigger: triggerPowerCheck, isMutating, error } = usePowerCheck(data.datasourceId!);
-
-  const handleCalculate = async () => {
-    setValidationError(null);
-
-    if (!data.clusterKey || !data.primaryMetric) {
-      return;
-    }
-
-    try {
-      const designSpec = convertToFrequentistDesignSpec({ ...data, desiredN: undefined });
-      const response = await triggerPowerCheck({ design_spec: designSpec });
-      const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
-      const metricSpec = primary?.metric_spec;
-
-      dispatch({
-        type: 'set-cluster-stats-from-datasource',
-        icc: metricSpec?.icc ?? undefined,
-        cv: metricSpec?.cv ?? undefined,
-        avgClusterSize: metricSpec?.avg_cluster_size ?? undefined,
-      });
-    } catch (err) {
-      if (err instanceof ZodError) {
-        setValidationError(err);
-        return;
-      }
-      throw err;
-    }
-  };
+  const hasClusterStatValues =
+    data.clusterIcc !== undefined || data.clusterCv !== undefined || data.clusterAvgClusterSize !== undefined;
 
   return (
     <Flex direction="column" gap="3">
@@ -130,21 +66,15 @@ export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSe
           Cluster ID field:
         </Text>
         <TextField.Root value={data.clusterKey ?? ''} readOnly />
-        <CalculateFromDatasourceButton
-          onClick={handleCalculate}
-          loading={isMutating}
-          disabledReason={data.primaryMetric === undefined ? 'Select a primary metric.' : undefined}
-        />
+        <Button
+          type="button"
+          variant="soft"
+          disabled={!hasClusterStatValues}
+          onClick={() => dispatch({ type: 'clear-cluster-stats' })}
+        >
+          Reset stats
+        </Button>
       </Flex>
-
-      {error && <GenericErrorCallout title="Failed to calculate cluster statistics" error={error} />}
-
-      {validationError && (
-        <GenericErrorCallout
-          title="Validation failed"
-          message={validationError.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('\n')}
-        />
-      )}
 
       <Grid columns={{ initial: '1', sm: '3' }} gap="4">
         <Flex direction="column" gap="1">

--- a/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
+++ b/src/app/experiments/create/experiment-form/cluster-statistics-section.tsx
@@ -120,9 +120,9 @@ export function ClusterStatisticsSection({ data, dispatch }: ClusterStatisticsSe
   return (
     <Flex direction="column" gap="3">
       <Text size="2" color="gray">
-        Information on how your data is clustered is required to estimate sample size. Enter estimates or derive them
-        from your data source. (NOTE: The ICC estimate entered or derived from the primary metric will also be applied
-        to all other metrics whether appropriate or not!)
+        Information on how your data is clustered is required to estimate sample size. We will derive them from your
+        data source, but you can enter your own below if desired. (NOTE: The ICC estimate entered or derived from the
+        primary metric will also be applied to all other metrics whether appropriate or not!)
       </Text>
 
       <Flex align="center" gap="2">

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -23,6 +23,7 @@ import {
 import { ExperimentsSummarizeFreqScreen } from '@/app/experiments/create/experiment-form/experiment-summarize-freq-screen';
 import {
   convertToFrequentistDesignSpec,
+  getClusterStatsFromPowerCheckResponse,
   getReasonableEndDate,
   getReasonableStartDate,
   removeFieldByName,
@@ -500,12 +501,12 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             createExperimentError: undefined,
           };
         }
-        if (msg.type === 'set-cluster-stats-from-datasource') {
+        if (msg.type === 'clear-cluster-stats') {
           return {
             ...data,
-            clusterIcc: msg.icc,
-            clusterCv: msg.cv,
-            clusterAvgClusterSize: msg.avgClusterSize,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -549,6 +550,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-chosen-n' || msg.type === 'set-power-check-response') {
+          const clusterStatsFromPowerCheck =
+            msg.type === 'set-power-check-response' && msg.response
+              ? getClusterStatsFromPowerCheckResponse(data, msg.response)
+              : undefined;
           switch (msg.sampleSizeOption) {
             case PowerCheckOption.NONE:
             case PowerCheckOption.USE_POWER_CHECK:
@@ -570,6 +575,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 desiredN: msg.desiredN,
                 powerCheckResponse: msg.response,
                 createExperimentError: undefined,
+                ...clusterStatsFromPowerCheck,
               };
             case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
             case PowerCheckOption.ENTER_OWN:
@@ -586,6 +592,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
                 desiredN: msg.desiredN,
                 mdePowerCheckResponse: msg.response,
                 createExperimentError: undefined,
+                ...clusterStatsFromPowerCheck,
               };
             default:
               return data;

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -173,6 +173,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       render: ExperimentSelectDatasourceScreen,
       reducer: (data, msg) => {
         const shouldClearDependents = data.datasourceId !== msg.datasourceId || data.tableName !== msg.tableName;
+        const shouldClearClusterStats = shouldClearDependents || data.clusterKey !== msg.clusterKey || !msg.clusterKey;
         if (msg.type === 'set-datasource') {
           return {
             ...data,
@@ -187,6 +188,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             secondaryMetrics: shouldClearDependents ? undefined : data.secondaryMetrics,
             filters: shouldClearDependents ? undefined : data.filters,
             strata: shouldClearDependents ? undefined : removeFieldByName(data.strata, msg.primaryKey),
+
+            clusterIcc: shouldClearClusterStats ? undefined : data.clusterIcc,
+            clusterCv: shouldClearClusterStats ? undefined : data.clusterCv,
+            clusterAvgClusterSize: shouldClearClusterStats ? undefined : data.clusterAvgClusterSize,
 
             // Changing datasource should clear power check
             powerCheckResponse: undefined,
@@ -371,6 +376,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             primaryMetric: msg.primaryMetric,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -383,6 +391,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -395,6 +406,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             ...data,
             primaryMetric: msg.primaryMetric,
             secondaryMetrics: msg.secondaryMetrics,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,
@@ -442,6 +456,56 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           return {
             ...data,
             filters: msg.filters,
+            clusterIcc: undefined,
+            clusterCv: undefined,
+            clusterAvgClusterSize: undefined,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+
+        if (msg.type === 'set-cluster-icc') {
+          return {
+            ...data,
+            clusterIcc: msg.value,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-cv') {
+          return {
+            ...data,
+            clusterCv: msg.value,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-avg-size') {
+          return {
+            ...data,
+            clusterAvgClusterSize: msg.value,
+            powerCheckResponse: undefined,
+            mdePowerCheckResponse: undefined,
+            desiredN: undefined,
+            sampleSizeOption: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'set-cluster-stats-from-datasource') {
+          return {
+            ...data,
+            clusterIcc: msg.icc,
+            clusterCv: msg.cv,
+            clusterAvgClusterSize: msg.avgClusterSize,
             powerCheckResponse: undefined,
             mdePowerCheckResponse: undefined,
             desiredN: undefined,

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -174,7 +174,11 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       render: ExperimentSelectDatasourceScreen,
       reducer: (data, msg) => {
         const shouldClearDependents = data.datasourceId !== msg.datasourceId || data.tableName !== msg.tableName;
-        const shouldClearClusterStats = shouldClearDependents || data.clusterKey !== msg.clusterKey || !msg.clusterKey;
+        const shouldClearClusterStats =
+          shouldClearDependents ||
+          !msg.clusterKey ||
+          data.clusterKey !== msg.clusterKey ||
+          data.primaryKey !== msg.primaryKey;
         if (msg.type === 'set-datasource') {
           return {
             ...data,

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -55,6 +55,15 @@ const zodNumberFromForm = (configure?: (num: z.ZodNumber) => z.ZodNumber) =>
 
 const zodMde = zodNumberFromForm((num) => num.int().safe().min(0).max(100));
 
+const getPrimaryMetricClusterStats = (data: ExperimentFormData) => {
+  if (!data.clusterKey) return undefined;
+  const icc = data.clusterIcc;
+  const cv = data.clusterCv;
+  const avgClusterSize = data.clusterAvgClusterSize;
+  if (icc === undefined && cv === undefined && avgClusterSize === undefined) return undefined;
+  return { icc, cv, avg_cluster_size: avgClusterSize };
+};
+
 export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFrequentistDesignSpecInput {
   if (!isFreqExperimentType(data.experimentType)) {
     throw new Error('Frequentist configuration is required.');
@@ -65,11 +74,20 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
 
   const metrics: DesignSpecMetricRequest[] = [];
 
+  const primaryClusterStats = getPrimaryMetricClusterStats(data);
+
   if (data.primaryMetric?.metric.field_name) {
     zodMde.parse(data.primaryMetric.mde, { path: ['primaryMetric', 'mde'] });
     metrics.push({
       field_name: data.primaryMetric.metric.field_name,
       metric_pct_change: Number(data.primaryMetric.mde) / 100.0,
+      ...(primaryClusterStats
+        ? {
+            icc: primaryClusterStats.icc ?? null,
+            cv: primaryClusterStats.cv ?? null,
+            avg_cluster_size: primaryClusterStats.avg_cluster_size ?? null,
+          }
+        : {}),
     });
   }
 
@@ -85,7 +103,7 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     field_name: f.field_name,
   }));
 
-  const commonFields = {
+  const designSpec: Record<string, unknown> = {
     experiment_name: data.name,
     description: data.hypothesis ?? '',
     design_url: data.designUrl ?? null,
@@ -99,19 +117,16 @@ export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFre
     filters: data.filters ?? [],
     power: data.power ? Number(data.power) / 100.0 : 0.8,
     alpha: data.confidence ? 1 - Number(data.confidence) / 100.0 : 0.05,
+    experiment_type: data.experimentType,
   };
+  if (data.experimentType === 'freq_preassigned' && data.clusterKey) {
+    designSpec.cluster_key = data.clusterKey;
+  }
+  if (data.experimentType === 'freq_preassigned' && data.desiredN !== undefined) {
+    designSpec.desired_n = data.desiredN;
+  }
 
-  const spec = createExperimentBody.strict().parse({
-    design_spec: {
-      ...commonFields,
-      experiment_type: data.experimentType,
-      ...(data.experimentType === 'freq_preassigned' && data.clusterKey ? { cluster_key: data.clusterKey } : {}),
-      ...(data.experimentType === 'freq_preassigned' && data.desiredN !== undefined
-        ? { desired_n: data.desiredN }
-        : {}),
-    },
-  }).design_spec;
-
+  const spec = createExperimentBody.strict().parse({ design_spec: designSpec }).design_spec;
   if (!isFrequentistSpec(spec)) {
     throw new Error('Frequentist configuration is required.');
   }

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -7,6 +7,7 @@ import {
   DesignSpecMetricRequest,
   MABExperimentSpecInputExperimentType,
   OnlineFrequentistExperimentSpecInputExperimentType,
+  PowerResponseOutput,
   PreassignedFrequentistExperimentSpecInputExperimentType,
   Stratum,
 } from '@/api/methods.schemas';
@@ -62,6 +63,23 @@ const getPrimaryMetricClusterStats = (data: ExperimentFormData) => {
   const avgClusterSize = data.clusterAvgClusterSize;
   if (icc === undefined && cv === undefined && avgClusterSize === undefined) return undefined;
   return { icc, cv, avg_cluster_size: avgClusterSize };
+};
+
+export const getClusterStatsFromPowerCheckResponse = (
+  data: ExperimentFormData,
+  response: PowerResponseOutput,
+): Pick<ExperimentFormData, 'clusterIcc' | 'clusterCv' | 'clusterAvgClusterSize'> | undefined => {
+  if (!data.clusterKey || !data.primaryMetric) return undefined;
+
+  const primary = response.analyses.find((a) => a.metric_spec.field_name === data.primaryMetric?.metric.field_name);
+  const metricSpec = primary?.metric_spec;
+  if (!metricSpec) return undefined;
+
+  return {
+    clusterIcc: metricSpec.icc ?? undefined,
+    clusterCv: metricSpec.cv ?? undefined,
+    clusterAvgClusterSize: metricSpec.avg_cluster_size ?? undefined,
+  };
 };
 
 export function convertToFrequentistDesignSpec(data: ExperimentFormData): AnyFrequentistDesignSpecInput {

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -123,6 +123,10 @@ export type ExperimentFormData = {
   mdePowerCheckResponse?: PowerResponseOutput;
   createExperimentResponse?: CreateExperimentResponse;
   createExperimentError?: ErrorType<unknown>;
+  // Values needed for cluster-randomized experiments
+  clusterAvgClusterSize?: number;
+  clusterIcc?: number;
+  clusterCv?: number;
 
   // experiment-describe-webhooks-screen
   selectedWebhookIds?: string[];

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -171,6 +171,7 @@ export const ExperimentFreqStackScreen = ({
             secondaryMetrics={data.secondaryMetrics ?? []}
             dispatch={dispatch}
             metricFields={metricFields}
+            excludeKeys={[data.primaryKey, data.clusterKey].filter((key): key is string => key !== undefined)}
           />
         </Card>
 

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -8,7 +8,7 @@ import { StrataBuilder } from '@/components/features/experiments/strata-builder'
 import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
 import { CreateExperimentResponse, FieldMetadata, FilterInput } from '@/api/methods.schemas';
 import { PowerCheckSection, PowerCheckSectionAction } from './power-check-section';
-import { ClusterStatisticsSection, ClusterStatisticsSectionAction } from './cluster-statistics-section';
+import { ClusterStatisticsSectionAction } from './cluster-statistics-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import {
   convertToFrequentistDesignSpec,
@@ -195,17 +195,6 @@ export const ExperimentFreqStackScreen = ({
             onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
           />
         </Card>
-
-        {data.clusterKey && (
-          <>
-            <Heading as="h3" size="3">
-              Cluster statistics
-            </Heading>
-            <Card>
-              <ClusterStatisticsSection data={data} dispatch={dispatch} />
-            </Card>
-          </>
-        )}
 
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -185,16 +185,20 @@ export const ExperimentFreqStackScreen = ({
           />
         </Card>
 
-        <Heading as="h3" size="3">
-          Strata
-        </Heading>
-        <Card>
-          <StrataBuilder
-            availableStrata={availableStrata}
-            selectedStrata={selectedStrata}
-            onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
-          />
-        </Card>
+        {!data.clusterKey && (
+          <>
+            <Heading as="h3" size="3">
+              Strata
+            </Heading>
+            <Card>
+              <StrataBuilder
+                availableStrata={availableStrata}
+                selectedStrata={selectedStrata}
+                onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
+              />
+            </Card>
+          </>
+        )}
 
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -8,6 +8,7 @@ import { StrataBuilder } from '@/components/features/experiments/strata-builder'
 import { useCreateExperiment, useInspectTableInDatasource } from '@/api/admin';
 import { CreateExperimentResponse, FieldMetadata, FilterInput } from '@/api/methods.schemas';
 import { PowerCheckSection, PowerCheckSectionAction } from './power-check-section';
+import { ClusterStatisticsSection, ClusterStatisticsSectionAction } from './cluster-statistics-section';
 import { NavigationButtons } from '@/components/features/experiments/navigation-buttons';
 import {
   convertToFrequentistDesignSpec,
@@ -20,6 +21,7 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 export type ExperimentFreqStackScreenMessage =
   | MetricBuilderAction
   | PowerCheckSectionAction
+  | ClusterStatisticsSectionAction
   | { type: 'set-filters'; filters: FilterInput[] }
   | { type: 'set-strata'; strata: FieldMetadata[] }
   | { type: 'set-create-response'; response: CreateExperimentResponse }
@@ -193,6 +195,17 @@ export const ExperimentFreqStackScreen = ({
             onStrataChange={(strata) => dispatch({ type: 'set-strata', strata })}
           />
         </Card>
+
+        {data.clusterKey && (
+          <>
+            <Heading as="h3" size="3">
+              Cluster statistics
+            </Heading>
+            <Card>
+              <ClusterStatisticsSection data={data} dispatch={dispatch} />
+            </Card>
+          </>
+        )}
 
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -164,7 +164,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
       </Flex>
 
       {data.clusterKey && (
-        <SectionCard title="Cluster statistics">
+        <SectionCard title="Cluster Statistics">
           <ClusterStatisticsSection data={data} dispatch={dispatch} />
         </SectionCard>
       )}

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -29,6 +29,7 @@ import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
 import { useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
+import { ClusterStatisticsSection, ClusterStatisticsSectionAction } from './cluster-statistics-section';
 
 export type PowerCheckSectionAction =
   | { type: 'set-confidence'; value: string }
@@ -38,7 +39,7 @@ export type PowerCheckSectionAction =
 
 interface PowerCheckSectionProps {
   data: ExperimentFormData;
-  dispatch: (action: PowerCheckSectionAction) => void;
+  dispatch: (action: PowerCheckSectionAction | ClusterStatisticsSectionAction) => void;
 }
 
 const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData) => {
@@ -161,6 +162,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
           />
         </Flex>
       </Flex>
+
+      {data.clusterKey && (
+        <SectionCard title="Cluster statistics">
+          <ClusterStatisticsSection data={data} dispatch={dispatch} />
+        </SectionCard>
+      )}
 
       <SectionCard title="Analysis">
         <Flex direction="column" gap="3" align="center">

--- a/src/app/experiments/create/experiment-form/select-cluster-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-cluster-key.tsx
@@ -4,27 +4,30 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
 import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
 import { Combobox } from '@/components/ui/combobox';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 interface ComboboxRowProps {
   data_type: DataType;
   field_name: string;
 }
 
-const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => {
-  return (
-    <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
-      <Text size="2">{field_name}</Text>
-      <DataTypeBadge type={data_type} />
-    </Flex>
-  );
-};
+const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => (
+  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+    <Text size="2">{field_name}</Text>
+    <DataTypeBadge type={data_type} />
+  </Flex>
+);
 
 interface SelectClusterKeyProps {
   tableData: InspectDatasourceTableResponse | undefined;
-  value: string | undefined;
+  /** Input text owned by the parent component. */
+  inputValue: string;
   isLoading: boolean;
-  onChange: (value: string | undefined) => void;
+  /**
+   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
+   * exact unique field-name match (same as Combobox), otherwise undefined.
+   */
+  onChange: (inputText: string, selectedKey?: string) => void;
   disabled?: boolean;
   excludeFieldName?: string; // to prevent the cluster key from being the same as the primary key
 }
@@ -32,12 +35,11 @@ interface SelectClusterKeyProps {
 export const SelectClusterKey = ({
   tableData,
   isLoading,
-  value,
+  inputValue,
   onChange,
   disabled,
   excludeFieldName,
 }: SelectClusterKeyProps) => {
-  const [inputValue, setInputValue] = useState<string>(value ?? '');
   const orderedFields = useMemo(() => {
     const fields = tableData?.fields ?? [];
     return fields
@@ -46,10 +48,6 @@ export const SelectClusterKey = ({
   }, [excludeFieldName, tableData]);
   const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
   const showSpinner = isLoading && !disabled;
-
-  useEffect(() => {
-    setInputValue(value ?? '');
-  }, [value]);
 
   return (
     <Flex direction="column" gap={'3'}>
@@ -73,10 +71,7 @@ export const SelectClusterKey = ({
       ) : (
         <Combobox
           value={inputValue}
-          onChange={(value, key) => {
-            setInputValue(value);
-            onChange(key);
-          }}
+          onChange={onChange}
           options={orderedFields}
           rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
           dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}

--- a/src/app/experiments/create/experiment-form/select-primary-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-primary-key.tsx
@@ -3,7 +3,7 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
 import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
 import { Combobox } from '@/components/ui/combobox';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 
 interface RightBadgesProps {
@@ -29,25 +29,27 @@ interface ComboboxRowProps {
   recommended: boolean;
 }
 
-const ComboboxRow = ({ field_name, data_type, recommended, primary_key }: ComboboxRowProps) => {
-  return (
-    <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
-      <Text size="2">{field_name}</Text>
-      <RightBadges recommended={recommended} type={data_type} primary_key={primary_key} />
-    </Flex>
-  );
-};
+const ComboboxRow = ({ field_name, data_type, recommended, primary_key }: ComboboxRowProps) => (
+  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+    <Text size="2">{field_name}</Text>
+    <RightBadges recommended={recommended} type={data_type} primary_key={primary_key} />
+  </Flex>
+);
 
 interface SelectPrimaryKeyProps {
   tableData: InspectDatasourceTableResponse | undefined;
-  value: string | undefined;
+  /** Input text owned by the parent component. */
+  inputValue: string;
   isLoading: boolean;
-  onChange: (value: string | undefined) => void;
+  /**
+   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
+   * exact unique field-name match (same as Combobox), otherwise undefined.
+   */
+  onChange: (inputText: string, selectedKey?: string) => void;
   disabled?: boolean;
 }
 
-export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabled }: SelectPrimaryKeyProps) => {
-  const [inputValue, setInputValue] = useState<string>(value ?? '');
+export const SelectPrimaryKey = ({ tableData, isLoading, inputValue, onChange, disabled }: SelectPrimaryKeyProps) => {
   const primaryKeyFields = useMemo(() => new Set(tableData?.primary_key_fields ?? []), [tableData]);
   const uniqueIdFields = useMemo(() => new Set(tableData?.detected_unique_id_fields ?? []), [tableData]);
   const orderedFields = useMemo(() => {
@@ -66,10 +68,6 @@ export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabl
   const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
   const showSpinner = isLoading && !disabled;
 
-  useEffect(() => {
-    setInputValue(value ?? '');
-  }, [value]);
-
   return (
     <Flex direction="column" gap={'3'}>
       <Flex align="center" gap="1">
@@ -85,20 +83,17 @@ export const SelectPrimaryKey = ({ tableData, isLoading, value, onChange, disabl
         <XSpinner message="Loading fields..." />
       ) : (
         <Combobox
-          value={inputValue ?? ''}
-          onChange={(value, key) => {
-            setInputValue(value);
-            onChange(key);
-          }}
+          value={inputValue}
+          onChange={onChange}
           options={orderedFields}
           rightSlot={
-            exactMatchField && (
+            exactMatchField ? (
               <RightBadges
                 primary_key={primaryKeyFields.has(exactMatchField.field_name)}
                 recommended={uniqueIdFields.has(exactMatchField.field_name)}
                 type={exactMatchField.data_type}
               />
-            )
+            ) : null
           }
           dropdownRow={({ option }) => (
             <ComboboxRow

--- a/src/components/features/experiments/metric-builder.tsx
+++ b/src/components/features/experiments/metric-builder.tsx
@@ -22,9 +22,16 @@ type MetricBuilderProps = {
   secondaryMetrics: MetricWithMDE[];
   dispatch: (action: MetricBuilderAction) => void;
   metricFields: GetMetricsResponseElement[];
+  excludeKeys?: string[];
 };
 
-export function MetricBuilder({ primaryMetric, secondaryMetrics, dispatch, metricFields }: MetricBuilderProps) {
+export function MetricBuilder({
+  primaryMetric,
+  secondaryMetrics,
+  dispatch,
+  metricFields,
+  excludeKeys,
+}: MetricBuilderProps) {
   const handlePrimaryMetricSelect = (metric: GetMetricsResponseElement) => {
     dispatch({ type: 'primary-metric-select', primaryMetric: { metric, mde: DEFAULT_MDE } });
   };
@@ -90,18 +97,17 @@ export function MetricBuilder({ primaryMetric, secondaryMetrics, dispatch, metri
     }
   };
 
-  // Determine metrics available for primary selection (all metrics not in secondaryMetrics)
+  const isExcludedMetric = (fieldName: string) =>
+    excludeKeys?.includes(fieldName) || secondaryMetrics.some((sm) => sm.metric.field_name === fieldName);
+
+  // Determine metrics available for primary selection
   const availablePrimaryMetricBadges = metricFields
-    .filter((m) => !secondaryMetrics.some((sm) => sm.metric.field_name === m.field_name))
+    .filter((m) => !isExcludedMetric(m.field_name))
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
 
   // Determine metrics available for secondary selection
   const availableSecondaryMetricBadges = metricFields
-    .filter(
-      (m) =>
-        m.field_name !== primaryMetric?.metric.field_name &&
-        !secondaryMetrics.some((sm) => sm.metric.field_name === m.field_name),
-    )
+    .filter((m) => m.field_name !== primaryMetric?.metric.field_name && !isExcludedMetric(m.field_name))
     .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
 
   return (

--- a/src/components/radix-custom/editable/editable-root.tsx
+++ b/src/components/radix-custom/editable/editable-root.tsx
@@ -38,11 +38,6 @@ export function EditableRoot({ children, value, onSubmit }: EditableRootProps) {
 
   const edit = () => setIsEditing(true);
   const submit = async () => {
-    if (inputValue.trim() === '') {
-      cancel();
-      return;
-    }
-
     if (onSubmit) {
       try {
         await onSubmit(inputValue);

--- a/src/components/ui/inputs/editable-text-field.tsx
+++ b/src/components/ui/inputs/editable-text-field.tsx
@@ -15,9 +15,25 @@ interface EditableTextFieldProps {
   onSubmit: (value: string) => Promise<void> | void;
   children: ReactNode;
   size?: '1' | '2' | '3';
+  type?: 'text' | 'number';
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Minimum width for the edit input (not the preview). */
+  minWidth?: string;
 }
 
-export function EditableTextField({ value, onSubmit, children, size = '2' }: EditableTextFieldProps) {
+export function EditableTextField({
+  value,
+  onSubmit,
+  children,
+  size = '2',
+  type = 'text',
+  min,
+  max,
+  step,
+  minWidth,
+}: EditableTextFieldProps) {
   const [error, setError] = useState<boolean>();
 
   const handleSubmit = async (value: string) => {
@@ -43,6 +59,10 @@ export function EditableTextField({ value, onSubmit, children, size = '2' }: Edi
               <EditableInput>
                 {({ value, onChange, onKeyDown }) => (
                   <TextField.Root
+                    type={type}
+                    min={min}
+                    max={max}
+                    step={step}
                     value={value}
                     onChange={(e) => {
                       onChange(e);
@@ -52,6 +72,7 @@ export function EditableTextField({ value, onSubmit, children, size = '2' }: Edi
                     size={size}
                     variant={error ? 'soft' : 'surface'}
                     color={error ? 'red' : undefined}
+                    style={minWidth ? { minWidth } : undefined}
                     autoFocus
                   />
                 )}


### PR DESCRIPTION
## Description

Follow-on to #265, which begins fleshing out the freq-stack changes 
- by adding a ClusterStatisticsSection to the PowerCheckSection
- and extracting the dwh-derived stats from the 'set-power-check-response' response objects

Also needed to tweak our EditableTextField and EditableRoot for numeric support and ability to clear out values.

### Future Tasks 

Lots more UI to build out, such as the power Analysis section, sample size selector, and much more.

## How has this been tested?

Manually
<img width="1153" height="353" alt="image" src="https://github.com/user-attachments/assets/fe2049a7-b5fa-4efc-8ac2-1627cd909145" />
<img width="1158" height="410" alt="image" src="https://github.com/user-attachments/assets/fa9752ca-d428-4917-8f03-e682a5998cbb" />
