### PR TITLE
MAB Phase 2: Add samples to frontend integrations modal

### DIFF
--- a/src/api/admin-third-party-tools-integrations.ts
+++ b/src/api/admin-third-party-tools-integrations.ts
@@ -14,6 +14,7 @@ import type {
 	AddWebhookToOrganizationResponse,
 	DeleteTurnArmJourneyMappingParams,
 	DeleteTurnConnectionFromOrganizationParams,
+	GetExperimentSampleCalls200,
 	GetOrganizationTurnConnectionParams,
 	GetTurnArmJourneyMappingResponse,
 	GetTurnConnectionResponse,
@@ -687,6 +688,79 @@ export const useDeleteTurnArmJourneyMapping = <
 	);
 
 	const query = useSWRMutation(swrKey, swrFn, swrOptions);
+
+	return {
+		swrKey,
+		...query,
+	};
+};
+export const getGetExperimentSampleCallsUrl = (
+	datasourceId: string,
+	experimentId: string,
+) => {
+	return `/v1/m/integrations/datasources/${datasourceId}/experiments/${experimentId}/sample-calls`;
+};
+
+export const getExperimentSampleCalls = async (
+	datasourceId: string,
+	experimentId: string,
+	options?: RequestInit,
+): Promise<GetExperimentSampleCalls200> => {
+	return orvalFetch<GetExperimentSampleCalls200>(
+		getGetExperimentSampleCallsUrl(datasourceId, experimentId),
+		{
+			...options,
+			method: "GET",
+		},
+	);
+};
+
+export const getGetExperimentSampleCallsKey = (
+	datasourceId: string,
+	experimentId: string,
+) =>
+	[
+		`/v1/m/integrations/datasources/${datasourceId}/experiments/${experimentId}/sample-calls`,
+	] as const;
+
+export type GetExperimentSampleCallsQueryResult = NonNullable<
+	Awaited<ReturnType<typeof getExperimentSampleCalls>>
+>;
+export type GetExperimentSampleCallsQueryError = ErrorType<
+	HTTPExceptionError | HTTPValidationError
+>;
+
+export const useGetExperimentSampleCalls = <
+	TError = ErrorType<HTTPExceptionError | HTTPValidationError>,
+>(
+	datasourceId: string,
+	experimentId: string,
+	options?: {
+		swr?: SWRConfiguration<
+			Awaited<ReturnType<typeof getExperimentSampleCalls>>,
+			TError
+		> & { swrKey?: Key; enabled?: boolean };
+		request?: SecondParameter<typeof orvalFetch>;
+	},
+) => {
+	const { swr: swrOptions, request: requestOptions } = options ?? {};
+
+	const isEnabled =
+		swrOptions?.enabled !== false && !!(datasourceId && experimentId);
+	const swrKey =
+		swrOptions?.swrKey ??
+		(() =>
+			isEnabled
+				? getGetExperimentSampleCallsKey(datasourceId, experimentId)
+				: null);
+	const swrFn = () =>
+		getExperimentSampleCalls(datasourceId, experimentId, requestOptions);
+
+	const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(
+		swrKey,
+		swrFn,
+		swrOptions,
+	);
 
 	return {
 		swrKey,

--- a/src/api/methods.schemas.ts
+++ b/src/api/methods.schemas.ts
@@ -1506,6 +1506,33 @@ export interface RevealedStr {
 	value: string;
 }
 
+/**
+ * Request headers; secrets are placeholders, never real values.
+ */
+export type SampleCallHeaders = { [key: string]: string };
+
+export type SampleCallBodyAnyOf = { [key: string]: unknown };
+
+export type SampleCallBody = SampleCallBodyAnyOf | null;
+
+export type SampleCallExampleResponseAnyOf = { [key: string]: unknown };
+
+export type SampleCallExampleResponse = SampleCallExampleResponseAnyOf | null;
+
+export interface SampleCall {
+	label: string;
+	method: string;
+	path: string;
+	/** Request headers; secrets are placeholders, never real values. */
+	headers: SampleCallHeaders;
+	body?: SampleCallBody;
+	example_response?: SampleCallExampleResponse;
+}
+
+export interface SampleCalls {
+	calls: SampleCall[];
+}
+
 export interface SetConnectionToTurnRequest {
 	/** @minLength 335 */
 	turn_api_token: string;
@@ -1880,3 +1907,5 @@ export type RegenerateTurnWebhookTokenParams = {
 export type DeleteTurnArmJourneyMappingParams = {
 	allow_missing?: boolean;
 };
+
+export type GetExperimentSampleCalls200 = SampleCalls | null;

--- a/src/components/features/experiments/integration-guide-dialog.tsx
+++ b/src/components/features/experiments/integration-guide-dialog.tsx
@@ -17,11 +17,13 @@ import { useCreateApiKey } from '@/api/admin';
 import {
   getGetOrganizationTurnJourneysKey,
   getGetTurnArmJourneyMappingKey,
+  useGetExperimentSampleCalls,
   useGetOrganizationTurnConnection,
   useGetOrganizationTurnJourneys,
   useGetTurnArmJourneyMapping,
   useSetTurnArmJourneyMapping,
 } from '@/api/admin-third-party-tools-integrations';
+import { SampleCallsList } from './sample-calls';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ApiError } from '@/services/orval-fetch';
 import Link from 'next/link';
@@ -60,6 +62,11 @@ export function IntegrationGuideDialog({
   const hasTurnConnection = !isLoadingTurnConnection && !turnConnectionError;
 
   const turnSectionEnabled = open && showTurnConfig && hasTurnConnection;
+
+  // Example API calls are integration docs, only needed once the guide is open — so lazy-load them.
+  const { data: sampleCalls } = useGetExperimentSampleCalls(datasourceId, experimentId, {
+    swr: { enabled: open },
+  });
 
   const {
     data: journeysData,
@@ -240,6 +247,15 @@ export function IntegrationGuideDialog({
                     </DataList.Item>
                   ))}
                 </DataList.Root>
+              </Flex>
+            )}
+
+            {sampleCalls && sampleCalls.calls.length > 0 && (
+              <Flex direction="column" gap="3">
+                <Dialog.Description size="3" weight="bold">
+                  Example API Calls
+                </Dialog.Description>
+                <SampleCallsList sampleCalls={sampleCalls} />
               </Flex>
             )}
 

--- a/src/components/features/experiments/integration-guide-dialog.tsx
+++ b/src/components/features/experiments/integration-guide-dialog.tsx
@@ -3,6 +3,7 @@ import { Button, Callout, Card, DataList, Dialog, Flex, Select, Text, Tooltip } 
 import {
   ChevronDownIcon,
   ChevronRightIcon,
+  CodeIcon,
   FileIcon,
   GearIcon,
   PlusIcon,
@@ -45,6 +46,7 @@ export function IntegrationGuideDialog({
 }: IntegrationGuideDialogProps) {
   const [open, setOpen] = useState(false);
   const [showTurnConfig, setShowTurnConfig] = useState(true);
+  const [showSampleCalls, setShowSampleCalls] = useState(false);
   const [armJourneyDraft, setArmJourneyDraft] = useState<Record<string, string>>({});
   const [staleArmIds, setStaleArmIds] = useState<string[]>([]); // List of arm IDs that have stale mappings
 
@@ -255,12 +257,26 @@ export function IntegrationGuideDialog({
             )}
 
             {sampleCalls && sampleCalls.calls.length > 0 && (
-              <Flex direction="column" gap="3">
-                <Dialog.Description size="3" weight="bold">
-                  Example API Calls
-                </Dialog.Description>
-                <SampleCallsList sampleCalls={sampleCalls} />
-              </Flex>
+              <Card>
+                <Collapsible.Root open={showSampleCalls} onOpenChange={setShowSampleCalls}>
+                  <Collapsible.Trigger style={{ all: 'unset', cursor: 'pointer', width: '100%' }}>
+                    <Flex align="center" justify="between">
+                      <Flex align="center" gap="2">
+                        <CodeIcon />
+                        <Text size="2" weight="medium">
+                          Example API Calls
+                        </Text>
+                      </Flex>
+                      {showSampleCalls ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                    </Flex>
+                  </Collapsible.Trigger>
+                  <Collapsible.Content>
+                    <Flex direction="column" gap="3" mt="3">
+                      <SampleCallsList sampleCalls={sampleCalls} />
+                    </Flex>
+                  </Collapsible.Content>
+                </Collapsible.Root>
+              </Card>
             )}
 
             <Card>

--- a/src/components/features/experiments/integration-guide-dialog.tsx
+++ b/src/components/features/experiments/integration-guide-dialog.tsx
@@ -64,7 +64,7 @@ export function IntegrationGuideDialog({
   const turnSectionEnabled = open && showTurnConfig && hasTurnConnection;
 
   // Example API calls are integration docs, only needed once the guide is open — so lazy-load them.
-  const { data: sampleCalls } = useGetExperimentSampleCalls(datasourceId, experimentId, {
+  const { data: sampleCalls, error: sampleCallsError } = useGetExperimentSampleCalls(datasourceId, experimentId, {
     swr: { enabled: open },
   });
 
@@ -248,6 +248,10 @@ export function IntegrationGuideDialog({
                   ))}
                 </DataList.Root>
               </Flex>
+            )}
+
+            {sampleCallsError && (
+              <GenericErrorCallout title="Error loading example API calls" error={sampleCallsError} />
             )}
 
             {sampleCalls && sampleCalls.calls.length > 0 && (

--- a/src/components/features/experiments/sample-calls.tsx
+++ b/src/components/features/experiments/sample-calls.tsx
@@ -1,0 +1,98 @@
+'use client';
+import { Flex, Text } from '@radix-ui/themes';
+import { SampleCall, SampleCalls } from '@/api/methods.schemas';
+import { CopyToClipBoard } from '@/components/ui/buttons/copy-to-clipboard';
+import { API_BASE_URL } from '@/services/constants';
+
+/**
+ * Joins the configured API base URL with a call's path, preserving template placeholders like
+ * `{participant_id}` (which `new URL` would percent-encode). Falls back to the bare path when no
+ * base URL is configured.
+ */
+function fullUrl(path: string): string {
+  if (!API_BASE_URL) return path;
+  return `${API_BASE_URL.replace(/\/+$/, '')}${path}`;
+}
+
+/** Builds a copy-pasteable curl command for a sample call. */
+function buildCurl(call: SampleCall): string {
+  const lines = [`curl -X ${call.method} '${fullUrl(call.path)}'`];
+  for (const [name, value] of Object.entries(call.headers)) {
+    lines.push(`  -H '${name}: ${value}'`);
+  }
+  if (call.body) {
+    lines.push(`  -H 'Content-Type: application/json'`);
+    // Trailing bash comment flagging the example outcome as a placeholder to edit. Safe because the
+    // body is always the final line (no `\` continuation), so `#` comments out only the reminder.
+    const outcome = call.body.outcome;
+    const reminder =
+      outcome !== undefined ? `  # Example value - replace ${JSON.stringify(outcome)} with the actual outcome` : '';
+    lines.push(`  -d '${JSON.stringify(call.body)}'${reminder}`);
+  }
+  return lines.join(' \\\n');
+}
+
+/**
+ * Whether an example response shows an assigned arm. The arm is server-chosen
+ * (we always just pick the control arm as it is first in the list) and varies per
+ * participant, so when one is present we caption the example to make that clear.
+ */
+function responseHasArm(exampleResponse: object): boolean {
+  return JSON.stringify(exampleResponse).includes('"arm_id"');
+}
+
+function CodeBlock({ content }: { content: string }) {
+  return (
+    <pre
+      style={{
+        margin: 0,
+        padding: 'var(--space-2)',
+        background: 'var(--gray-a3)',
+        borderRadius: 'var(--radius-2)',
+        fontSize: 'var(--font-size-1)',
+        overflowX: 'auto',
+      }}
+    >
+      {content}
+    </pre>
+  );
+}
+
+function SampleCallItem({ call }: { call: SampleCall }) {
+  const curl = buildCurl(call);
+  return (
+    <Flex direction="column" gap="2">
+      <Flex align="center" justify="between">
+        <Text size="2" weight="medium">
+          {call.label}
+        </Text>
+        <CopyToClipBoard content={curl} tooltipContent="Copy as curl" />
+      </Flex>
+      <CodeBlock content={curl} />
+      {call.example_response ? (
+        <Flex direction="column" gap="1">
+          <Text size="1" color="gray">
+            Expected response
+          </Text>
+          <CodeBlock content={JSON.stringify(call.example_response, null, 2)} />
+          {responseHasArm(call.example_response) ? (
+            <Text size="1" color="gray">
+              Example shows your control arm; the actual assigned arm varies per participant.
+            </Text>
+          ) : null}
+        </Flex>
+      ) : null}
+    </Flex>
+  );
+}
+
+/** Renders the backend-provided example API calls for an experiment as curl commands + responses. */
+export function SampleCallsList({ sampleCalls }: { sampleCalls: SampleCalls }) {
+  return (
+    <Flex direction="column" gap="4">
+      {sampleCalls.calls.map((call) => (
+        <SampleCallItem key={call.label} call={call} />
+      ))}
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Ticket

Fixes: General CMAB tix

## Related PRs

Backend: Should only be merged once [this](https://github.com/agency-fund/evidential-be/pull/296) is finalized 

## Description

### Goal

Updates the frontend logic for backend cluster work done in [295](https://github.com/agency-fund/evidential-be/pull/295)

Add in frontend modal that populates with clean sample CURLS + example responses from BE

## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)

- [ ] I have updated the automated tests
- [ ] I have updated dependencies
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
