### PR TITLE
Enable cluster randomized experiments publicly, tighten client-side validation, add helper fns for dev

### DIFF
--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -66,11 +66,6 @@ const getNextDisabledReasons = (data: ExperimentFormData): string[] => {
       return reasons;
     }
 
-    // Must have selected a sample size for pre-assigned frequentist experiment
-    if (data.desiredN === undefined || data.desiredN === 0) {
-      reasons.push('Select a sample size.');
-    }
-
     // desiredN must not exceed the primary metric's available samples
     const availableN = getPrimaryAnalysisAvailableN(data);
     const hasAvailableN = availableN !== undefined && availableN !== 0;
@@ -84,8 +79,12 @@ const getNextDisabledReasons = (data: ExperimentFormData): string[] => {
       );
     }
 
-    if (data.clusterKey && (data.desiredNClusters === undefined || data.desiredNClusters < 1)) {
+    // Must have selected a valid sample size for pre-assigned frequentist experiments
+    if (data.clusterKey && (data.desiredNClusters === undefined || data.desiredNClusters <= 1)) {
       reasons.push('Select a valid cluster sample size.');
+    } else if (data.desiredN === undefined || data.desiredN <= 1) {
+      // Individual-level scenario
+      reasons.push('Select a valid sample size.');
     }
 
     // If in MDE mode, must have an MDE estimate

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -82,8 +82,7 @@ const getNextDisabledReasons = (data: ExperimentFormData): string[] => {
     // Must have selected a valid sample size for pre-assigned frequentist experiments
     if (data.clusterKey && (data.desiredNClusters === undefined || data.desiredNClusters <= 1)) {
       reasons.push('Select a valid cluster sample size.');
-    } else if (data.desiredN === undefined || data.desiredN <= 1) {
-      // Individual-level scenario
+    } else if (!data.clusterKey && (data.desiredN === undefined || data.desiredN <= 1)) {
       reasons.push('Select a valid sample size.');
     }
 

--- a/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-desired-n-input.tsx
@@ -6,7 +6,8 @@ import { useDebounced } from '@/providers/use-debounced';
 
 const getValidDraftN = (input: string): number | undefined => {
   const parsed = input === '' ? undefined : Number(input);
-  return parsed !== undefined && !isNaN(parsed) && parsed > 0 ? parsed : undefined;
+  // Allow 1 assuming it was typed as a leading 1 digit for a more stable UX.
+  return parsed !== undefined && !isNaN(parsed) && parsed >= 1 ? parsed : undefined;
 };
 
 /** Input is valid if it's the empty string or a positive number. */
@@ -26,6 +27,9 @@ interface PowerCheckDesiredNInputProps {
  * - `value`: external sync/reset string (e.g. when parent changes desiredN from outside typing).
  * - `onChange`: latest ref called after debounce delay with a parsed positive integer, or
  * `undefined` for empty/invalid input.
+ *
+ * Input field sets a min of 2 preventing arrow keys from decrementing below, but a user can type in
+ * 1 to allow it to be a leading digit. Parent should handle the special case of 1.
  */
 export function PowerCheckDesiredNInput({ value, onChange, max, label, placeholder }: PowerCheckDesiredNInputProps) {
   const [draftN, setDraftN] = useState(value);
@@ -55,7 +59,7 @@ export function PowerCheckDesiredNInput({ value, onChange, max, label, placehold
         style={{ width: '150px' }}
         size="2"
         type="number"
-        min={1}
+        min={2}
         max={max}
         color={highlightInvalid ? 'red' : undefined}
         value={draftN}

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -163,10 +163,10 @@ export function PowerCheckSampleSizeSelector({
   /**
    * Handler immediately reports back:
    * - the selected option,
-   * - the desiredN if appropriate for the option, and
+   * - the desiredN / desiredNClusters if appropriate for the option, and
    * - its current power estimate if it doesn't need updating.
    *
-   * If the cached response doesn't match the desiredN, we also trigger a new MDE estimate.
+   * If the cached response doesn't match the desiredN / desiredNClusters, we also trigger a new MDE estimate.
    */
   const handleOptionChange = (option: PowerCheckOption) => {
     let useCachedResponse = false;
@@ -224,22 +224,21 @@ export function PowerCheckSampleSizeSelector({
   };
 
   const handleInputChange = (newN: number | undefined, newNClusters?: number) => {
-    if (newN === undefined) {
-      // Wipe the form data if the user entered an invalid newN.
-      if (desiredN !== undefined || desiredNClusters !== undefined) {
-        onOptionChange({
-          sampleSizeOption: selectedSampleOption,
-          desiredN: undefined,
-          desiredNClusters: undefined,
-          response: undefined,
-        });
-      }
-      return;
-    }
     if (
       selectedSampleOption !== PowerCheckOption.ENTER_OWN ||
       (newN === desiredN && (!isClustered || newNClusters === desiredNClusters))
     ) {
+      // User either switched selection or entered the same stored value, so nothing to change.
+      return;
+    }
+    if (newN === undefined) {
+      // Wipe the form data if the user entered an invalid newN.
+      onOptionChange({
+        sampleSizeOption: selectedSampleOption,
+        desiredN: undefined,
+        desiredNClusters: undefined,
+        response: undefined,
+      });
       return;
     }
     onOptionChange({

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -241,13 +241,19 @@ export function PowerCheckSampleSizeSelector({
       });
       return;
     }
+
+    // Immediately notify of new input and wipe the old response as it is now stale.
     onOptionChange({
       sampleSizeOption: selectedSampleOption,
       desiredN: newN,
       desiredNClusters: newNClusters,
       response: undefined,
     });
-    estimateMde(PowerCheckOption.ENTER_OWN, newN, newNClusters);
+
+    // But only estimate MDE if the user entered a valid new value.
+    if (newN > 1 || (newNClusters && newNClusters > 1)) {
+      estimateMde(PowerCheckOption.ENTER_OWN, newN, newNClusters);
+    }
   };
 
   const handleClusterInputChange = (clusterN: number | undefined) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 import '@radix-ui/themes/styles.css';
+import '@/services/feature-flags/feature-flag-dev-tools';
 
 import { Geist, Geist_Mono } from 'next/font/google';
 import { Container, Flex, Theme } from '@radix-ui/themes';

--- a/src/services/feature-flags/feature-flag-dev-tools.ts
+++ b/src/services/feature-flags/feature-flag-dev-tools.ts
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * Browser-console helpers for toggling feature flags at runtime.
+ *
+ * Imported once from `layout.tsx`; no app code needs to call these directly.
+ * Open DevTools on a running page and use the flag keys declared in `feature-flags.ts`.
+ * Changes apply immediately (no refresh). Remove a key from localStorage to fall back to the env
+ * default in `FLAG_DEFAULTS`.
+ *
+ * @example
+ * ff('cluster_experiments');      // read
+ * ffon('cluster_experiments');    // enable
+ * ffoff('cluster_experiments');   // disable
+ * ffclear('cluster_experiments'); // clear override, fall back to env default
+ */
+
+import { FLAG_DEFAULTS, FlagKey } from './feature-flags';
+
+function storageKey(flagKey: FlagKey): string {
+  return `ff_${flagKey}`;
+}
+
+/** Format of key is defined by `useLocalStorage` in `use-local-storage.ts`. */
+function storageEventKey(flagKey: FlagKey): string {
+  return `uls_${storageKey(flagKey)}_event`;
+}
+
+export function ff(flagKey: FlagKey): boolean {
+  const stored = localStorage.getItem(storageKey(flagKey));
+  if (stored !== null) {
+    return JSON.parse(stored) as boolean;
+  }
+  return FLAG_DEFAULTS[flagKey];
+}
+
+export function ffon(flagKey: FlagKey): void {
+  localStorage.setItem(storageKey(flagKey), JSON.stringify(true));
+  window.dispatchEvent(new StorageEvent(storageEventKey(flagKey)));
+}
+
+export function ffoff(flagKey: FlagKey): void {
+  localStorage.setItem(storageKey(flagKey), JSON.stringify(false));
+  window.dispatchEvent(new StorageEvent(storageEventKey(flagKey)));
+}
+
+export function ffclear(flagKey: FlagKey): boolean {
+  localStorage.removeItem(storageKey(flagKey));
+  window.dispatchEvent(new StorageEvent(storageEventKey(flagKey)));
+  return FLAG_DEFAULTS[flagKey];
+}
+
+declare global {
+  interface Window {
+    ff: (flagKey: FlagKey) => boolean;
+    ffon: (flagKey: FlagKey) => void;
+    ffoff: (flagKey: FlagKey) => void;
+    ffclear: (flagKey: FlagKey) => boolean;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.ff = ff;
+  window.ffon = ffon;
+  window.ffoff = ffoff;
+  window.ffclear = ffclear;
+}

--- a/src/services/feature-flags/feature-flags.ts
+++ b/src/services/feature-flags/feature-flags.ts
@@ -15,5 +15,5 @@ function isTrue(val: string | undefined | null): boolean {
  * To permanently enable a feature, we require a code change that sets the default to true.
  */
 export const FLAG_DEFAULTS: Record<FlagKey, boolean> = {
-  [FLAGS.CLUSTER_EXPERIMENTS]: isTrue(process.env.NEXT_PUBLIC_FF_CLUSTER_EXPERIMENTS),
+  [FLAGS.CLUSTER_EXPERIMENTS]: true,
 };

--- a/src/services/feature-flags/use-feature-flag.ts
+++ b/src/services/feature-flags/use-feature-flag.ts
@@ -8,7 +8,7 @@ import { useLocalStorage } from '@/providers/use-local-storage';
  *
  * Resolution order:
  * 1. `localStorage` override at `ff_<flagKey>` (developer tooling)
- * 2. Build-time default from `FLAG_DEFAULTS` (env vars)
+ * 2. Build-time default from `FLAG_DEFAULTS` (env vars or hard-coded)
  *
  * Usage:
  * ```tsx

--- a/src/services/feature-flags/use-feature-flag.ts
+++ b/src/services/feature-flags/use-feature-flag.ts
@@ -10,16 +10,27 @@ import { useLocalStorage } from '@/providers/use-local-storage';
  * 1. `localStorage` override at `ff_<flagKey>` (developer tooling)
  * 2. Build-time default from `FLAG_DEFAULTS` (env vars)
  *
- * @example
+ * Usage:
  * ```tsx
  * import { FLAGS } from './feature-flags';
  *
  * const clusterExperimentsEnabled = useFeatureFlag(FLAGS.CLUSTER_EXPERIMENTS);
  * ```
  *
- * Override a flag from the browser console without refreshing:
+ * How to manually override a flag without refreshing:
  *
- * @example
+ * For the most convenient development experience, use the browser console helpers registered on
+ * `window` (see `feature-flag-dev-tools.ts`):
+ *
+ * ```js
+ * ff('cluster_experiments');      // read current value
+ * ffon('cluster_experiments');    // enable
+ * ffoff('cluster_experiments');   // disable
+ * ffclear('cluster_experiments'); // clear override, fall back to env default
+ * ```
+ *
+ * Or directly override the flag in localStorage & trigger an event to pick up the change:
+ *
  * ```js
  * const key = 'ff_cluster_experiments';
  * const eventKey = `uls_${key}_event`;
@@ -28,9 +39,8 @@ import { useLocalStorage } from '@/providers/use-local-storage';
  * window.dispatchEvent(new StorageEvent(eventKey));
  * ```
  *
- * Remove the override to fall back to the env default:
+ * Remove the override to fall back to the build-time default:
  *
- * @example
  * ```js
  * localStorage.removeItem(key);
  * window.dispatchEvent(new StorageEvent(eventKey));


### PR DESCRIPTION
## Description

Closes https://github.com/agency-fund/evidential-be/issues/217

Also:
* Tightens client-side validation of ENTER_OWN values.
* Adds additional helper feature flag functions for devs.

### Future Tasks

* Tweak backend model constraints to check for > 1 instead of >= 1.
* Refine UI to be simpler for users.
* add public-facing documentation at https://docs.evidential.dev/

## How has this been tested?

Manually

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts