### PR TITLE
Eslint tweak and add explicit package dependencies

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from '@eslint/eslintrc';
+import eslintConfigPrettier from 'eslint-config-prettier/flat';
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname,
@@ -9,7 +10,8 @@ const eslintConfig = [
   {
     ignores: ['.next/**', 'next-env.d.ts', 'src/api/**/*', 'orval.config.ts'],
   },
-  ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier'),
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  eslintConfigPrettier,
   {
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
+        "@radix-ui/react-accessible-icon": "^1.1.7",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-icons": "^1.3.2",
+        "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/themes": "^3.2.1",
         "@sentry/nextjs": "^9.47.1",
         "next": "15.5.18",
@@ -21,6 +24,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
+        "@eslint/eslintrc": "^3.3.5",
         "@next/bundle-analyzer": "^16.2.6",
         "@types/node": "^22.14.0",
         "@types/react": "^19",
@@ -29,6 +33,7 @@
         "eslint-config-next": "15.5.18",
         "eslint-config-prettier": "^10.0.2",
         "jsonpath-plus": "^10.4.0",
+        "openapi3-ts": "^4.5.0",
         "orval": "7.19.0",
         "prettier": "^3.6.2",
         "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
+    "@radix-ui/react-accessible-icon": "^1.1.7",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/themes": "^3.2.1",
     "@sentry/nextjs": "^9.47.1",
     "next": "15.5.18",
-    "@phosphor-icons/react": "^2.1.10",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "recharts": "^3.5.1",
@@ -26,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@eslint/eslintrc": "^3.3.5",
     "@next/bundle-analyzer": "^16.2.6",
     "@types/node": "^22.14.0",
     "@types/react": "^19",
@@ -34,6 +38,7 @@
     "eslint-config-next": "15.5.18",
     "eslint-config-prettier": "^10.0.2",
     "jsonpath-plus": "^10.4.0",
+    "openapi3-ts": "^4.5.0",
     "orval": "7.19.0",
     "prettier": "^3.6.2",
     "typescript": "^5"

--- a/src/components/features/experiments/integration-guide-dialog.tsx
+++ b/src/components/features/experiments/integration-guide-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Button, Callout, Card, DataList, Dialog, Flex, Select, Text } from '@radix-ui/themes';
 import { ChevronDownIcon, ChevronRightIcon, FileIcon, GearIcon, PlusIcon } from '@radix-ui/react-icons';
-import { Collapsible } from 'radix-ui';
+import * as Collapsible from '@radix-ui/react-collapsible';
 import { useState } from 'react';
 import { mutate } from 'swr';
 import { Arm, Context } from '@/api/methods.schemas';


### PR DESCRIPTION
Just a small cleanup chore:
* Use Prettier's flat ESLint config directly
* add missing direct dependencies to package.json and scope down IntegrationGuideDialog's radix-ui dep.