### PR TITLE
pnpm: hoist import-in-the-middle require-in-the-middle

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,10 @@ saveExact: true
 # min age is in minutes for pnpm; 5d=7200
 minimumReleaseAge: 7200
 
+publicHoistPattern:
+- "*import-in-the-middle*"
+- "*require-in-the-middle*"
+
 allowBuilds:
   '@biomejs/biome': true
   '@sentry/cli': true


### PR DESCRIPTION
Addresses log warnings seen in dev like:

Package import-in-the-middle can't be external
The request import-in-the-middle matches serverExternalPackages (or the default list). The request could not be resolved by Node.js from the project directory. Packages that should be external need to be installed in the project directory, so they can be resolved from the output files.

refs: 
* https://docs.sentry.io/platforms/javascript/guides/node/troubleshooting/#pnpm-resolving-import-in-the-middle-external-package-errors
* https://pnpm.io/settings#publichoistpattern 