### PR TITLE
DWH C/MAB Phase 1: Frontend updates for wizard

### DIFF
--- a/src/app/experiments/create/datasource-form/datasource-form-def.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-form-def.tsx
@@ -7,13 +7,16 @@ import {
   DatasourceFormData as CreateDatasourceFormData,
   defaultDatasourceFormData,
 } from '@/components/features/datasources/add-datasource-form';
-import type { ExperimentType } from '@/services/experiment-utils';
+import { DataType } from '@/api/methods.schemas';
+import { type ExperimentType, isMabExperimentType } from '@/services/experiment-utils';
 
 export type DatasourceFormInputData = {
   datasourceId?: string;
   tableName?: string;
   primaryKey?: string;
   clusterKey?: string;
+  targetFieldName?: string;
+  targetFieldType?: DataType;
   experimentType?: ExperimentType;
 };
 // Form data for the datasource selection/creation wizard
@@ -26,6 +29,10 @@ export type DatasourceFormData = {
   primaryKey?: string;
   // Optional cluster key field for cluster-randomized experiments
   clusterKey?: string;
+  // Target column for DWH-backed MAB experiments (the column read as each participant's outcome).
+  targetFieldName?: string;
+  // The target column's data type, used downstream to lock the binary/real outcome choice.
+  targetFieldType?: DataType;
   // Experiment type context from the parent wizard (read-only)
   experimentType?: ExperimentType;
   // Selection mode: existing or create
@@ -47,6 +54,8 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
     tableName: inputData?.tableName,
     primaryKey: inputData?.primaryKey,
     clusterKey: inputData?.clusterKey,
+    targetFieldName: inputData?.targetFieldName,
+    targetFieldType: inputData?.targetFieldType,
     experimentType: inputData?.experimentType,
     selectionMode: 'existing',
   }),
@@ -64,6 +73,8 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             tableName: undefined,
             primaryKey: undefined,
             clusterKey: undefined,
+            targetFieldName: undefined,
+            targetFieldType: undefined,
           };
         }
         if (msg.type === 'set-mode') {
@@ -80,6 +91,8 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             tableName: undefined,
             primaryKey: undefined,
             clusterKey: undefined,
+            targetFieldName: undefined,
+            targetFieldType: undefined,
             createForm: defaultDatasourceFormData(),
           };
         }
@@ -94,21 +107,37 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
       render: SelectTableScreen,
       reducer: (data, msg) => {
         if (msg.type === 'set-table') {
-          return { ...data, tableName: msg.value, primaryKey: undefined, clusterKey: undefined };
+          return {
+            ...data,
+            tableName: msg.value,
+            primaryKey: undefined,
+            clusterKey: undefined,
+            targetFieldName: undefined,
+            targetFieldType: undefined,
+          };
         }
         if (msg.type === 'set-primary-key') {
+          // The target can't be the same column as the primary key; drop it (and its type) if it was.
+          const targetCollidesWithPk = data.targetFieldName === msg.value;
           return {
             ...data,
             primaryKey: msg.value,
             clusterKey: data.clusterKey === msg.value ? undefined : data.clusterKey, // Can't be the same as the primary key
+            targetFieldName: targetCollidesWithPk ? undefined : data.targetFieldName,
+            targetFieldType: targetCollidesWithPk ? undefined : data.targetFieldType,
           };
         }
         if (msg.type === 'set-cluster-key') {
           return { ...data, clusterKey: msg.value };
         }
+        if (msg.type === 'set-target-field') {
+          return { ...data, targetFieldName: msg.value, targetFieldType: msg.dataType };
+        }
         return data;
       },
-      isNextEnabled: (data) => !!data.tableName && !!data.primaryKey,
+      // MAB-DWH requires a target column; for all other flows the target picker is not shown and is irrelevant.
+      isNextEnabled: (data) =>
+        !!data.tableName && !!data.primaryKey && (!isMabExperimentType(data.experimentType) || !!data.targetFieldName),
       prevScreen: () => ({ type: 'screen', id: 'select-datasource' }),
       nextScreen: () => ({ type: 'submit' }),
       isBreadcrumbClickable: (data) => !!data.datasourceId,

--- a/src/app/experiments/create/datasource-form/datasource-form-def.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-form-def.tsx
@@ -7,16 +7,13 @@ import {
   DatasourceFormData as CreateDatasourceFormData,
   defaultDatasourceFormData,
 } from '@/components/features/datasources/add-datasource-form';
-import { DataType } from '@/api/methods.schemas';
-import { type ExperimentType, isMabExperimentType } from '@/services/experiment-utils';
+import { type ExperimentType } from '@/services/experiment-utils';
 
 export type DatasourceFormInputData = {
   datasourceId?: string;
   tableName?: string;
   primaryKey?: string;
   clusterKey?: string;
-  targetFieldName?: string;
-  targetFieldType?: DataType;
   experimentType?: ExperimentType;
 };
 // Form data for the datasource selection/creation wizard
@@ -29,10 +26,6 @@ export type DatasourceFormData = {
   primaryKey?: string;
   // Optional cluster key field for cluster-randomized experiments
   clusterKey?: string;
-  // Target column for DWH-backed MAB experiments (the column read as each participant's outcome).
-  targetFieldName?: string;
-  // The target column's data type, used downstream to lock the binary/real outcome choice.
-  targetFieldType?: DataType;
   // Experiment type context from the parent wizard (read-only)
   experimentType?: ExperimentType;
   // Selection mode: existing or create
@@ -54,8 +47,6 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
     tableName: inputData?.tableName,
     primaryKey: inputData?.primaryKey,
     clusterKey: inputData?.clusterKey,
-    targetFieldName: inputData?.targetFieldName,
-    targetFieldType: inputData?.targetFieldType,
     experimentType: inputData?.experimentType,
     selectionMode: 'existing',
   }),
@@ -73,8 +64,6 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             tableName: undefined,
             primaryKey: undefined,
             clusterKey: undefined,
-            targetFieldName: undefined,
-            targetFieldType: undefined,
           };
         }
         if (msg.type === 'set-mode') {
@@ -91,8 +80,6 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             tableName: undefined,
             primaryKey: undefined,
             clusterKey: undefined,
-            targetFieldName: undefined,
-            targetFieldType: undefined,
             createForm: defaultDatasourceFormData(),
           };
         }
@@ -112,32 +99,21 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             tableName: msg.value,
             primaryKey: undefined,
             clusterKey: undefined,
-            targetFieldName: undefined,
-            targetFieldType: undefined,
           };
         }
         if (msg.type === 'set-primary-key') {
-          // The target can't be the same column as the primary key; drop it (and its type) if it was.
-          const targetCollidesWithPk = data.targetFieldName === msg.value;
           return {
             ...data,
             primaryKey: msg.value,
             clusterKey: data.clusterKey === msg.value ? undefined : data.clusterKey, // Can't be the same as the primary key
-            targetFieldName: targetCollidesWithPk ? undefined : data.targetFieldName,
-            targetFieldType: targetCollidesWithPk ? undefined : data.targetFieldType,
           };
         }
         if (msg.type === 'set-cluster-key') {
           return { ...data, clusterKey: msg.value };
         }
-        if (msg.type === 'set-target-field') {
-          return { ...data, targetFieldName: msg.value, targetFieldType: msg.dataType };
-        }
         return data;
       },
-      // MAB-DWH requires a target column; for all other flows the target picker is not shown and is irrelevant.
-      isNextEnabled: (data) =>
-        !!data.tableName && !!data.primaryKey && (!isMabExperimentType(data.experimentType) || !!data.targetFieldName),
+      isNextEnabled: (data) => !!data.tableName && !!data.primaryKey,
       prevScreen: () => ({ type: 'screen', id: 'select-datasource' }),
       nextScreen: () => ({ type: 'submit' }),
       isBreadcrumbClickable: (data) => !!data.datasourceId,

--- a/src/app/experiments/create/datasource-form/select-datasource-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-datasource-screen.tsx
@@ -8,15 +8,14 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { CreateDatasourceForm } from './create-datasource-form';
 import { DatasourceCardsGrid } from '@/app/experiments/create/datasource-form/datasource-cards-grid';
 import { DatasourceSummary } from '@/api/methods.schemas';
+import { isUsableDatasource } from '@/services/genapi-helpers';
 
 type SelectDatasourceMessages =
   | { type: 'set-datasource'; value: string }
   | { type: 'set-mode'; value: 'existing' | 'create' }
   | { type: 'datasource-created'; datasourceId: string };
 
-const is_usable_datasource = (ds: DatasourceSummary) => ds.driver !== 'none';
-
-const find_first_remote_datasource = (datasources: DatasourceSummary[]) => datasources.find(is_usable_datasource);
+const find_first_remote_datasource = (datasources: DatasourceSummary[]) => datasources.find(isUsableDatasource);
 
 export const SelectDatasourceScreen = ({
   data,
@@ -41,7 +40,7 @@ export const SelectDatasourceScreen = ({
     },
   });
 
-  const availableDatasources = datasourcesData?.items?.filter(is_usable_datasource) ?? [];
+  const availableDatasources = datasourcesData?.items?.filter(isUsableDatasource) ?? [];
   const hasDatasources = availableDatasources.length > 0;
 
   if (isLoading) {

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -1,21 +1,13 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { DatasourceFormData, DatasourceScreenId } from './datasource-form-def';
-import { useInspectDatasource, useInspectTableInDatasource } from '@/api/admin';
 import {
   DataType,
   MABExperimentSpecExperimentType,
   PreassignedFrequentistExperimentSpecExperimentType,
 } from '@/api/methods.schemas';
-import { XSpinner } from '@/components/ui/x-spinner';
-import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
-import { GenericErrorCallout } from '@/components/ui/generic-error';
-import { SelectClusterKey } from '@/app/experiments/create/experiment-form/select-cluster-key';
-import { SelectPrimaryKey } from '@/app/experiments/create/experiment-form/select-primary-key';
-import { SelectTargetField } from '@/app/experiments/create/experiment-form/select-target-field';
+import { SelectTableFields } from '@/app/experiments/create/experiment-form/select-table-fields';
 import { useFeatureFlag } from '@/services/feature-flags/use-feature-flag';
-import { ReloadIcon } from '@radix-ui/react-icons';
-import { useState } from 'react';
 
 type SelectTableMessages =
   | { type: 'set-table'; value: string }
@@ -28,172 +20,25 @@ export const SelectTableScreen = ({
   dispatch,
 }: ScreenProps<DatasourceFormData, SelectTableMessages, DatasourceScreenId>) => {
   const ffClusterExperimentsEnabled = useFeatureFlag('cluster_experiments');
-  const [refresh, setRefresh] = useState(false);
-  const [selectPrimaryKeyInput, setSelectPrimaryKeyInput] = useState(data.primaryKey ?? '');
-  const [selectClusterKeyInput, setSelectClusterKeyInput] = useState(data.clusterKey ?? '');
-  const [selectTargetFieldInput, setSelectTargetFieldInput] = useState(data.targetFieldName ?? '');
-
-  const {
-    data: inspectData,
-    isValidating: validatingDatasource,
-    isLoading,
-    error,
-  } = useInspectDatasource(data.datasourceId!, refresh ? { refresh: true } : undefined, {
-    swr: {
-      enabled: !!data.datasourceId,
-      onSuccess: (response) => {
-        if (refresh) {
-          setRefresh(false);
-        }
-        if (!data.tableName && response.tables.length > 0) {
-          handleTableChange(response.tables[0]);
-        }
-      },
-    },
-  });
-
-  const { data: tableData, isLoading: isLoadingTable } = useInspectTableInDatasource(
-    data.datasourceId!,
-    data.tableName!,
-    undefined,
-    {
-      swr: {
-        enabled: !!data.datasourceId && !!data.tableName,
-        onSuccess: (response) => {
-          if (!data.primaryKey) {
-            const detectedPrimaryKey = response.primary_key_fields[0] ?? response.detected_unique_id_fields[0];
-            if (detectedPrimaryKey) {
-              handlePrimaryKeyChange(detectedPrimaryKey, detectedPrimaryKey);
-            }
-          }
-        },
-      },
-    },
-  );
-
-  const tables = inspectData?.tables ?? [];
-  const primaryKeyDisabled = !data.tableName || !inspectData;
   const showClusterKeyField =
     ffClusterExperimentsEnabled &&
     data.experimentType === PreassignedFrequentistExperimentSpecExperimentType.freq_preassigned;
-  // The target column is only meaningful for DWH-backed MAB experiments.
   const showTargetField = data.experimentType === MABExperimentSpecExperimentType.mab_online;
 
-  function handleTableChange(tableName: string) {
-    setSelectPrimaryKeyInput('');
-    setSelectClusterKeyInput('');
-    setSelectTargetFieldInput('');
-    dispatch({ type: 'set-table', value: tableName });
-  }
-
-  function handlePrimaryKeyChange(inputText: string, selectedKey?: string) {
-    setSelectPrimaryKeyInput(inputText);
-    dispatch({ type: 'set-primary-key', value: selectedKey });
-  }
-
-  function handleClusterKeyChange(inputText: string, selectedKey?: string) {
-    setSelectClusterKeyInput(inputText);
-    dispatch({ type: 'set-cluster-key', value: selectedKey });
-  }
-
-  function handleTargetFieldChange(inputText: string, selectedKey?: string) {
-    setSelectTargetFieldInput(inputText);
-    const dataType = selectedKey ? tableData?.fields.find((f) => f.field_name === selectedKey)?.data_type : undefined;
-    dispatch({ type: 'set-target-field', value: selectedKey, dataType });
-  }
-
-  if (isLoading) {
-    return <XSpinner message="Loading tables..." />;
-  }
-
-  if (error) {
-    return (
-      <Flex direction="column" gap={'2'}>
-        <GenericErrorCallout title="Failed to fetch tables" error={error} />
-      </Flex>
-    );
-  }
-
-  if (tables.length === 0) {
-    return (
-      <Flex direction="column" gap={'2'}>
-        <Text color="gray">No tables found in this datasource. Please check your datasource configuration.</Text>
-      </Flex>
-    );
-  }
-
   return (
-    <Flex direction="column" gap={'3'}>
-      <Box maxWidth={'50%'}>
-        <Flex direction="column" gap={'3'}>
-          <Text size="2" weight="bold">
-            Select a table
-          </Text>
-          <Flex direction={'row'} gap={'3'}>
-            <Select.Root value={data.tableName} onValueChange={handleTableChange}>
-              <Select.Trigger placeholder="Select a table" />
-              <Select.Content>
-                {tables.map((table) => (
-                  <Select.Item key={table} value={table}>
-                    {table}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select.Root>
-            <IconButton
-              size={'2'}
-              variant={'soft'}
-              onClick={async () => {
-                if (!refresh) {
-                  setRefresh(!refresh);
-                }
-              }}
-              loading={validatingDatasource}
-            >
-              <ReloadIcon />
-            </IconButton>
-          </Flex>
-        </Flex>
-      </Box>
-      <Text size="1" color="gray">
-        {tables.length} table{tables.length !== 1 ? 's' : ''} available
-      </Text>
-
-      <Box maxWidth={'50%'}>
-        <SelectPrimaryKey
-          tableData={tableData}
-          isLoading={isLoadingTable}
-          inputValue={selectPrimaryKeyInput}
-          onChange={handlePrimaryKeyChange}
-          disabled={primaryKeyDisabled}
-        />
-      </Box>
-
-      {showClusterKeyField && (
-        <Box maxWidth={'50%'}>
-          <SelectClusterKey
-            tableData={tableData}
-            isLoading={isLoadingTable}
-            inputValue={selectClusterKeyInput}
-            onChange={handleClusterKeyChange}
-            disabled={primaryKeyDisabled}
-            excludeFieldName={data.primaryKey}
-          />
-        </Box>
-      )}
-
-      {showTargetField && (
-        <Box maxWidth={'50%'}>
-          <SelectTargetField
-            tableData={tableData}
-            isLoading={isLoadingTable}
-            inputValue={selectTargetFieldInput}
-            onChange={handleTargetFieldChange}
-            disabled={primaryKeyDisabled}
-            excludeFieldName={data.primaryKey}
-          />
-        </Box>
-      )}
-    </Flex>
+    <SelectTableFields
+      key={data.datasourceId}
+      datasourceId={data.datasourceId!}
+      tableName={data.tableName}
+      primaryKey={data.primaryKey}
+      clusterKey={data.clusterKey}
+      targetFieldName={data.targetFieldName}
+      onTableChange={(tableName) => dispatch({ type: 'set-table', value: tableName })}
+      onPrimaryKeyChange={(value) => dispatch({ type: 'set-primary-key', value })}
+      showClusterKey={showClusterKeyField}
+      onClusterKeyChange={(value) => dispatch({ type: 'set-cluster-key', value })}
+      showTargetField={showTargetField}
+      onTargetFieldChange={(value, dataType) => dispatch({ type: 'set-target-field', value, dataType })}
+    />
   );
 };

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -1,19 +1,14 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { DatasourceFormData, DatasourceScreenId } from './datasource-form-def';
-import {
-  DataType,
-  MABExperimentSpecExperimentType,
-  PreassignedFrequentistExperimentSpecExperimentType,
-} from '@/api/methods.schemas';
+import { PreassignedFrequentistExperimentSpecExperimentType } from '@/api/methods.schemas';
 import { SelectTableFields } from '@/app/experiments/create/experiment-form/select-table-fields';
 import { useFeatureFlag } from '@/services/feature-flags/use-feature-flag';
 
 type SelectTableMessages =
   | { type: 'set-table'; value: string }
   | { type: 'set-primary-key'; value: string | undefined }
-  | { type: 'set-cluster-key'; value: string | undefined }
-  | { type: 'set-target-field'; value: string | undefined; dataType: DataType | undefined };
+  | { type: 'set-cluster-key'; value: string | undefined };
 
 export const SelectTableScreen = ({
   data,
@@ -23,7 +18,6 @@ export const SelectTableScreen = ({
   const showClusterKeyField =
     ffClusterExperimentsEnabled &&
     data.experimentType === PreassignedFrequentistExperimentSpecExperimentType.freq_preassigned;
-  const showTargetField = data.experimentType === MABExperimentSpecExperimentType.mab_online;
 
   return (
     <SelectTableFields
@@ -32,13 +26,10 @@ export const SelectTableScreen = ({
       tableName={data.tableName}
       primaryKey={data.primaryKey}
       clusterKey={data.clusterKey}
-      targetFieldName={data.targetFieldName}
       onTableChange={(tableName) => dispatch({ type: 'set-table', value: tableName })}
       onPrimaryKeyChange={(value) => dispatch({ type: 'set-primary-key', value })}
       showClusterKey={showClusterKeyField}
       onClusterKeyChange={(value) => dispatch({ type: 'set-cluster-key', value })}
-      showTargetField={showTargetField}
-      onTargetFieldChange={(value, dataType) => dispatch({ type: 'set-target-field', value, dataType })}
     />
   );
 };

--- a/src/app/experiments/create/datasource-form/select-table-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-table-screen.tsx
@@ -2,12 +2,17 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { DatasourceFormData, DatasourceScreenId } from './datasource-form-def';
 import { useInspectDatasource, useInspectTableInDatasource } from '@/api/admin';
-import { PreassignedFrequentistExperimentSpecExperimentType } from '@/api/methods.schemas';
+import {
+  DataType,
+  MABExperimentSpecExperimentType,
+  PreassignedFrequentistExperimentSpecExperimentType,
+} from '@/api/methods.schemas';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { SelectClusterKey } from '@/app/experiments/create/experiment-form/select-cluster-key';
 import { SelectPrimaryKey } from '@/app/experiments/create/experiment-form/select-primary-key';
+import { SelectTargetField } from '@/app/experiments/create/experiment-form/select-target-field';
 import { useFeatureFlag } from '@/services/feature-flags/use-feature-flag';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
@@ -15,7 +20,8 @@ import { useState } from 'react';
 type SelectTableMessages =
   | { type: 'set-table'; value: string }
   | { type: 'set-primary-key'; value: string | undefined }
-  | { type: 'set-cluster-key'; value: string | undefined };
+  | { type: 'set-cluster-key'; value: string | undefined }
+  | { type: 'set-target-field'; value: string | undefined; dataType: DataType | undefined };
 
 export const SelectTableScreen = ({
   data,
@@ -25,6 +31,7 @@ export const SelectTableScreen = ({
   const [refresh, setRefresh] = useState(false);
   const [selectPrimaryKeyInput, setSelectPrimaryKeyInput] = useState(data.primaryKey ?? '');
   const [selectClusterKeyInput, setSelectClusterKeyInput] = useState(data.clusterKey ?? '');
+  const [selectTargetFieldInput, setSelectTargetFieldInput] = useState(data.targetFieldName ?? '');
 
   const {
     data: inspectData,
@@ -69,10 +76,13 @@ export const SelectTableScreen = ({
   const showClusterKeyField =
     ffClusterExperimentsEnabled &&
     data.experimentType === PreassignedFrequentistExperimentSpecExperimentType.freq_preassigned;
+  // The target column is only meaningful for DWH-backed MAB experiments.
+  const showTargetField = data.experimentType === MABExperimentSpecExperimentType.mab_online;
 
   function handleTableChange(tableName: string) {
     setSelectPrimaryKeyInput('');
     setSelectClusterKeyInput('');
+    setSelectTargetFieldInput('');
     dispatch({ type: 'set-table', value: tableName });
   }
 
@@ -84,6 +94,12 @@ export const SelectTableScreen = ({
   function handleClusterKeyChange(inputText: string, selectedKey?: string) {
     setSelectClusterKeyInput(inputText);
     dispatch({ type: 'set-cluster-key', value: selectedKey });
+  }
+
+  function handleTargetFieldChange(inputText: string, selectedKey?: string) {
+    setSelectTargetFieldInput(inputText);
+    const dataType = selectedKey ? tableData?.fields.find((f) => f.field_name === selectedKey)?.data_type : undefined;
+    dispatch({ type: 'set-target-field', value: selectedKey, dataType });
   }
 
   if (isLoading) {
@@ -160,6 +176,19 @@ export const SelectTableScreen = ({
             isLoading={isLoadingTable}
             inputValue={selectClusterKeyInput}
             onChange={handleClusterKeyChange}
+            disabled={primaryKeyDisabled}
+            excludeFieldName={data.primaryKey}
+          />
+        </Box>
+      )}
+
+      {showTargetField && (
+        <Box maxWidth={'50%'}>
+          <SelectTargetField
+            tableData={tableData}
+            isLoading={isLoadingTable}
+            inputValue={selectTargetFieldInput}
+            onChange={handleTargetFieldChange}
             disabled={primaryKeyDisabled}
             excludeFieldName={data.primaryKey}
           />

--- a/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
+++ b/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
@@ -6,11 +6,30 @@ import {
   FormOutcomeType,
   PriorType,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import { DataType } from '@/api/methods.schemas';
 
 type RewardType = 'binary' | 'real-valued';
 
 export const getCanonicalRewardType = (outcomeType?: FormOutcomeType): RewardType =>
   outcomeType === 'binary' ? 'binary' : 'real-valued';
+
+/**
+ * The bandit outcome type implied by a DWH target column's type: a boolean column backs a binary
+ * (Bernoulli) outcome, a numeric column backs a real-valued (Normal) one. Returns undefined for any
+ * other type (those columns are filtered out of the target picker, so a bound target always maps).
+ */
+export const outcomeTypeForTargetDataType = (dataType?: DataType): FormOutcomeType | undefined => {
+  if (dataType === DataType.boolean) return 'binary';
+  if (
+    dataType === DataType.bigint ||
+    dataType === DataType.integer ||
+    dataType === DataType.numeric ||
+    dataType === DataType.double_precision
+  ) {
+    return 'real';
+  }
+  return undefined;
+};
 
 const maybeConvertArm = (arm: BanditArm, priorType: PriorType): BanditArm => {
   const baseArm = {

--- a/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
+++ b/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
@@ -6,12 +6,10 @@ import {
   FormOutcomeType,
   PriorType,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
-import { DataType } from '@/api/methods.schemas';
+import { DataType, LikelihoodTypes } from '@/api/methods.schemas';
 
-type RewardType = 'binary' | 'real-valued';
-
-export const getCanonicalRewardType = (outcomeType?: FormOutcomeType): RewardType =>
-  outcomeType === 'binary' ? 'binary' : 'real-valued';
+export const getCanonicalRewardType = (outcomeType?: FormOutcomeType): LikelihoodTypes =>
+  outcomeType === 'binary' ? LikelihoodTypes.binary : LikelihoodTypes['real-valued'];
 
 /**
  * The bandit outcome type implied by a DWH target column's type: a boolean column backs a binary

--- a/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
+++ b/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
@@ -3,20 +3,16 @@ import {
   BanditExperimentType,
   BanditParams,
   Context,
-  FormOutcomeType,
   PriorType,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { DataType, LikelihoodTypes } from '@/api/methods.schemas';
-
-export const getCanonicalRewardType = (outcomeType?: FormOutcomeType): LikelihoodTypes =>
-  outcomeType === 'binary' ? LikelihoodTypes.binary : LikelihoodTypes['real-valued'];
 
 /**
  * The bandit outcome type implied by a DWH target column's type: a boolean column backs a binary
  * (Bernoulli) outcome, a numeric column backs a real-valued (Normal) one. Returns undefined for any
  * other type (those columns are filtered out of the target picker, so a bound target always maps).
  */
-export const outcomeTypeForTargetDataType = (dataType?: DataType): FormOutcomeType | undefined => {
+export const outcomeTypeForTargetDataType = (dataType?: DataType): LikelihoodTypes | undefined => {
   if (dataType === DataType.boolean) return 'binary';
   if (
     dataType === DataType.bigint ||
@@ -24,7 +20,7 @@ export const outcomeTypeForTargetDataType = (dataType?: DataType): FormOutcomeTy
     dataType === DataType.numeric ||
     dataType === DataType.double_precision
   ) {
-    return 'real';
+    return 'real-valued';
   }
   return undefined;
 };
@@ -98,7 +94,7 @@ const getDefaultBanditArms = (priorType: PriorType): BanditArm[] => {
 
 const getDefaultContexts = (): Context[] => [{ name: 'Context', description: '', type: 'real-valued' }];
 
-export const toMabBanditParams = (outcomeType: FormOutcomeType, arms: BanditArm[]): BanditParams => {
+export const toMabBanditParams = (outcomeType: LikelihoodTypes, arms: BanditArm[]): BanditParams => {
   if (outcomeType === 'binary') {
     return {
       experimentType: 'mab_online',
@@ -109,14 +105,14 @@ export const toMabBanditParams = (outcomeType: FormOutcomeType, arms: BanditArm[
   }
   return {
     experimentType: 'mab_online',
-    outcomeType: 'real',
+    outcomeType: 'real-valued',
     priorType: 'normal',
     arms: maybeConvertArms(arms, 'normal'),
   };
 };
 
 export const toCmabBanditParams = (
-  outcomeType: FormOutcomeType,
+  outcomeType: LikelihoodTypes,
   arms: BanditArm[],
   contexts?: Context[],
 ): BanditParams => ({
@@ -128,9 +124,8 @@ export const toCmabBanditParams = (
 });
 
 export const createDefaultBanditParams = (experimentType: BanditExperimentType): BanditParams => {
-  // Flipped from checking mab_online so mab_online_dwh gets MAB defaults, not CMAB ones.
   if (experimentType === 'cmab_online') {
-    return toCmabBanditParams('real', getDefaultBanditArms('normal'), getDefaultContexts());
+    return toCmabBanditParams('real-valued', getDefaultBanditArms('normal'), getDefaultContexts());
   }
   return toMabBanditParams('binary', getDefaultBanditArms('beta'));
 };

--- a/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
+++ b/src/app/experiments/create/experiment-form/experiment-bandit-helpers.ts
@@ -130,10 +130,11 @@ export const toCmabBanditParams = (
 });
 
 export const createDefaultBanditParams = (experimentType: BanditExperimentType): BanditParams => {
-  if (experimentType === 'mab_online') {
-    return toMabBanditParams('binary', getDefaultBanditArms('beta'));
+  // Flipped from checking mab_online so mab_online_dwh gets MAB defaults, not CMAB ones.
+  if (experimentType === 'cmab_online') {
+    return toCmabBanditParams('real', getDefaultBanditArms('normal'), getDefaultContexts());
   }
-  return toCmabBanditParams('real', getDefaultBanditArms('normal'), getDefaultContexts());
+  return toMabBanditParams('binary', getDefaultBanditArms('beta'));
 };
 
 export const toBanditParamsForExperimentType = (
@@ -145,6 +146,7 @@ export const toBanditParamsForExperimentType = (
   }
   switch (experimentType) {
     case 'mab_online':
+    case 'mab_online_dwh':
       return toMabBanditParams(current.outcomeType, current.arms);
     case 'cmab_online':
       return toCmabBanditParams(current.outcomeType, getDefaultBanditArms('normal'), getDefaultContexts());

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -28,6 +28,7 @@ import { convertToBanditCreateRequest } from '@/app/experiments/create/experimen
 import { CreateExperimentResponse } from '@/api/methods.schemas';
 import { ErrorType } from '@/services/orval-fetch';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { isUsableDatasource } from '@/services/genapi-helpers';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { BanditArm, PriorType } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { ArmWeightsDialog } from '@/components/features/experiments/arm-weights-dialog';
@@ -211,7 +212,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
   if (dwhTarget) {
     datasource = datasourcesData?.items.find((ds) => ds.id === dwhTarget.datasourceId);
   } else {
-    const noDwhDatasource = datasourcesData?.items?.find((ds) => ds.driver === 'none');
+    const noDwhDatasource = datasourcesData?.items?.find((ds) => !isUsableDatasource(ds));
     datasource = noDwhDatasource ?? datasourcesData?.items[0];
   }
   const datasourceId = datasource?.id ?? '';

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -207,7 +207,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
   const isDwhTargetMab = data.bandit?.experimentType === 'mab_online' && !!data.targetFieldName && !!data.datasourceId;
   let datasource;
   if (isDwhTargetMab) {
-    datasource = datasourcesData?.items?.find((ds) => ds.id === data.datasourceId);
+    datasource = datasourcesData?.items.find((ds) => ds.id === data.datasourceId);
   } else {
     const noDwhDatasource = datasourcesData?.items?.find((ds) => ds.driver === 'none');
     datasource = noDwhDatasource ?? datasourcesData?.items[0];

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import {
+  ExperimentFormData,
+  ExperimentScreenId,
+  getMabDwhTarget,
+} from '@/app/experiments/create/experiment-form/experiment-form-types';
 import {
   Badge,
   Box,
@@ -201,13 +205,11 @@ export const ExperimentDescribeBanditArmsScreen = ({
     swr: { enabled: !!organizationId },
   });
 
-  // A MAB bound to a DWH target is created against the datasource the user picked on the datasource
-  // step. Otherwise (API-only MAB, or CMAB) we use the NoDWH datasource (driver === 'none'), falling
-  // back to the first datasource in the list if none exists.
-  const isDwhTargetMab = data.bandit?.experimentType === 'mab_online' && !!data.targetFieldName && !!data.datasourceId;
+  // DWH-target MAB uses the picked datasource; otherwise the NoDWH one (or the first as fallback).
+  const dwhTarget = getMabDwhTarget(data);
   let datasource;
-  if (isDwhTargetMab) {
-    datasource = datasourcesData?.items.find((ds) => ds.id === data.datasourceId);
+  if (dwhTarget) {
+    datasource = datasourcesData?.items.find((ds) => ds.id === dwhTarget.datasourceId);
   } else {
     const noDwhDatasource = datasourcesData?.items?.find((ds) => ds.driver === 'none');
     datasource = noDwhDatasource ?? datasourcesData?.items[0];

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -201,14 +201,16 @@ export const ExperimentDescribeBanditArmsScreen = ({
     swr: { enabled: !!organizationId },
   });
 
-  // Find the NoDWH datasource (driver === 'none')
-  // If it doesn't exist, fall back to the first datasource in the list (if any)
+  // A MAB bound to a DWH target is created against the datasource the user picked on the datasource
+  // step. Otherwise (API-only MAB, or CMAB) we use the NoDWH datasource (driver === 'none'), falling
+  // back to the first datasource in the list if none exists.
+  const isDwhTargetMab = data.bandit?.experimentType === 'mab_online' && !!data.targetFieldName && !!data.datasourceId;
   let datasource;
-  const noDwhDatasource = datasourcesData?.items?.find((ds) => ds.driver === 'none');
-  if (noDwhDatasource) {
-    datasource = noDwhDatasource;
+  if (isDwhTargetMab) {
+    datasource = datasourcesData?.items?.find((ds) => ds.id === data.datasourceId);
   } else {
-    datasource = datasourcesData?.items[0];
+    const noDwhDatasource = datasourcesData?.items?.find((ds) => ds.driver === 'none');
+    datasource = noDwhDatasource ?? datasourcesData?.items[0];
   }
   const datasourceId = datasource?.id ?? '';
 
@@ -234,7 +236,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
 
   const handleCreate = async () => {
     if (!datasourceId) {
-      console.error('No NoDWH datasource found');
+      console.error('No datasource available to create the experiment against.');
       return;
     }
     if (!isFormValid(data, showPriors)) {
@@ -278,7 +280,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
   if (!datasource) {
     return (
       <Flex direction="column" gap="3">
-        <GenericErrorCallout title="Configuration error" message="No NoDWH datasource found. Please contact support." />
+        <GenericErrorCallout title="Configuration error" message="No datasource found. Please contact support." />
       </Flex>
     );
   }

--- a/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-describe-bandit-arms-screen.tsx
@@ -331,8 +331,7 @@ export const ExperimentDescribeBanditArmsScreen = ({
             <InfoCircledIcon />
           </Callout.Icon>
           <Callout.Text>
-            Using {priorType === 'beta' ? 'Beta' : 'Normal'} distribution for{' '}
-            {outcomeType === 'binary' ? 'binary' : 'real-valued'} outcomes.
+            Using {priorType === 'beta' ? 'Beta' : 'Normal'} distribution for {outcomeType} outcomes.
           </Callout.Text>
         </Callout.Root>
 

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -49,6 +49,7 @@ import {
   isBanditExperimentType,
   isCmabExperimentType,
   isFreqExperimentType,
+  isMabExperimentType,
 } from '@/services/experiment-utils';
 
 // Helper to create screens with proper type inference
@@ -149,6 +150,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       reducer: (data, msg) => {
         if (msg.type === 'set-experiment-type') {
           const experimentType = msg.value;
+          const stillMab = isMabExperimentType(experimentType);
           const nextData = {
             ...data,
             experimentType,
@@ -156,6 +158,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
               isBanditExperimentType(data.experimentType) != isBanditExperimentType(experimentType)
                 ? undefined
                 : data.datasourceId,
+            // Drop the DWH target when leaving MAB so stale fields can't leak into a later screen.
+            targetFieldName: stillMab ? data.targetFieldName : undefined,
+            targetFieldType: stillMab ? data.targetFieldType : undefined,
             createExperimentResponse: undefined,
             createExperimentError: undefined,
             commitError: undefined,
@@ -225,9 +230,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       render: ExperimentMabSelectDatasourceScreen,
       reducer: (data, msg: ExperimentMabSelectDatasourceMessages) => {
         if (msg.type === 'set-datasource') {
-          // A boolean target implies a binary outcome, a numeric one a real-valued outcome. Apply that
-          // to the bandit here so the (now-locked) Outcomes step and the arms config can't drift from
-          // the chosen column, even if the user breadcrumb-jumps past Outcomes.
+          // Boolean target => binary outcome, numeric => real-valued; lock the bandit to it here.
           const derivedOutcome = outcomeTypeForTargetDataType(msg.targetFieldType);
           const bandit =
             derivedOutcome && data.bandit?.experimentType === 'mab_online'

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -42,6 +42,7 @@ import {
 import {
   ExperimentFormData,
   ExperimentScreenId,
+  getMabDwhTarget,
   PowerCheckOption,
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import {
@@ -58,8 +59,8 @@ const screen = packScreen<ExperimentFormData, ExperimentScreenId>();
 const FREQUENTIST_BREADCRUMBS: Array<ExperimentScreenId> = [
   'metadata',
   'experiment-type',
-  'describe-arms',
   'freq-select-datasource',
+  'describe-arms',
   'freq-stack',
   'summarize-freq',
 ] as const;
@@ -158,7 +159,7 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
               isBanditExperimentType(data.experimentType) != isBanditExperimentType(experimentType)
                 ? undefined
                 : data.datasourceId,
-            // Drop the DWH target when leaving MAB so stale fields can't leak into a later screen.
+            dwhMode: stillMab ? data.dwhMode : undefined,
             targetFieldName: stillMab ? data.targetFieldName : undefined,
             targetFieldType: stillMab ? data.targetFieldType : undefined,
             createExperimentResponse: undefined,
@@ -229,29 +230,10 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       breadcrumbTitle: 'Datasource',
       render: ExperimentMabSelectDatasourceScreen,
       reducer: (data, msg: ExperimentMabSelectDatasourceMessages) => {
-        if (msg.type === 'set-datasource') {
-          // Boolean target => binary outcome, numeric => real-valued; lock the bandit to it here.
-          const derivedOutcome = outcomeTypeForTargetDataType(msg.targetFieldType);
-          const bandit =
-            derivedOutcome && data.bandit?.experimentType === 'mab_online'
-              ? toMabBanditParams(derivedOutcome, data.bandit.arms)
-              : data.bandit;
+        if (msg.type === 'set-dwh-mode') {
           return {
             ...data,
-            datasourceId: msg.datasourceId,
-            tableName: msg.tableName,
-            primaryKey: msg.primaryKey,
-            targetFieldName: msg.targetFieldName,
-            targetFieldType: msg.targetFieldType,
-            bandit,
-            createExperimentResponse: undefined,
-            createExperimentError: undefined,
-          };
-        }
-        if (msg.type === 'skip-dwh-target') {
-          // No DWH binding: clear any previously-selected target so the experiment is created API-only.
-          return {
-            ...data,
+            dwhMode: msg.value,
             datasourceId: undefined,
             tableName: undefined,
             primaryKey: undefined,
@@ -261,10 +243,50 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
             createExperimentError: undefined,
           };
         }
+        if (msg.type === 'set-datasource') {
+          // A new datasource invalidates the downstream table/key/target choices.
+          return {
+            ...data,
+            datasourceId: msg.datasourceId,
+            tableName: undefined,
+            primaryKey: undefined,
+            targetFieldName: undefined,
+            targetFieldType: undefined,
+          };
+        }
+        if (msg.type === 'set-table') {
+          return {
+            ...data,
+            tableName: msg.tableName,
+            primaryKey: undefined,
+            targetFieldName: undefined,
+            targetFieldType: undefined,
+          };
+        }
+        if (msg.type === 'set-primary-key') {
+          return { ...data, primaryKey: msg.primaryKey };
+        }
+        if (msg.type === 'set-target-field') {
+          // Boolean target => binary outcome, numeric => real-valued; lock the bandit to it here.
+          const derivedOutcome = outcomeTypeForTargetDataType(msg.targetFieldType);
+          const bandit =
+            derivedOutcome && data.bandit?.experimentType === 'mab_online'
+              ? toMabBanditParams(derivedOutcome, data.bandit.arms)
+              : data.bandit;
+          return {
+            ...data,
+            targetFieldName: msg.targetFieldName,
+            targetFieldType: msg.targetFieldType,
+            bandit,
+            createExperimentResponse: undefined,
+            createExperimentError: undefined,
+          };
+        }
         return data;
       },
       isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
-      hideNavigation: () => true, // nested datasource wizard + Skip button own navigation.
+      // Next needs a complete target if connecting DWH; no DWH lets it through without one.
+      isNextEnabled: (data) => data.dwhMode === 'none' || getMabDwhTarget(data) !== null,
     }),
     'bandit-binary-or-real': screen({
       breadcrumbTitle: 'Outcomes',

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -8,6 +8,10 @@ import { ExperimentTypeScreen } from '@/app/experiments/create/experiment-form/e
 import { ContextType } from '@/api/methods.schemas';
 import { abandonExperiment } from '@/api/admin';
 import { ExperimentSelectDatasourceScreen } from '@/app/experiments/create/experiment-form/experiment-select-datasource-screen';
+import {
+  ExperimentMabSelectDatasourceMessages,
+  ExperimentMabSelectDatasourceScreen,
+} from '@/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen';
 import { ExperimentSelectBinaryOrRealOutcomes } from '@/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes';
 import {
   ExperimentDescribeArmsMessage,
@@ -30,6 +34,7 @@ import {
 } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import {
   createDefaultBanditParams,
+  outcomeTypeForTargetDataType,
   toBanditParamsForExperimentType,
   toCmabBanditParams,
   toMabBanditParams,
@@ -70,6 +75,7 @@ const CMAB_BREADCRUMBS: Array<ExperimentScreenId> = [
 const MAB_BREADCRUMBS: Array<ExperimentScreenId> = [
   'metadata',
   'experiment-type',
+  'mab-select-datasource',
   'bandit-binary-or-real',
   'describe-bandit-arms',
   'summarize-bandit',
@@ -213,6 +219,49 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
       isNextEnabled: (data) => !!data.datasourceId && !!data.tableName,
 
       hideNavigation: () => true, // hide navigation because this screen uses a nested wizard.
+    }),
+    'mab-select-datasource': screen({
+      breadcrumbTitle: 'Datasource',
+      render: ExperimentMabSelectDatasourceScreen,
+      reducer: (data, msg: ExperimentMabSelectDatasourceMessages) => {
+        if (msg.type === 'set-datasource') {
+          // A boolean target implies a binary outcome, a numeric one a real-valued outcome. Apply that
+          // to the bandit here so the (now-locked) Outcomes step and the arms config can't drift from
+          // the chosen column, even if the user breadcrumb-jumps past Outcomes.
+          const derivedOutcome = outcomeTypeForTargetDataType(msg.targetFieldType);
+          const bandit =
+            derivedOutcome && data.bandit?.experimentType === 'mab_online'
+              ? toMabBanditParams(derivedOutcome, data.bandit.arms)
+              : data.bandit;
+          return {
+            ...data,
+            datasourceId: msg.datasourceId,
+            tableName: msg.tableName,
+            primaryKey: msg.primaryKey,
+            targetFieldName: msg.targetFieldName,
+            targetFieldType: msg.targetFieldType,
+            bandit,
+            createExperimentResponse: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        if (msg.type === 'skip-dwh-target') {
+          // No DWH binding: clear any previously-selected target so the experiment is created API-only.
+          return {
+            ...data,
+            datasourceId: undefined,
+            tableName: undefined,
+            primaryKey: undefined,
+            targetFieldName: undefined,
+            targetFieldType: undefined,
+            createExperimentResponse: undefined,
+            createExperimentError: undefined,
+          };
+        }
+        return data;
+      },
+      isBreadcrumbClickable: ({ bandit }) => bandit !== undefined,
+      hideNavigation: () => true, // nested datasource wizard + Skip button own navigation.
     }),
     'bandit-binary-or-real': screen({
       breadcrumbTitle: 'Outcomes',

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -152,13 +152,14 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
         if (msg.type === 'set-experiment-type') {
           const experimentType = msg.value;
           const stillMab = isMabExperimentType(experimentType);
+          const shouldClearDatasourceFields =
+            isBanditExperimentType(data.experimentType) != isBanditExperimentType(experimentType);
           const nextData = {
             ...data,
             experimentType,
-            datasourceId:
-              isBanditExperimentType(data.experimentType) != isBanditExperimentType(experimentType)
-                ? undefined
-                : data.datasourceId,
+            datasourceId: shouldClearDatasourceFields ? undefined : data.datasourceId,
+            tableName: shouldClearDatasourceFields ? undefined : data.tableName,
+            primaryKey: shouldClearDatasourceFields ? undefined : data.primaryKey,
             dwhMode: stillMab ? data.dwhMode : undefined,
             targetFieldName: stillMab ? data.targetFieldName : undefined,
             targetFieldType: stillMab ? data.targetFieldType : undefined,

--- a/src/app/experiments/create/experiment-form/experiment-form-def.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-def.tsx
@@ -264,6 +264,9 @@ export const ExperimentForm: WizardForm<ExperimentFormData, ExperimentScreenId, 
           };
         }
         if (msg.type === 'set-primary-key') {
+          if (data.targetFieldName === msg.primaryKey) {
+            return { ...data, primaryKey: msg.primaryKey, targetFieldName: undefined, targetFieldType: undefined };
+          }
           return { ...data, primaryKey: msg.primaryKey };
         }
         if (msg.type === 'set-target-field') {

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -13,7 +13,7 @@ import {
   Stratum,
 } from '@/api/methods.schemas';
 import { createExperimentBody } from '@/api/admin.zod';
-import { ExperimentFormData } from './experiment-form-types';
+import { ExperimentFormData, getMabDwhTarget } from './experiment-form-types';
 import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 import { isFreqExperimentType, isFrequentistSpec, getPowerAnalysis } from '@/services/experiment-utils';
 
@@ -202,20 +202,12 @@ export function convertToBanditCreateRequest(data: ExperimentFormData): CreateEx
 
   // A MAB experiment bound to a DWH target column is created as the distinct mab_online_dwh spec,
   // carrying the table / primary key / target column. Without a target it stays API-only (mab_online).
-  // datasourceId is required so this stays in lockstep with the datasource the create call targets
-  // (see experiment-describe-bandit-arms-screen) — a stale target from a since-cleared datasource
-  // must not flip the spec type.
-  if (
-    experimentType === 'mab_online' &&
-    data.datasourceId &&
-    data.targetFieldName &&
-    data.tableName &&
-    data.primaryKey
-  ) {
+  const dwhTarget = getMabDwhTarget(data);
+  if (dwhTarget) {
     designSpec.experiment_type = MABDwhExperimentSpecExperimentType.mab_online_dwh;
-    designSpec.table_name = data.tableName;
-    designSpec.primary_key = data.primaryKey;
-    designSpec.target_field_name = data.targetFieldName;
+    designSpec.table_name = dwhTarget.tableName;
+    designSpec.primary_key = dwhTarget.primaryKey;
+    designSpec.target_field_name = dwhTarget.targetFieldName;
   }
 
   return createExperimentBody.strict().parse({
@@ -255,9 +247,7 @@ export const ExperimentTypeOptions = [
   },
 ];
 
-// mab_online_dwh has no wizard card of its own (it's a MAB created against a DWH target), so it
-// isn't in ExperimentTypeOptions. This is its human-readable label, used wherever an existing
-// experiment's type is displayed (summary, badge).
+// mab_online_dwh has no wizard card, so its label isn't in ExperimentTypeOptions; used for display.
 export const MAB_DWH_LABEL = 'Multi-Armed Bandit (DWH-connected)';
 
 /** Human-readable label for an experiment type. Single source of truth for type display names. */

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -5,6 +5,7 @@ import {
   CMABExperimentSpecExperimentType,
   CreateExperimentRequest,
   DesignSpecMetricRequest,
+  MABDwhExperimentSpecExperimentType,
   MABExperimentSpecExperimentType,
   OnlineFrequentistExperimentSpecExperimentType,
   PowerResponse,
@@ -185,20 +186,40 @@ export function convertToBanditCreateRequest(data: ExperimentFormData): CreateEx
     }));
   }
 
+  const designSpec: Record<string, unknown> = {
+    experiment_name: data.name!,
+    experiment_type: experimentType,
+    arms: standardArms,
+    end_date: new Date(Date.parse(data.endDate!)).toISOString(),
+    start_date: new Date(Date.parse(data.startDate!)).toISOString(),
+    description: data.hypothesis ?? '',
+    design_url: data.designUrl ?? null,
+    prior_type: priorType,
+    reward_type: canonicalRewardType,
+    contexts: standardContexts,
+    desired_n: 0,
+  };
+
+  // A MAB experiment bound to a DWH target column is created as the distinct mab_online_dwh spec,
+  // carrying the table / primary key / target column. Without a target it stays API-only (mab_online).
+  // datasourceId is required so this stays in lockstep with the datasource the create call targets
+  // (see experiment-describe-bandit-arms-screen) — a stale target from a since-cleared datasource
+  // must not flip the spec type.
+  if (
+    experimentType === 'mab_online' &&
+    data.datasourceId &&
+    data.targetFieldName &&
+    data.tableName &&
+    data.primaryKey
+  ) {
+    designSpec.experiment_type = MABDwhExperimentSpecExperimentType.mab_online_dwh;
+    designSpec.table_name = data.tableName;
+    designSpec.primary_key = data.primaryKey;
+    designSpec.target_field_name = data.targetFieldName;
+  }
+
   return createExperimentBody.strict().parse({
-    design_spec: {
-      experiment_name: data.name!,
-      experiment_type: experimentType,
-      arms: standardArms,
-      end_date: new Date(Date.parse(data.endDate!)).toISOString(),
-      start_date: new Date(Date.parse(data.startDate!)).toISOString(),
-      description: data.hypothesis ?? '',
-      design_url: data.designUrl ?? null,
-      prior_type: priorType,
-      reward_type: canonicalRewardType,
-      contexts: standardContexts,
-      desired_n: 0,
-    },
+    design_spec: designSpec,
     webhooks: data.selectedWebhookIds && data.selectedWebhookIds.length > 0 ? data.selectedWebhookIds : [],
   });
 }
@@ -233,3 +254,16 @@ export const ExperimentTypeOptions = [
       'Context-aware optimization for personalized experiences. Adapts recommendations based on user or environmental context.',
   },
 ];
+
+// mab_online_dwh has no wizard card of its own (it's a MAB created against a DWH target), so it
+// isn't in ExperimentTypeOptions. This is its human-readable label, used wherever an existing
+// experiment's type is displayed (summary, badge).
+export const MAB_DWH_LABEL = 'Multi-Armed Bandit (DWH-connected)';
+
+/** Human-readable label for an experiment type. Single source of truth for type display names. */
+export function experimentTypeLabel(experimentType: string): string {
+  if (experimentType === MABDwhExperimentSpecExperimentType.mab_online_dwh) {
+    return MAB_DWH_LABEL;
+  }
+  return ExperimentTypeOptions.find((v) => v.value === experimentType)?.title ?? experimentType;
+}

--- a/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-form-helpers.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/api/methods.schemas';
 import { createExperimentBody } from '@/api/admin.zod';
 import { ExperimentFormData, getMabDwhTarget } from './experiment-form-types';
-import { getCanonicalRewardType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 import { isFreqExperimentType, isFrequentistSpec, getPowerAnalysis } from '@/services/experiment-utils';
 
 /**
@@ -160,7 +159,6 @@ export function convertToBanditCreateRequest(data: ExperimentFormData): CreateEx
     throw new Error('Bandit configuration is required.');
   }
   const { experimentType, outcomeType, priorType, arms } = data.bandit;
-  const canonicalRewardType = getCanonicalRewardType(outcomeType);
 
   // Map bandit arms to standard arms format with prior parameters
   const standardArms = arms.map((arm) => ({
@@ -195,7 +193,7 @@ export function convertToBanditCreateRequest(data: ExperimentFormData): CreateEx
     description: data.hypothesis ?? '',
     design_url: data.designUrl ?? null,
     prior_type: priorType,
-    reward_type: canonicalRewardType,
+    reward_type: outcomeType,
     contexts: standardContexts,
     desired_n: 0,
   };

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -90,6 +90,8 @@ export type ExperimentFormData = {
   tableName?: string;
   primaryKey?: string;
   clusterKey?: string;
+  // mab-select-datasource-screen options
+  dwhMode?: 'none' | 'existing' | 'create';
   // mab-select-datasource-screen: the DWH column read as each participant's outcome. When set, a MAB
   // experiment is created as mab_online_dwh instead of mab_online. Left undefined for API-only MAB.
   targetFieldName?: string;

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -12,7 +12,7 @@ import {
   PreassignedFrequentistExperimentSpecExperimentType,
 } from '@/api/methods.schemas';
 import { ErrorType } from '@/services/orval-fetch';
-import type { ExperimentType } from '@/services/experiment-utils';
+import { type ExperimentType, isMabExperimentType } from '@/services/experiment-utils';
 
 export type ContextVariableType = ContextType;
 
@@ -154,3 +154,29 @@ export type ExperimentScreenId =
 
 export const isClusteredExperimentFormData = (data: ExperimentFormData): boolean =>
   data.experimentType === PreassignedFrequentistExperimentSpecExperimentType.freq_preassigned && !!data.clusterKey;
+
+/** The resolved DWH-target binding for a wizard form. */
+export type MabDwhTarget = {
+  datasourceId: string;
+  tableName: string;
+  primaryKey: string;
+  targetFieldName: string;
+  targetFieldType: DataType;
+};
+
+// Single source of truth for the MAB DWH-target binding. Null unless it's a MAB with every field set,
+// so stale fields from a since-changed type are ignored. undefined (not empty/0) means "not selected".
+export function getMabDwhTarget(data: ExperimentFormData): MabDwhTarget | null {
+  if (!isMabExperimentType(data.experimentType)) return null;
+  const { datasourceId, tableName, primaryKey, targetFieldName, targetFieldType } = data;
+  if (
+    datasourceId === undefined ||
+    tableName === undefined ||
+    primaryKey === undefined ||
+    targetFieldName === undefined ||
+    targetFieldType === undefined
+  ) {
+    return null;
+  }
+  return { datasourceId, tableName, primaryKey, targetFieldName, targetFieldType };
+}

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -2,6 +2,7 @@ import {
   Arm,
   ContextType,
   CreateExperimentResponse,
+  DataType,
   FieldMetadata,
   Filter,
   GetFiltersResponseElement,
@@ -89,6 +90,12 @@ export type ExperimentFormData = {
   tableName?: string;
   primaryKey?: string;
   clusterKey?: string;
+  // mab-select-datasource-screen: the DWH column read as each participant's outcome. When set, a MAB
+  // experiment is created as mab_online_dwh instead of mab_online. Left undefined for API-only MAB.
+  targetFieldName?: string;
+  // The target column's data type, captured at selection. Drives (and locks) the binary/real outcome
+  // choice on the Outcomes step, so the two can't disagree.
+  targetFieldType?: DataType;
 
   // experiment-freq-stack-screen
   primaryMetric?: MetricWithMDE;
@@ -136,6 +143,7 @@ export type ExperimentScreenId =
   | 'metadata'
   | 'experiment-type'
   | 'freq-select-datasource'
+  | 'mab-select-datasource'
   | 'bandit-binary-or-real'
   | 'describe-contexts'
   | 'describe-arms'

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -7,6 +7,7 @@ import {
   Filter,
   GetFiltersResponseElement,
   GetMetricsResponseElement,
+  LikelihoodTypes,
   MABExperimentSpec,
   PowerResponse,
   PreassignedFrequentistExperimentSpecExperimentType,
@@ -23,7 +24,6 @@ export type Context = {
   type: ContextVariableType;
 };
 export type PriorType = MABExperimentSpec['prior_type'];
-export type FormOutcomeType = 'binary' | 'real';
 export type BanditExperimentType = 'mab_online' | 'mab_online_dwh' | 'cmab_online';
 
 // Sample-size selection mode on the Power Analysis screen (power-check-section).
@@ -55,14 +55,14 @@ export type BanditParams =
     }
   | {
       experimentType: 'mab_online';
-      outcomeType: 'real';
+      outcomeType: 'real-valued';
       priorType: 'normal';
       arms: BanditArm[];
       contexts?: never;
     }
   | {
       experimentType: 'cmab_online';
-      outcomeType: FormOutcomeType;
+      outcomeType: LikelihoodTypes;
       priorType: 'normal';
       arms: BanditArm[];
       contexts: Context[];

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -24,7 +24,7 @@ export type Context = {
 };
 export type PriorType = MABExperimentSpec['prior_type'];
 export type FormOutcomeType = 'binary' | 'real';
-export type BanditExperimentType = 'mab_online' | 'cmab_online';
+export type BanditExperimentType = 'mab_online' | 'mab_online_dwh' | 'cmab_online';
 
 // Sample-size selection mode on the Power Analysis screen (power-check-section).
 export enum PowerCheckOption {

--- a/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
@@ -6,7 +6,6 @@ import { DatasourceForm, DatasourceFormData, DatasourceFormInputData } from '../
 import { DataType } from '@/api/methods.schemas';
 import { Callout, Card, Flex } from '@radix-ui/themes';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { useMemo } from 'react';
 
 export type ExperimentMabSelectDatasourceMessages =
   | {
@@ -47,24 +46,14 @@ export const ExperimentMabSelectDatasourceScreen = ({
     navigateNext();
   };
 
-  const inputData: DatasourceFormInputData = useMemo(
-    () => ({
-      datasourceId: data.datasourceId,
-      tableName: data.tableName,
-      primaryKey: data.primaryKey,
-      targetFieldName: data.targetFieldName,
-      targetFieldType: data.targetFieldType,
-      experimentType: data.experimentType,
-    }),
-    [
-      data.datasourceId,
-      data.experimentType,
-      data.primaryKey,
-      data.tableName,
-      data.targetFieldName,
-      data.targetFieldType,
-    ],
-  );
+  const inputData: DatasourceFormInputData = {
+    datasourceId: data.datasourceId,
+    tableName: data.tableName,
+    primaryKey: data.primaryKey,
+    targetFieldName: data.targetFieldName,
+    targetFieldType: data.targetFieldType,
+    experimentType: data.experimentType,
+  };
 
   return (
     <Flex direction="column" gap={'3'}>

--- a/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
@@ -1,82 +1,112 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
-import { Wizard } from '@/services/wizard/Wizard';
-import { DatasourceForm, DatasourceFormData, DatasourceFormInputData } from '../datasource-form/datasource-form-def';
-import { DataType } from '@/api/methods.schemas';
-import { Callout, Card, Flex } from '@radix-ui/themes';
-import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { DataType, DatasourceSummary } from '@/api/methods.schemas';
+import { Card, Flex, RadioGroup, Text } from '@radix-ui/themes';
+import { useCurrentOrganization } from '@/providers/organization-provider';
+import { useListOrganizationDatasources } from '@/api/admin';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { DatasourceCardsGrid } from '../datasource-form/datasource-cards-grid';
+import { CreateDatasourceForm } from '../datasource-form/create-datasource-form';
+import { SelectTableFields } from './select-table-fields';
+
+export type DwhMode = 'none' | 'existing' | 'create';
 
 export type ExperimentMabSelectDatasourceMessages =
-  | {
-      type: 'set-datasource';
-      datasourceId: string;
-      tableName: string;
-      primaryKey?: string;
-      targetFieldName?: string;
-      targetFieldType?: DataType;
-    }
-  | { type: 'skip-dwh-target' };
+  | { type: 'set-dwh-mode'; value: DwhMode }
+  | { type: 'set-datasource'; datasourceId: string }
+  | { type: 'set-table'; tableName: string }
+  | { type: 'set-primary-key'; primaryKey?: string }
+  | { type: 'set-target-field'; targetFieldName?: string; targetFieldType?: DataType };
+
+const isUsableDatasource = (ds: DatasourceSummary) => ds.driver !== 'none';
 
 /**
- * Optional MAB step for binding the bandit to a data-warehouse target column. Reuses the nested
- * DatasourceForm (datasource → table → primary key → target column); completing it emits the
- * mab_online_dwh spec. The "Skip" affordance leaves the experiment API-only (mab_online).
+ * Optional MAB step for binding the bandit to a data-warehouse target column. A single radio picks how
+ * outcomes are recorded — no warehouse (API-only), an existing datasource, or a new one — and the
+ * shared table / primary key / target-column picker appears inline once a datasource is chosen.
  */
 export const ExperimentMabSelectDatasourceScreen = ({
   data,
   dispatch,
-  navigateNext,
-  navigatePrev,
 }: ScreenProps<ExperimentFormData, ExperimentMabSelectDatasourceMessages, ExperimentScreenId>) => {
-  const handleSubmit = (formData: DatasourceFormData) => {
-    dispatch({
-      type: 'set-datasource',
-      datasourceId: formData.datasourceId!,
-      tableName: formData.tableName!,
-      primaryKey: formData.primaryKey,
-      targetFieldName: formData.targetFieldName,
-      targetFieldType: formData.targetFieldType,
-    });
-    navigateNext();
-  };
+  const orgContext = useCurrentOrganization();
+  const organizationId = orgContext!.current.id;
 
-  const handleSkip = () => {
-    dispatch({ type: 'skip-dwh-target' });
-    navigateNext();
-  };
+  const { data: datasourcesData, isLoading: loadingDatasources } = useListOrganizationDatasources(organizationId, {
+    swr: { enabled: !!organizationId },
+  });
+  const availableDatasources = datasourcesData?.items?.filter(isUsableDatasource) ?? [];
 
-  const inputData: DatasourceFormInputData = {
-    datasourceId: data.datasourceId,
-    tableName: data.tableName,
-    primaryKey: data.primaryKey,
-    targetFieldName: data.targetFieldName,
-    targetFieldType: data.targetFieldType,
-    experimentType: data.experimentType,
-  };
+  if (loadingDatasources) {
+    return <XSpinner message="Loading datasources..." />;
+  }
+
+  const hasDatasources = availableDatasources.length > 0;
+  // Default to connecting a warehouse; fall back to create when there are none yet.
+  const mode: DwhMode = data.dwhMode ?? (hasDatasources ? 'existing' : 'create');
+
+  // The table/target picker, shown inside whichever datasource option is active once one is chosen.
+  const datasourceId = data.datasourceId;
+  const picker = datasourceId ? (
+    <SelectTableFields
+      key={datasourceId}
+      datasourceId={datasourceId}
+      tableName={data.tableName}
+      primaryKey={data.primaryKey}
+      targetFieldName={data.targetFieldName}
+      showTargetField
+      onTableChange={(tableName) => dispatch({ type: 'set-table', tableName })}
+      onPrimaryKeyChange={(primaryKey) => dispatch({ type: 'set-primary-key', primaryKey })}
+      onTargetFieldChange={(targetFieldName, targetFieldType) =>
+        dispatch({ type: 'set-target-field', targetFieldName, targetFieldType })
+      }
+    />
+  ) : null;
 
   return (
-    <Flex direction="column" gap={'3'}>
-      <Callout.Root>
-        <Callout.Icon>
-          <InfoCircledIcon />
-        </Callout.Icon>
-        <Callout.Text>
-          Optionally bind this bandit to a data-warehouse target column. Select a datasource, table, unique ID, and the
-          column whose value will be read as each participant&apos;s outcome. Skip this step to report outcomes through
-          the API instead.
-        </Callout.Text>
-      </Callout.Root>
-
+    <Flex direction="column" gap="3">
       <Card>
-        <Wizard
-          form={DatasourceForm}
-          onSubmit={handleSubmit}
-          onPrev={navigatePrev}
-          inputData={inputData}
-          onSkip={handleSkip}
-          skipLabel="Skip (I do not want to connect a data warehouse)"
-        />
+        <RadioGroup.Root
+          value={mode}
+          onValueChange={(value) => dispatch({ type: 'set-dwh-mode', value: value as DwhMode })}
+        >
+          <Flex direction="column" gap="3">
+            {hasDatasources && (
+              <RadioGroup.Item value="existing">
+                <Text weight="bold">Use an existing datasource</Text>
+                {mode === 'existing' && (
+                  <Flex direction="column" gap="3">
+                    <DatasourceCardsGrid
+                      datasources={availableDatasources}
+                      selectedDatasourceId={data.datasourceId}
+                      onSelect={(id) => dispatch({ type: 'set-datasource', datasourceId: id })}
+                    />
+                    {picker}
+                  </Flex>
+                )}
+              </RadioGroup.Item>
+            )}
+
+            <RadioGroup.Item value="create">
+              <Text weight="bold">Create a new datasource</Text>
+              {mode === 'create' &&
+                (data.datasourceId ? (
+                  picker
+                ) : (
+                  <Card>
+                    <CreateDatasourceForm
+                      onDatasourceCreated={(id) => dispatch({ type: 'set-datasource', datasourceId: id })}
+                    />
+                  </Card>
+                ))}
+            </RadioGroup.Item>
+
+            <RadioGroup.Item value="none">
+              <Text weight="bold">No data warehouse</Text>
+            </RadioGroup.Item>
+          </Flex>
+        </RadioGroup.Root>
       </Card>
     </Flex>
   );

--- a/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { ScreenProps } from '@/services/wizard/wizard-types';
+import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import { Wizard } from '@/services/wizard/Wizard';
+import { DatasourceForm, DatasourceFormData, DatasourceFormInputData } from '../datasource-form/datasource-form-def';
+import { DataType } from '@/api/methods.schemas';
+import { Callout, Card, Flex } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { useMemo } from 'react';
+
+export type ExperimentMabSelectDatasourceMessages =
+  | {
+      type: 'set-datasource';
+      datasourceId: string;
+      tableName: string;
+      primaryKey?: string;
+      targetFieldName?: string;
+      targetFieldType?: DataType;
+    }
+  | { type: 'skip-dwh-target' };
+
+/**
+ * Optional MAB step for binding the bandit to a data-warehouse target column. Reuses the nested
+ * DatasourceForm (datasource → table → primary key → target column); completing it emits the
+ * mab_online_dwh spec. The "Skip" affordance leaves the experiment API-only (mab_online).
+ */
+export const ExperimentMabSelectDatasourceScreen = ({
+  data,
+  dispatch,
+  navigateNext,
+  navigatePrev,
+}: ScreenProps<ExperimentFormData, ExperimentMabSelectDatasourceMessages, ExperimentScreenId>) => {
+  const handleSubmit = (formData: DatasourceFormData) => {
+    dispatch({
+      type: 'set-datasource',
+      datasourceId: formData.datasourceId!,
+      tableName: formData.tableName!,
+      primaryKey: formData.primaryKey,
+      targetFieldName: formData.targetFieldName,
+      targetFieldType: formData.targetFieldType,
+    });
+    navigateNext();
+  };
+
+  const handleSkip = () => {
+    dispatch({ type: 'skip-dwh-target' });
+    navigateNext();
+  };
+
+  const inputData: DatasourceFormInputData = useMemo(
+    () => ({
+      datasourceId: data.datasourceId,
+      tableName: data.tableName,
+      primaryKey: data.primaryKey,
+      targetFieldName: data.targetFieldName,
+      targetFieldType: data.targetFieldType,
+      experimentType: data.experimentType,
+    }),
+    [
+      data.datasourceId,
+      data.experimentType,
+      data.primaryKey,
+      data.tableName,
+      data.targetFieldName,
+      data.targetFieldType,
+    ],
+  );
+
+  return (
+    <Flex direction="column" gap={'3'}>
+      <Callout.Root>
+        <Callout.Icon>
+          <InfoCircledIcon />
+        </Callout.Icon>
+        <Callout.Text>
+          Optionally bind this bandit to a data-warehouse target column. Select a datasource, table, unique ID, and the
+          column whose value will be read as each participant&apos;s outcome. Skip this step to report outcomes through
+          the API instead.
+        </Callout.Text>
+      </Callout.Root>
+
+      <Card>
+        <Wizard
+          form={DatasourceForm}
+          onSubmit={handleSubmit}
+          onPrev={navigatePrev}
+          inputData={inputData}
+          onSkip={handleSkip}
+          skipLabel="Skip (I do not want to connect a data warehouse)"
+        />
+      </Card>
+    </Flex>
+  );
+};

--- a/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
-import { DataType, DatasourceSummary } from '@/api/methods.schemas';
+import { DataType } from '@/api/methods.schemas';
 import { Card, Flex, RadioGroup, Text } from '@radix-ui/themes';
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { useListOrganizationDatasources } from '@/api/admin';
@@ -9,6 +9,7 @@ import { XSpinner } from '@/components/ui/x-spinner';
 import { DatasourceCardsGrid } from '../datasource-form/datasource-cards-grid';
 import { CreateDatasourceForm } from '../datasource-form/create-datasource-form';
 import { SelectTableFields } from './select-table-fields';
+import { isUsableDatasource } from '@/services/genapi-helpers';
 
 export type DwhMode = 'none' | 'existing' | 'create';
 
@@ -18,8 +19,6 @@ export type ExperimentMabSelectDatasourceMessages =
   | { type: 'set-table'; tableName: string }
   | { type: 'set-primary-key'; primaryKey?: string }
   | { type: 'set-target-field'; targetFieldName?: string; targetFieldType?: DataType };
-
-const isUsableDatasource = (ds: DatasourceSummary) => ds.driver !== 'none';
 
 /**
  * Optional MAB step for binding the bandit to a data-warehouse target column. A single radio picks how

--- a/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
@@ -1,39 +1,64 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
-import { Flex, Heading, RadioCards, Text } from '@radix-ui/themes';
+import { Callout, Flex, Heading, RadioCards, Text } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
 import { FormOutcomeType } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import { outcomeTypeForTargetDataType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 
 type ExperimentSelectBinaryOrRealMessages = { type: 'set-outcome-type'; value: FormOutcomeType };
 
 export const ExperimentSelectBinaryOrRealOutcomes = ({
   data,
   dispatch,
-}: ScreenProps<ExperimentFormData, ExperimentSelectBinaryOrRealMessages, ExperimentScreenId>) => (
-  <Flex direction="column" gap={'3'}>
-    <Heading as="h3" size={'3'}>
-      Select Outcome Type
-    </Heading>
-    <RadioCards.Root
-      value={data.bandit?.outcomeType}
-      columns={{ initial: '1', sm: '3' }}
-      onValueChange={(v) => dispatch({ type: 'set-outcome-type', value: v as FormOutcomeType })}
-    >
-      <RadioCards.Item value="binary">
-        <Flex direction="column" width="100%">
-          <Text weight="bold">Binary</Text>
-          <Text>
-            Yes/No outcomes: conversions, clicks, sign-ups, purchases. Results are expressed as percentages or rates.
-          </Text>
-        </Flex>
-      </RadioCards.Item>
-      <RadioCards.Item value="real">
-        <Flex direction="column" width="100%">
-          <Text weight="bold">Real-valued</Text>
-          <Text>
-            Continuous numeric outcomes: revenue per user, time spent, satisfaction scores, any measurable quantity.
-          </Text>
-        </Flex>
-      </RadioCards.Item>
-    </RadioCards.Root>
-  </Flex>
-);
+}: ScreenProps<ExperimentFormData, ExperimentSelectBinaryOrRealMessages, ExperimentScreenId>) => {
+  // When the bandit is bound to a DWH target column, the column's type fixes the outcome type
+  // (boolean → binary, numeric → real-valued). Lock the choice so it can't disagree with the column;
+  // the value itself is applied upstream when the target is selected.
+  const isDwhTargetBound = !!(data.targetFieldName && data.datasourceId);
+  const lockedOutcomeType = isDwhTargetBound ? outcomeTypeForTargetDataType(data.targetFieldType) : undefined;
+  const locked = lockedOutcomeType !== undefined;
+
+  return (
+    <Flex direction="column" gap={'3'}>
+      <Heading as="h3" size={'3'}>
+        Select Outcome Type
+      </Heading>
+      {locked && (
+        <Callout.Root>
+          <Callout.Icon>
+            <InfoCircledIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            Set by the target column <strong>{data.targetFieldName}</strong> ({data.targetFieldType}). Change the column
+            on the Datasource step to change this.
+          </Callout.Text>
+        </Callout.Root>
+      )}
+      <RadioCards.Root
+        value={data.bandit?.outcomeType}
+        columns={{ initial: '1', sm: '3' }}
+        onValueChange={(v) => {
+          if (locked) return;
+          dispatch({ type: 'set-outcome-type', value: v as FormOutcomeType });
+        }}
+      >
+        <RadioCards.Item value="binary" disabled={locked}>
+          <Flex direction="column" width="100%">
+            <Text weight="bold">Binary</Text>
+            <Text>
+              Yes/No outcomes: conversions, clicks, sign-ups, purchases. Results are expressed as percentages or rates.
+            </Text>
+          </Flex>
+        </RadioCards.Item>
+        <RadioCards.Item value="real" disabled={locked}>
+          <Flex direction="column" width="100%">
+            <Text weight="bold">Real-valued</Text>
+            <Text>
+              Continuous numeric outcomes: revenue per user, time spent, satisfaction scores, any measurable quantity.
+            </Text>
+          </Flex>
+        </RadioCards.Item>
+      </RadioCards.Root>
+    </Flex>
+  );
+};

--- a/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
@@ -1,5 +1,9 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import {
+  ExperimentFormData,
+  ExperimentScreenId,
+  getMabDwhTarget,
+} from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Callout, Flex, Heading, RadioCards, Text } from '@radix-ui/themes';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
 import { FormOutcomeType } from '@/app/experiments/create/experiment-form/experiment-form-types';
@@ -11,11 +15,9 @@ export const ExperimentSelectBinaryOrRealOutcomes = ({
   data,
   dispatch,
 }: ScreenProps<ExperimentFormData, ExperimentSelectBinaryOrRealMessages, ExperimentScreenId>) => {
-  // When the bandit is bound to a DWH target column, the column's type fixes the outcome type
-  // (boolean → binary, numeric → real-valued). Lock the choice so it can't disagree with the column;
-  // the value itself is applied upstream when the target is selected.
-  const isDwhTargetBound = !!(data.targetFieldName && data.datasourceId);
-  const lockedOutcomeType = isDwhTargetBound ? outcomeTypeForTargetDataType(data.targetFieldType) : undefined;
+  // A DWH target locks the outcome type to the column's type, so it can't disagree.
+  const dwhTarget = getMabDwhTarget(data);
+  const lockedOutcomeType = dwhTarget ? outcomeTypeForTargetDataType(dwhTarget.targetFieldType) : undefined;
   const locked = lockedOutcomeType !== undefined;
 
   return (

--- a/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
@@ -6,10 +6,10 @@ import {
 } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { Callout, Flex, Heading, RadioCards, Text } from '@radix-ui/themes';
 import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { FormOutcomeType } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import { LikelihoodTypes } from '@/api/methods.schemas';
 import { outcomeTypeForTargetDataType } from '@/app/experiments/create/experiment-form/experiment-bandit-helpers';
 
-type ExperimentSelectBinaryOrRealMessages = { type: 'set-outcome-type'; value: FormOutcomeType };
+type ExperimentSelectBinaryOrRealMessages = { type: 'set-outcome-type'; value: LikelihoodTypes };
 
 export const ExperimentSelectBinaryOrRealOutcomes = ({
   data,
@@ -41,7 +41,7 @@ export const ExperimentSelectBinaryOrRealOutcomes = ({
         columns={{ initial: '1', sm: '3' }}
         onValueChange={(v) => {
           if (locked) return;
-          dispatch({ type: 'set-outcome-type', value: v as FormOutcomeType });
+          dispatch({ type: 'set-outcome-type', value: v as LikelihoodTypes });
         }}
       >
         <RadioCards.Item value="binary" disabled={locked && lockedOutcomeType !== 'binary'}>
@@ -52,7 +52,7 @@ export const ExperimentSelectBinaryOrRealOutcomes = ({
             </Text>
           </Flex>
         </RadioCards.Item>
-        <RadioCards.Item value="real" disabled={locked && lockedOutcomeType !== 'real'}>
+        <RadioCards.Item value="real-valued" disabled={locked && lockedOutcomeType !== 'real-valued'}>
           <Flex direction="column" width="100%">
             <Text weight="bold">Real-valued</Text>
             <Text>

--- a/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-select-binary-or-real-outcomes.tsx
@@ -44,7 +44,7 @@ export const ExperimentSelectBinaryOrRealOutcomes = ({
           dispatch({ type: 'set-outcome-type', value: v as FormOutcomeType });
         }}
       >
-        <RadioCards.Item value="binary" disabled={locked}>
+        <RadioCards.Item value="binary" disabled={locked && lockedOutcomeType !== 'binary'}>
           <Flex direction="column" width="100%">
             <Text weight="bold">Binary</Text>
             <Text>
@@ -52,7 +52,7 @@ export const ExperimentSelectBinaryOrRealOutcomes = ({
             </Text>
           </Flex>
         </RadioCards.Item>
-        <RadioCards.Item value="real" disabled={locked}>
+        <RadioCards.Item value="real" disabled={locked && lockedOutcomeType !== 'real'}>
           <Flex direction="column" width="100%">
             <Text weight="bold">Real-valued</Text>
             <Text>

--- a/src/app/experiments/create/experiment-form/experiment-summarize-bandit-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-bandit-screen.tsx
@@ -31,6 +31,8 @@ export const ExperimentsSummarizeBanditScreen = ({
         treatmentArms: 'describe-bandit-arms',
         outcomesPrior: 'bandit-binary-or-real',
         contexts: isCmab ? 'describe-contexts' : undefined,
+        // The optional DWH-target step exists only in the MAB flow, not CMAB.
+        datasource: isCmab ? undefined : 'mab-select-datasource',
       }}
     />
   );

--- a/src/app/experiments/create/experiment-form/select-cluster-key.tsx
+++ b/src/app/experiments/create/experiment-form/select-cluster-key.tsx
@@ -1,85 +1,22 @@
-import { Flex, Text, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { XSpinner } from '@/components/ui/x-spinner';
-import { DataTypeBadge } from '@/components/ui/data-type-badge';
-import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
-import { Combobox } from '@/components/ui/combobox';
-import { useMemo } from 'react';
+import { InspectDatasourceTableResponse } from '@/api/methods.schemas';
+import { SelectField } from './select-field';
 
-interface ComboboxRowProps {
-  data_type: DataType;
-  field_name: string;
-}
-
-const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => (
-  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
-    <Text size="2">{field_name}</Text>
-    <DataTypeBadge type={data_type} />
-  </Flex>
-);
+const CLUSTER_KEY_TOOLTIP =
+  'If your treatment is naturally delivered at a group level (such as schools, clinics, ' +
+  'or districts), but you will track metrics at the participant level, set this to ' +
+  'randomly assign whole groups of participants together to your arms. ' +
+  'Select the field that identifies each group.';
 
 interface SelectClusterKeyProps {
   tableData: InspectDatasourceTableResponse | undefined;
   /** Input text owned by the parent component. */
   inputValue: string;
   isLoading: boolean;
-  /**
-   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
-   * exact unique field-name match (same as Combobox), otherwise undefined.
-   */
   onChange: (inputText: string, selectedKey?: string) => void;
   disabled?: boolean;
   excludeFieldName?: string; // to prevent the cluster key from being the same as the primary key
 }
 
-export const SelectClusterKey = ({
-  tableData,
-  isLoading,
-  inputValue,
-  onChange,
-  disabled,
-  excludeFieldName,
-}: SelectClusterKeyProps) => {
-  const orderedFields = useMemo(() => {
-    const fields = tableData?.fields ?? [];
-    return fields
-      .filter((field) => field.field_name !== excludeFieldName)
-      .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
-  }, [excludeFieldName, tableData]);
-  const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
-  const showSpinner = isLoading && !disabled;
-
-  return (
-    <Flex direction="column" gap={'3'}>
-      <Flex align="center" gap="1">
-        <Text as="label" size="2" weight="bold">
-          Cluster key (optional)
-        </Text>
-        <Tooltip
-          content={
-            'If your treatment is naturally delivered at a group level (such as schools, clinics, ' +
-            'or districts), but you will track metrics at the participant level, set this to ' +
-            'randomly assign whole groups of participants together to your arms. ' +
-            'Select the field that identifies each group.'
-          }
-        >
-          <InfoCircledIcon />
-        </Tooltip>
-      </Flex>
-      {showSpinner ? (
-        <XSpinner message="Loading fields..." />
-      ) : (
-        <Combobox
-          value={inputValue}
-          onChange={onChange}
-          options={orderedFields}
-          rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
-          dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}
-          getDisplayTextForOption={(v) => v.field_name}
-          getKeyForOption={(v) => v.field_name}
-          disabled={disabled}
-        />
-      )}
-    </Flex>
-  );
-};
+export const SelectClusterKey = (props: SelectClusterKeyProps) => (
+  <SelectField {...props} label="Cluster key (optional)" tooltip={CLUSTER_KEY_TOOLTIP} />
+);

--- a/src/app/experiments/create/experiment-form/select-field.tsx
+++ b/src/app/experiments/create/experiment-form/select-field.tsx
@@ -1,0 +1,85 @@
+import { Flex, Text, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
+import { Combobox } from '@/components/ui/combobox';
+import { useMemo } from 'react';
+
+type TableField = InspectDatasourceTableResponse['fields'][number];
+
+const ComboboxRow = ({ field_name, data_type }: { field_name: string; data_type: DataType }) => (
+  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+    <Text size="2">{field_name}</Text>
+    <DataTypeBadge type={data_type} />
+  </Flex>
+);
+
+interface SelectFieldProps {
+  tableData: InspectDatasourceTableResponse | undefined;
+  /** Input text owned by the parent component. */
+  inputValue: string;
+  isLoading: boolean;
+  /**
+   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
+   * exact unique field-name match (same as Combobox), otherwise undefined.
+   */
+  onChange: (inputText: string, selectedKey?: string) => void;
+  disabled?: boolean;
+  excludeFieldName?: string;
+  /** Label shown above the combobox. */
+  label: string;
+  /** Tooltip explaining what the field is for. */
+  tooltip: string;
+  /** Optional eligibility filter applied on top of the exclude-by-name filter. */
+  isEligible?: (field: TableField) => boolean;
+}
+
+/** Combobox for picking a single table column by name, with a label, tooltip, and data-type badges. */
+export const SelectField = ({
+  tableData,
+  isLoading,
+  inputValue,
+  onChange,
+  disabled,
+  excludeFieldName,
+  label,
+  tooltip,
+  isEligible,
+}: SelectFieldProps) => {
+  const orderedFields = useMemo(() => {
+    const fields = tableData?.fields ?? [];
+    return fields
+      .filter((field) => field.field_name !== excludeFieldName && (isEligible?.(field) ?? true))
+      .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
+  }, [excludeFieldName, isEligible, tableData]);
+  const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
+  const showSpinner = isLoading && !disabled;
+
+  return (
+    <Flex direction="column" gap={'3'}>
+      <Flex align="center" gap="1">
+        <Text as="label" size="2" weight="bold">
+          {label}
+        </Text>
+        <Tooltip content={tooltip}>
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+      {showSpinner ? (
+        <XSpinner message="Loading fields..." />
+      ) : (
+        <Combobox
+          value={inputValue}
+          onChange={onChange}
+          options={orderedFields}
+          rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
+          dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}
+          getDisplayTextForOption={(v) => v.field_name}
+          getKeyForOption={(v) => v.field_name}
+          disabled={disabled}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/src/app/experiments/create/experiment-form/select-table-fields.tsx
+++ b/src/app/experiments/create/experiment-form/select-table-fields.tsx
@@ -1,0 +1,191 @@
+'use client';
+import { useInspectDatasource, useInspectTableInDatasource } from '@/api/admin';
+import { DataType } from '@/api/methods.schemas';
+import { Box, Flex, IconButton, Select, Text } from '@radix-ui/themes';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { SelectPrimaryKey } from './select-primary-key';
+import { SelectClusterKey } from './select-cluster-key';
+import { SelectTargetField } from './select-target-field';
+import { useState } from 'react';
+
+interface SelectTableFieldsProps {
+  datasourceId: string;
+  tableName: string | undefined;
+  primaryKey: string | undefined;
+  // Seed values for the comboboxes (so a revisited step shows the prior selection).
+  clusterKey?: string;
+  targetFieldName?: string;
+  onTableChange: (tableName: string) => void;
+  onPrimaryKeyChange: (fieldName: string | undefined) => void;
+  // Cluster-key field (freq clustered experiments).
+  showClusterKey?: boolean;
+  onClusterKeyChange?: (fieldName: string | undefined) => void;
+  // Target-column field (DWH-backed MAB).
+  showTargetField?: boolean;
+  onTargetFieldChange?: (fieldName: string | undefined, dataType: DataType | undefined) => void;
+}
+
+/**
+ * Table selection plus its dependent field pickers (primary key, and optionally a cluster key or a
+ * target column), sharing the datasource/table inspection and auto-select logic. Owns the combobox
+ * input text; reset it across datasources by giving this a `key={datasourceId}` at the call site.
+ */
+export const SelectTableFields = ({
+  datasourceId,
+  tableName,
+  primaryKey,
+  clusterKey,
+  targetFieldName,
+  onTableChange,
+  onPrimaryKeyChange,
+  showClusterKey,
+  onClusterKeyChange,
+  showTargetField,
+  onTargetFieldChange,
+}: SelectTableFieldsProps) => {
+  const [refresh, setRefresh] = useState(false);
+  const [primaryKeyInput, setPrimaryKeyInput] = useState(primaryKey ?? '');
+  const [clusterKeyInput, setClusterKeyInput] = useState(clusterKey ?? '');
+  const [targetFieldInput, setTargetFieldInput] = useState(targetFieldName ?? '');
+
+  const {
+    data: inspectData,
+    isValidating,
+    isLoading: loadingTables,
+    error,
+  } = useInspectDatasource(datasourceId, refresh ? { refresh: true } : undefined, {
+    swr: {
+      enabled: !!datasourceId,
+      onSuccess: (response) => {
+        if (refresh) {
+          setRefresh(false);
+        }
+        if (!tableName && response.tables.length > 0) {
+          handleTableChange(response.tables[0]);
+        }
+      },
+    },
+  });
+
+  const { data: tableData, isLoading: loadingTable } = useInspectTableInDatasource(
+    datasourceId,
+    tableName!,
+    undefined,
+    {
+      swr: {
+        enabled: !!datasourceId && !!tableName,
+        onSuccess: (response) => {
+          if (!primaryKey) {
+            const detectedPrimaryKey = response.primary_key_fields[0] ?? response.detected_unique_id_fields[0];
+            if (detectedPrimaryKey) {
+              handlePrimaryKeyChange(detectedPrimaryKey, detectedPrimaryKey);
+            }
+          }
+        },
+      },
+    },
+  );
+
+  const tables = inspectData?.tables ?? [];
+  const disabled = !tableName || !inspectData;
+
+  function handleTableChange(newTableName: string) {
+    setPrimaryKeyInput('');
+    setClusterKeyInput('');
+    setTargetFieldInput('');
+    onTableChange(newTableName);
+  }
+
+  function handlePrimaryKeyChange(inputText: string, selectedKey?: string) {
+    setPrimaryKeyInput(inputText);
+    onPrimaryKeyChange(selectedKey);
+  }
+
+  function handleClusterKeyChange(inputText: string, selectedKey?: string) {
+    setClusterKeyInput(inputText);
+    onClusterKeyChange?.(selectedKey);
+  }
+
+  function handleTargetFieldChange(inputText: string, selectedKey?: string) {
+    setTargetFieldInput(inputText);
+    const dataType = selectedKey ? tableData?.fields.find((f) => f.field_name === selectedKey)?.data_type : undefined;
+    onTargetFieldChange?.(selectedKey, dataType);
+  }
+
+  if (loadingTables) {
+    return <XSpinner message="Loading tables..." />;
+  }
+
+  if (error) {
+    return <GenericErrorCallout title="Failed to fetch tables" error={error} />;
+  }
+
+  if (tables.length === 0) {
+    return <Text color="gray">No tables found in this datasource. Please check your datasource configuration.</Text>;
+  }
+
+  return (
+    <Flex direction="column" gap="3">
+      <Box maxWidth="50%">
+        <Flex direction="column" gap="2">
+          <Text size="2" weight="bold">
+            Select a table
+          </Text>
+          <Flex direction="row" gap="3">
+            <Select.Root value={tableName} onValueChange={handleTableChange}>
+              <Select.Trigger placeholder="Select a table" />
+              <Select.Content>
+                {tables.map((table) => (
+                  <Select.Item key={table} value={table}>
+                    {table}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+            <IconButton size="2" variant="soft" onClick={() => setRefresh(true)} loading={isValidating}>
+              <ReloadIcon />
+            </IconButton>
+          </Flex>
+        </Flex>
+      </Box>
+
+      <Box maxWidth="50%">
+        <SelectPrimaryKey
+          tableData={tableData}
+          isLoading={loadingTable}
+          inputValue={primaryKeyInput}
+          onChange={handlePrimaryKeyChange}
+          disabled={disabled}
+        />
+      </Box>
+
+      {showClusterKey && (
+        <Box maxWidth="50%">
+          <SelectClusterKey
+            tableData={tableData}
+            isLoading={loadingTable}
+            inputValue={clusterKeyInput}
+            onChange={handleClusterKeyChange}
+            disabled={disabled}
+            excludeFieldName={primaryKey}
+          />
+        </Box>
+      )}
+
+      {showTargetField && (
+        <Box maxWidth="50%">
+          <SelectTargetField
+            tableData={tableData}
+            isLoading={loadingTable}
+            inputValue={targetFieldInput}
+            onChange={handleTargetFieldChange}
+            disabled={disabled}
+            excludeFieldName={primaryKey}
+          />
+        </Box>
+      )}
+    </Flex>
+  );
+};

--- a/src/app/experiments/create/experiment-form/select-target-field.tsx
+++ b/src/app/experiments/create/experiment-form/select-target-field.tsx
@@ -3,9 +3,9 @@ import { isEligibleForUseAsMetric } from '@/services/genapi-helpers';
 import { SelectField } from './select-field';
 
 const TARGET_TOOLTIP =
-  'The data-warehouse column read as each participant outcome for this bandit. Its type ' +
-  'sets what a valid outcome looks like — a boolean column expects 0/1, a numeric column ' +
-  'expects a number. Validity is enforced when the experiment is created.';
+  "The data-warehouse column for this bandit's outcome. Its type sets what a valid outcome looks " +
+  'like — a boolean column expects 0/1, a numeric column expects a number. Validity is enforced ' +
+  'when the results are sent to Evidential.';
 
 // Only boolean/numeric columns can back a bandit outcome (the chosen type locks binary vs real-valued
 // downstream), so don't offer columns we'd reject at create time.

--- a/src/app/experiments/create/experiment-form/select-target-field.tsx
+++ b/src/app/experiments/create/experiment-form/select-target-field.tsx
@@ -1,87 +1,26 @@
-import { Flex, Text, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { XSpinner } from '@/components/ui/x-spinner';
-import { DataTypeBadge } from '@/components/ui/data-type-badge';
 import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
-import { Combobox } from '@/components/ui/combobox';
 import { isEligibleForUseAsMetric } from '@/services/genapi-helpers';
-import { useMemo } from 'react';
+import { SelectField } from './select-field';
 
-interface ComboboxRowProps {
-  data_type: DataType;
-  field_name: string;
-}
+const TARGET_TOOLTIP =
+  'The data-warehouse column read as each participant outcome for this bandit. Its type ' +
+  'sets what a valid outcome looks like — a boolean column expects 0/1, a numeric column ' +
+  'expects a number. Validity is enforced when the experiment is created.';
 
-const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => (
-  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
-    <Text size="2">{field_name}</Text>
-    <DataTypeBadge type={data_type} />
-  </Flex>
-);
+// Only boolean/numeric columns can back a bandit outcome (the chosen type locks binary vs real-valued
+// downstream), so don't offer columns we'd reject at create time.
+const isMetricEligible = (field: { data_type: DataType }) => isEligibleForUseAsMetric(field.data_type);
 
 interface SelectTargetFieldProps {
   tableData: InspectDatasourceTableResponse | undefined;
   /** Input text owned by the parent component. */
   inputValue: string;
   isLoading: boolean;
-  /**
-   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
-   * exact unique field-name match (same as Combobox), otherwise undefined.
-   */
   onChange: (inputText: string, selectedKey?: string) => void;
   disabled?: boolean;
   excludeFieldName?: string; // to prevent the target from being the same as the primary key
 }
 
-export const SelectTargetField = ({
-  tableData,
-  isLoading,
-  inputValue,
-  onChange,
-  disabled,
-  excludeFieldName,
-}: SelectTargetFieldProps) => {
-  const orderedFields = useMemo(() => {
-    const fields = tableData?.fields ?? [];
-    // Only boolean/numeric columns can back a bandit outcome (and the chosen type locks binary vs
-    // real-valued downstream), so don't offer columns we'd reject at create time.
-    return fields
-      .filter((field) => field.field_name !== excludeFieldName && isEligibleForUseAsMetric(field.data_type))
-      .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
-  }, [excludeFieldName, tableData]);
-  const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
-  const showSpinner = isLoading && !disabled;
-
-  return (
-    <Flex direction="column" gap={'3'}>
-      <Flex align="center" gap="1">
-        <Text as="label" size="2" weight="bold">
-          Target column
-        </Text>
-        <Tooltip
-          content={
-            'The data-warehouse column read as each participant outcome for this bandit. Its type ' +
-            'sets what a valid outcome looks like — a boolean column expects 0/1, a numeric column ' +
-            'expects a number. Validity is enforced when the experiment is created.'
-          }
-        >
-          <InfoCircledIcon />
-        </Tooltip>
-      </Flex>
-      {showSpinner ? (
-        <XSpinner message="Loading fields..." />
-      ) : (
-        <Combobox
-          value={inputValue}
-          onChange={onChange}
-          options={orderedFields}
-          rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
-          dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}
-          getDisplayTextForOption={(v) => v.field_name}
-          getKeyForOption={(v) => v.field_name}
-          disabled={disabled}
-        />
-      )}
-    </Flex>
-  );
-};
+export const SelectTargetField = (props: SelectTargetFieldProps) => (
+  <SelectField {...props} label="Target column" tooltip={TARGET_TOOLTIP} isEligible={isMetricEligible} />
+);

--- a/src/app/experiments/create/experiment-form/select-target-field.tsx
+++ b/src/app/experiments/create/experiment-form/select-target-field.tsx
@@ -1,0 +1,87 @@
+import { Flex, Text, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { XSpinner } from '@/components/ui/x-spinner';
+import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import { DataType, InspectDatasourceTableResponse } from '@/api/methods.schemas';
+import { Combobox } from '@/components/ui/combobox';
+import { isEligibleForUseAsMetric } from '@/services/genapi-helpers';
+import { useMemo } from 'react';
+
+interface ComboboxRowProps {
+  data_type: DataType;
+  field_name: string;
+}
+
+const ComboboxRow = ({ field_name, data_type }: ComboboxRowProps) => (
+  <Flex gap="2" align="center" justify="between" style={{ whiteSpace: 'nowrap' }}>
+    <Text size="2">{field_name}</Text>
+    <DataTypeBadge type={data_type} />
+  </Flex>
+);
+
+interface SelectTargetFieldProps {
+  tableData: InspectDatasourceTableResponse | undefined;
+  /** Input text owned by the parent component. */
+  inputValue: string;
+  isLoading: boolean;
+  /**
+   * `inputText` is always the new input from typing or selection. `selectedKey` is set only on an
+   * exact unique field-name match (same as Combobox), otherwise undefined.
+   */
+  onChange: (inputText: string, selectedKey?: string) => void;
+  disabled?: boolean;
+  excludeFieldName?: string; // to prevent the target from being the same as the primary key
+}
+
+export const SelectTargetField = ({
+  tableData,
+  isLoading,
+  inputValue,
+  onChange,
+  disabled,
+  excludeFieldName,
+}: SelectTargetFieldProps) => {
+  const orderedFields = useMemo(() => {
+    const fields = tableData?.fields ?? [];
+    // Only boolean/numeric columns can back a bandit outcome (and the chosen type locks binary vs
+    // real-valued downstream), so don't offer columns we'd reject at create time.
+    return fields
+      .filter((field) => field.field_name !== excludeFieldName && isEligibleForUseAsMetric(field.data_type))
+      .toSorted((a, b) => a.field_name.localeCompare(b.field_name));
+  }, [excludeFieldName, tableData]);
+  const exactMatchField = tableData?.fields.find((v) => v.field_name === inputValue);
+  const showSpinner = isLoading && !disabled;
+
+  return (
+    <Flex direction="column" gap={'3'}>
+      <Flex align="center" gap="1">
+        <Text as="label" size="2" weight="bold">
+          Target column
+        </Text>
+        <Tooltip
+          content={
+            'The data-warehouse column read as each participant outcome for this bandit. Its type ' +
+            'sets what a valid outcome looks like — a boolean column expects 0/1, a numeric column ' +
+            'expects a number. Validity is enforced when the experiment is created.'
+          }
+        >
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+      {showSpinner ? (
+        <XSpinner message="Loading fields..." />
+      ) : (
+        <Combobox
+          value={inputValue}
+          onChange={onChange}
+          options={orderedFields}
+          rightSlot={exactMatchField && <DataTypeBadge type={exactMatchField.data_type} />}
+          dropdownRow={({ option }) => <ComboboxRow data_type={option.data_type} field_name={option.field_name} />}
+          getDisplayTextForOption={(v) => v.field_name}
+          getKeyForOption={(v) => v.field_name}
+          disabled={disabled}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/src/components/features/experiments/experiment-confirmation-display.tsx
+++ b/src/components/features/experiments/experiment-confirmation-display.tsx
@@ -8,6 +8,7 @@ import {
   isCmabSpec,
   isFreqPreassignedSpec,
   isFrequentistSpec,
+  isMabDwhSpec,
 } from '@/services/experiment-utils';
 import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
 import { ExperimentDescriptionSection } from '@/components/features/experiments/sections/experiment-description-section';
@@ -53,6 +54,7 @@ export function ExperimentConfirmationDisplay({
   const isFreqPreassigned = isFreqPreassignedSpec(designSpec);
   const isBandit = isBanditSpec(designSpec);
   const isCmab = isCmabSpec(designSpec);
+  const isMabDwh = isMabDwhSpec(designSpec);
   const clusterKey = isClusteredPreassignedSpec(designSpec) ? (designSpec.cluster_key ?? undefined) : undefined;
 
   // Extract frequentist-specific properties (confidence/power/filters/strata)
@@ -104,6 +106,14 @@ export function ExperimentConfirmationDisplay({
               />
             )}
           </>
+        )}
+        {isMabDwh && (
+          <DatasourceTargetingSection
+            tableName={designSpec.table_name}
+            primaryKey={designSpec.primary_key}
+            targetField={designSpec.target_field_name}
+            onEditDatasource={onEditDatasource}
+          />
         )}
         {isBandit && (
           <OutcomesPriorSection priorType={priorType} rewardType={rewardType} onEdit={onEditOutcomesPrior} />

--- a/src/components/features/experiments/experiment-type-badge.tsx
+++ b/src/components/features/experiments/experiment-type-badge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Badge, Tooltip } from '@radix-ui/themes';
+import { MAB_DWH_LABEL } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 
 export const ExperimentTypeBadge = ({ type }: { type: string }) => {
   const typeMap: Record<
@@ -10,6 +11,8 @@ export const ExperimentTypeBadge = ({ type }: { type: string }) => {
     freq_preassigned: { name: 'A/B PreAs', tooltipName: 'A/B Preassigned', color: 'blue', variant: 'soft' },
     freq_online: { name: 'A/B Online', tooltipName: 'A/B Online', color: 'blue', variant: 'soft' },
     mab_online: { name: 'MAB', tooltipName: 'Multi-Armed Bandit', color: 'green', variant: 'soft' },
+    // A DWH-target MAB is a MAB variant; keep a compact pill but spell it out on hover.
+    mab_online_dwh: { name: 'MAB (+DWH)', tooltipName: MAB_DWH_LABEL, color: 'green', variant: 'soft' },
     cmab_online: { name: 'CMAB', tooltipName: 'Contextual Multi-Armed Bandit', color: 'purple', variant: 'soft' },
   };
 

--- a/src/components/features/experiments/navigation-buttons.tsx
+++ b/src/components/features/experiments/navigation-buttons.tsx
@@ -9,9 +9,6 @@ interface NavigationButtonsProps {
   // The text to render on the next button.
   nextLabel?: string;
 
-  // The text to render on the skip button.
-  skipLabel?: string;
-
   // If true, the "prev" button will be rendered in a disabled state.
   prevDisabled?: boolean;
 
@@ -27,10 +24,6 @@ interface NavigationButtonsProps {
   // Handler for the "next" button. If undefined, the next button will not be rendered.
   onNext?: () => void;
 
-  // Handler for an optional "Skip" button, rendered to the left of Back/Next. If undefined, no skip
-  // button is shown.
-  onSkip?: () => void;
-
   // Tooltip to display over the "next" button when nextDisabled is true.
   nextTooltipContent?: string;
 }
@@ -44,8 +37,6 @@ export function NavigationButtons({
   nextLoading = false,
   prevDisabled = false,
   nextTooltipContent,
-  onSkip,
-  skipLabel = 'Skip',
 }: NavigationButtonsProps) {
   let nextButton = (
     <Button onClick={onNext} disabled={!onNext || nextDisabled} loading={nextLoading}>
@@ -64,14 +55,8 @@ export function NavigationButtons({
       {prevLabel}
     </Button>
   );
-  const skipButton = (
-    <Button onClick={onSkip} variant="soft" color="gray">
-      {skipLabel}
-    </Button>
-  );
   return (
     <Flex gap="3" justify="end" align="center" mt="6">
-      {onSkip ? skipButton : null}
       {onPrev ? prevButton : <div />}
       {onNext ? nextButton : <div />}
     </Flex>

--- a/src/components/features/experiments/navigation-buttons.tsx
+++ b/src/components/features/experiments/navigation-buttons.tsx
@@ -9,6 +9,9 @@ interface NavigationButtonsProps {
   // The text to render on the next button.
   nextLabel?: string;
 
+  // The text to render on the skip button.
+  skipLabel?: string;
+
   // If true, the "prev" button will be rendered in a disabled state.
   prevDisabled?: boolean;
 
@@ -24,6 +27,10 @@ interface NavigationButtonsProps {
   // Handler for the "next" button. If undefined, the next button will not be rendered.
   onNext?: () => void;
 
+  // Handler for an optional "Skip" button, rendered to the left of Back/Next. If undefined, no skip
+  // button is shown.
+  onSkip?: () => void;
+
   // Tooltip to display over the "next" button when nextDisabled is true.
   nextTooltipContent?: string;
 }
@@ -37,6 +44,8 @@ export function NavigationButtons({
   nextLoading = false,
   prevDisabled = false,
   nextTooltipContent,
+  onSkip,
+  skipLabel = 'Skip',
 }: NavigationButtonsProps) {
   let nextButton = (
     <Button onClick={onNext} disabled={!onNext || nextDisabled} loading={nextLoading}>
@@ -55,8 +64,14 @@ export function NavigationButtons({
       {prevLabel}
     </Button>
   );
+  const skipButton = (
+    <Button onClick={onSkip} variant="soft" color="gray">
+      {skipLabel}
+    </Button>
+  );
   return (
     <Flex gap="3" justify="end" align="center" mt="6">
+      {onSkip ? skipButton : null}
       {onPrev ? prevButton : <div />}
       {onNext ? nextButton : <div />}
     </Flex>

--- a/src/components/features/experiments/sections/datasource-targeting-section.tsx
+++ b/src/components/features/experiments/sections/datasource-targeting-section.tsx
@@ -9,7 +9,8 @@ interface DatasourceTargetingSectionProps {
   tableName?: string;
   primaryKey?: string;
   clusterKey?: string;
-  filters: Filter[];
+  targetField?: string;
+  filters?: Filter[];
   onEditDatasource?: () => void;
   onEditFilters?: () => void;
 }
@@ -44,6 +45,7 @@ export function DatasourceTargetingSection({
   tableName,
   primaryKey,
   clusterKey,
+  targetField,
   filters,
   onEditDatasource,
   onEditFilters,
@@ -85,35 +87,43 @@ export function DatasourceTargetingSection({
             <DataList.Value>{clusterKey}</DataList.Value>
           </DataList.Item>
         )}
-        <DataList.Item>
-          <DataList.Label>Filters</DataList.Label>
-          <DataList.Value>
-            {filters.length === 0 ? (
-              <Text color="gray">No filters defined</Text>
-            ) : (
-              <Table.Root>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeaderCell>Field</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell>Operator</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell>Values</Table.ColumnHeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  {filters.map((filter, index) => {
-                    return (
-                      <Table.Row key={`${filter.field_name}-${index}`}>
-                        <Table.Cell>{filter.field_name}</Table.Cell>
-                        <Table.Cell align={'center'}>{getFilterOperatorLabel(filter)}</Table.Cell>
-                        <Table.Cell>{formatFilterValueDisplay(filter)}</Table.Cell>
-                      </Table.Row>
-                    );
-                  })}
-                </Table.Body>
-              </Table.Root>
-            )}
-          </DataList.Value>
-        </DataList.Item>
+        {targetField && (
+          <DataList.Item>
+            <DataList.Label>Target column</DataList.Label>
+            <DataList.Value>{targetField}</DataList.Value>
+          </DataList.Item>
+        )}
+        {filters !== undefined && (
+          <DataList.Item>
+            <DataList.Label>Filters</DataList.Label>
+            <DataList.Value>
+              {filters.length === 0 ? (
+                <Text color="gray">No filters defined</Text>
+              ) : (
+                <Table.Root>
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.ColumnHeaderCell>Field</Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell>Operator</Table.ColumnHeaderCell>
+                      <Table.ColumnHeaderCell>Values</Table.ColumnHeaderCell>
+                    </Table.Row>
+                  </Table.Header>
+                  <Table.Body>
+                    {filters.map((filter, index) => {
+                      return (
+                        <Table.Row key={`${filter.field_name}-${index}`}>
+                          <Table.Cell>{filter.field_name}</Table.Cell>
+                          <Table.Cell align={'center'}>{getFilterOperatorLabel(filter)}</Table.Cell>
+                          <Table.Cell>{formatFilterValueDisplay(filter)}</Table.Cell>
+                        </Table.Row>
+                      );
+                    })}
+                  </Table.Body>
+                </Table.Root>
+              )}
+            </DataList.Value>
+          </DataList.Item>
+        )}
       </DataList.Root>
     </SectionCard>
   );

--- a/src/components/features/experiments/sections/experiment-description-section.tsx
+++ b/src/components/features/experiments/sections/experiment-description-section.tsx
@@ -9,7 +9,7 @@ import { ReadMoreText } from '@/components/ui/read-more-text';
 import { formatIsoDateLocal } from '@/services/date-utils';
 import { useListOrganizationWebhooks } from '@/api/admin';
 import { useCurrentOrganization } from '@/providers/organization-provider';
-import { ExperimentTypeOptions } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
+import { experimentTypeLabel } from '@/app/experiments/create/experiment-form/experiment-form-helpers';
 import { XSpinner } from '@/components/ui/x-spinner';
 
 interface ExperimentDescriptionSectionProps {
@@ -26,8 +26,7 @@ export function ExperimentDescriptionSection({ response, onEdit }: ExperimentDes
     swr: { enabled: !!organizationId },
   });
   const selectedWebhooks = webhooksData?.items?.filter((webhook) => webhookIds.includes(webhook.id)) ?? [];
-  const experimentTypeTitle =
-    ExperimentTypeOptions.find((v) => v.value == designSpec.experiment_type)?.title ?? designSpec.experiment_type;
+  const experimentTypeTitle = experimentTypeLabel(designSpec.experiment_type);
   return (
     <SectionCard
       title="Experiment Description"

--- a/src/components/features/experiments/targeting-dialog.tsx
+++ b/src/components/features/experiments/targeting-dialog.tsx
@@ -3,7 +3,13 @@
 import { useState } from 'react';
 import { Box, Button, Dialog, Flex } from '@radix-ui/themes';
 import { DesignSpec } from '@/api/methods.schemas';
-import { isBanditSpec, isClusteredPreassignedSpec, isCmabSpec, isFrequentistSpec } from '@/services/experiment-utils';
+import {
+  isBanditSpec,
+  isClusteredPreassignedSpec,
+  isCmabSpec,
+  isFrequentistSpec,
+  isMabDwhSpec,
+} from '@/services/experiment-utils';
 import { DatasourceTargetingSection } from '@/components/features/experiments/sections/datasource-targeting-section';
 import { ContextsSection } from '@/components/features/experiments/sections/contexts-section';
 import { OutcomesPriorSection } from '@/components/features/experiments/sections/outcomes-prior-section';
@@ -38,6 +44,13 @@ export function TargetingDialog({ designSpec, webhookIds }: TargetingDialogProps
                     isClusteredPreassignedSpec(designSpec) ? (designSpec.cluster_key ?? undefined) : undefined
                   }
                   filters={designSpec.filters}
+                />
+              )}
+              {isMabDwhSpec(designSpec) && (
+                <DatasourceTargetingSection
+                  tableName={designSpec.table_name}
+                  primaryKey={designSpec.primary_key}
+                  targetField={designSpec.target_field_name}
                 />
               )}
               {isBanditSpec(designSpec) && (

--- a/src/services/experiment-utils.ts
+++ b/src/services/experiment-utils.ts
@@ -54,8 +54,7 @@ export const isCmabExperimentType = (
 ): experimentType is CMABExperimentSpecExperimentType =>
   experimentType === CMABExperimentSpecExperimentType.cmab_online;
 
-// The plain MAB type selectable in the creation wizard (a DWH-target MAB is derived from this plus a
-// target column, so it never appears as the wizard's experimentType — hence mab_online only here).
+// Only mab_online: a DWH-target MAB is this type plus a target column, never its own wizard type.
 export const isMabExperimentType = (
   experimentType?: ExperimentType,
 ): experimentType is MABExperimentSpecExperimentType => experimentType === MABExperimentSpecExperimentType.mab_online;

--- a/src/services/experiment-utils.ts
+++ b/src/services/experiment-utils.ts
@@ -6,6 +6,7 @@ import {
   DesignSpec,
   ExperimentConfig,
   GetExperimentResponse,
+  MABDwhExperimentSpecExperimentType,
   MABExperimentSpec,
   MABExperimentSpecExperimentType,
   MetricPowerAnalysis,
@@ -53,10 +54,18 @@ export const isCmabExperimentType = (
 ): experimentType is CMABExperimentSpecExperimentType =>
   experimentType === CMABExperimentSpecExperimentType.cmab_online;
 
+// The plain MAB type selectable in the creation wizard (a DWH-target MAB is derived from this plus a
+// target column, so it never appears as the wizard's experimentType — hence mab_online only here).
+export const isMabExperimentType = (
+  experimentType?: ExperimentType,
+): experimentType is MABExperimentSpecExperimentType => experimentType === MABExperimentSpecExperimentType.mab_online;
+
 export const isBanditExperimentType = (
   experimentType?: ExperimentType,
 ): experimentType is MABExperimentSpecExperimentType | CMABExperimentSpecExperimentType =>
   experimentType === MABExperimentSpecExperimentType.mab_online ||
+  // A DWH-target MAB is a MAB for every read/display purpose (arms, priors, contexts).
+  experimentType === MABDwhExperimentSpecExperimentType.mab_online_dwh ||
   experimentType === CMABExperimentSpecExperimentType.cmab_online;
 
 export const isFrequentistSpec = (
@@ -72,7 +81,12 @@ export const isClusteredPreassignedSpec = (
 ): spec is PreassignedFrequentistExperimentSpec => isFreqPreassignedSpec(spec) && !!spec.cluster_key;
 
 export function isMabSpec(spec: DesignSpec | undefined): spec is MABExperimentSpec {
-  return !!spec && spec.experiment_type === MABExperimentSpecExperimentType.mab_online;
+  return (
+    !!spec &&
+    (spec.experiment_type === MABExperimentSpecExperimentType.mab_online ||
+      // A DWH-target MAB is structurally a MAB for display (same arms/priors/contexts).
+      spec.experiment_type === MABDwhExperimentSpecExperimentType.mab_online_dwh)
+  );
 }
 
 export function isCmabSpec(spec: DesignSpec | undefined): spec is CMABExperimentSpec {

--- a/src/services/experiment-utils.ts
+++ b/src/services/experiment-utils.ts
@@ -6,6 +6,7 @@ import {
   DesignSpec,
   ExperimentConfig,
   GetExperimentResponse,
+  MABDwhExperimentSpec,
   MABDwhExperimentSpecExperimentType,
   MABExperimentSpec,
   MABExperimentSpecExperimentType,
@@ -61,7 +62,10 @@ export const isMabExperimentType = (
 
 export const isBanditExperimentType = (
   experimentType?: ExperimentType,
-): experimentType is MABExperimentSpecExperimentType | CMABExperimentSpecExperimentType =>
+): experimentType is
+  | MABExperimentSpecExperimentType
+  | MABDwhExperimentSpecExperimentType
+  | CMABExperimentSpecExperimentType =>
   experimentType === MABExperimentSpecExperimentType.mab_online ||
   // A DWH-target MAB is a MAB for every read/display purpose (arms, priors, contexts).
   experimentType === MABDwhExperimentSpecExperimentType.mab_online_dwh ||
@@ -79,7 +83,7 @@ export const isClusteredPreassignedSpec = (
   spec: DesignSpec | undefined,
 ): spec is PreassignedFrequentistExperimentSpec => isFreqPreassignedSpec(spec) && !!spec.cluster_key;
 
-export function isMabSpec(spec: DesignSpec | undefined): spec is MABExperimentSpec {
+export function isMabSpec(spec: DesignSpec | undefined): spec is MABExperimentSpec | MABDwhExperimentSpec {
   return (
     !!spec &&
     (spec.experiment_type === MABExperimentSpecExperimentType.mab_online ||
@@ -88,12 +92,17 @@ export function isMabSpec(spec: DesignSpec | undefined): spec is MABExperimentSp
   );
 }
 
+export function isMabDwhSpec(spec: DesignSpec | undefined): spec is MABDwhExperimentSpec {
+  return !!spec && spec.experiment_type === MABDwhExperimentSpecExperimentType.mab_online_dwh;
+}
+
 export function isCmabSpec(spec: DesignSpec | undefined): spec is CMABExperimentSpec {
   return !!spec && spec.experiment_type === CMABExperimentSpecExperimentType.cmab_online;
 }
 
-export const isBanditSpec = (spec: DesignSpec | undefined): spec is MABExperimentSpec | CMABExperimentSpec =>
-  isMabSpec(spec) || isCmabSpec(spec);
+export const isBanditSpec = (
+  spec: DesignSpec | undefined,
+): spec is MABExperimentSpec | MABDwhExperimentSpec | CMABExperimentSpec => isMabSpec(spec) || isCmabSpec(spec);
 
 export const isCmabExperiment = (experiment: GetExperimentResponse | ExperimentConfig | undefined): boolean =>
   !!experiment && isCmabSpec(experiment.design_spec);

--- a/src/services/genapi-helpers.ts
+++ b/src/services/genapi-helpers.ts
@@ -1,6 +1,5 @@
 import { DataType, DatasourceSummary } from '@/api/methods.schemas';
 
-/** A datasource backed by a real warehouse, not the API-only "none" placeholder. */
 export const isUsableDatasource = (ds: DatasourceSummary): boolean => ds.driver !== 'none';
 
 export const isEligibleForUseAsMetric = (data_type: DataType): boolean => {

--- a/src/services/genapi-helpers.ts
+++ b/src/services/genapi-helpers.ts
@@ -1,4 +1,7 @@
-import { DataType } from '@/api/methods.schemas';
+import { DataType, DatasourceSummary } from '@/api/methods.schemas';
+
+/** A datasource backed by a real warehouse, not the API-only "none" placeholder. */
+export const isUsableDatasource = (ds: DatasourceSummary): boolean => ds.driver !== 'none';
 
 export const isEligibleForUseAsMetric = (data_type: DataType): boolean => {
   const numericTypes: DataType[] = [

--- a/src/services/wizard/Wizard.tsx
+++ b/src/services/wizard/Wizard.tsx
@@ -40,11 +40,6 @@ type WizardProps<FormData, ScreenId extends string, InputData> = {
   // If true, a debugging drawer will be rendered at the bottom of the screen, showing navigation state and current
   // form data.
   debug?: boolean;
-  // Optional "Skip" button rendered in the Next/Prev button row, e.g. to bypass an optional nested
-  // wizard. Shown on every screen that renders navigation. If undefined, no skip button is shown.
-  onSkip?: (data: FormData) => void;
-  // The text to render on the skip button (defaults to "Skip").
-  skipLabel?: string;
 };
 
 // language=Markdown
@@ -153,8 +148,6 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
   onPrev,
   debug,
   inputData,
-  onSkip,
-  skipLabel,
 }: WizardProps<FormData, ScreenId, InputData>) {
   const [data, setData] = useState<FormData>(() => form.initialData(inputData));
   const [currentScreenId, setCurrentScreenId] = useState<ScreenId>(() => form.initialScreenId(data));
@@ -307,8 +300,6 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
                   prevDisabled={!isPrevEnabled || isTransitioning}
                   nextDisabled={!isNextEnabled || isTransitioning}
                   nextTooltipContent={nextButtonTooltip}
-                  onSkip={onSkip ? () => onSkip(data) : undefined}
-                  skipLabel={skipLabel}
                 />
               )}
             </Flex>

--- a/src/services/wizard/Wizard.tsx
+++ b/src/services/wizard/Wizard.tsx
@@ -40,6 +40,11 @@ type WizardProps<FormData, ScreenId extends string, InputData> = {
   // If true, a debugging drawer will be rendered at the bottom of the screen, showing navigation state and current
   // form data.
   debug?: boolean;
+  // Optional "Skip" button rendered in the Next/Prev button row, e.g. to bypass an optional nested
+  // wizard. Shown on every screen that renders navigation. If undefined, no skip button is shown.
+  onSkip?: (data: FormData) => void;
+  // The text to render on the skip button (defaults to "Skip").
+  skipLabel?: string;
 };
 
 // language=Markdown
@@ -148,6 +153,8 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
   onPrev,
   debug,
   inputData,
+  onSkip,
+  skipLabel,
 }: WizardProps<FormData, ScreenId, InputData>) {
   const [data, setData] = useState<FormData>(() => form.initialData(inputData));
   const [currentScreenId, setCurrentScreenId] = useState<ScreenId>(() => form.initialScreenId(data));
@@ -300,6 +307,8 @@ export function Wizard<FormData, ScreenId extends string, InputData>({
                   prevDisabled={!isPrevEnabled || isTransitioning}
                   nextDisabled={!isNextEnabled || isTransitioning}
                   nextTooltipContent={nextButtonTooltip}
+                  onSkip={onSkip ? () => onSkip(data) : undefined}
+                  skipLabel={skipLabel}
                 />
               )}
             </Flex>


### PR DESCRIPTION
## Ticket

Fixes [this](https://idinsight.atlassian.net/browse/EVE-8)

## Related PRs

Backend: Already [merged](https://github.com/agency-fund/evidential-be/pull/267) 

## Description

Let users design a MAB experiment against a data-warehouse target column through the creation wizard; the frontend for the Phase-1 backend `mab_online_dwh` support.

### Changes
  - New **optional, skippable "Datasource" step** in the MAB flow. Also reshuffled flow to be datasource → table → primary key → typed target column. Emits `MABDwhExperimentSpec` when a target is set, else plain `MABExperimentSpec`.
  - Outcome type is **derived from and locked to** the target column's type (boolean → binary, numeric → real). This is shown by greyed out buttons in the FE navigation.
  - A DWH-target MAB shows as a distinct, human-readable **"MAB (+DWH)"** / **"Multi-Armed Bandit (DWH-connected)"** across the badge and summary - no separate experiment-type card yet but distinction still made. `mab_online_dwh` is handled in the one central `experiment-utils` guard (aligned with #272's guard centralization).
  - Added a reusable **Skip** button to the wizard (next to prev / nexT)

  ## How has this been tested?
  - `tsc`, `eslint`, and `prettier` clean.
  - Manual click-through of the DWH-target, skip, and back-then-skip paths. All works groovily

  ## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have reviewed my own code to ensure good quality
  - [x] I have tested the functionality of my code to ensure it works as intended
  - [x] I have resolved merge conflicts

(Delete any items below that are not relevant)

- [ ] I have updated the automated tests
- [ ] I have updated dependencies
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
