### PR TITLE
Power-check: dedupe available/non-null counts, warn on missing values, and rework filter null handling

### DIFF
--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -201,7 +201,7 @@ export const ExperimentFreqStackScreen = ({
             </Card>
           </>
         )}
-        
+
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>
             <Heading as="h3" size="3">

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -5,6 +5,7 @@ import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create
 import { ErrorType } from '@/services/orval-fetch';
 import { ExperimentConfirmationDisplayProps } from '@/components/features/experiments/experiment-confirmation-display';
 import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';
+import { metricHasMissingValues } from '@/services/experiment-utils';
 
 type ExperimentsSummarizeFreqScreenMessage = { type: 'set-commit-error'; response: ErrorType<unknown> };
 
@@ -24,6 +25,11 @@ export const ExperimentsSummarizeFreqScreen = ({
     return raw != null ? (raw * 100).toFixed(1) : null;
   };
 
+  const missingValuesByField = new Map(
+    (data.powerCheckResponse?.analyses ?? []).map((a) => [a.metric_spec.field_name, metricHasMissingValues(a)]),
+  );
+  const hasMissingValuesFor = (fieldName: string): boolean => missingValuesByField.get(fieldName) ?? false;
+
   // Specifically, data_type is not available in the createExperimentResponse, so we provide it here
   // along with other related info for convenience.
   const metrics: ExperimentConfirmationDisplayProps['metrics'] = {
@@ -33,6 +39,7 @@ export const ExperimentsSummarizeFreqScreen = ({
           data_type: data.primaryMetric.metric.data_type,
           mde: data.primaryMetric.mde,
           estimatedMde: estimatedMdeFor(data.primaryMetric.metric.field_name),
+          hasMissingValues: hasMissingValuesFor(data.primaryMetric.metric.field_name),
         }
       : undefined,
     secondary: (data.secondaryMetrics ?? []).map((m) => ({
@@ -40,6 +47,7 @@ export const ExperimentsSummarizeFreqScreen = ({
       data_type: m.metric.data_type,
       mde: m.mde,
       estimatedMde: estimatedMdeFor(m.metric.field_name),
+      hasMissingValues: hasMissingValuesFor(m.metric.field_name),
     })),
   };
 

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -77,12 +77,12 @@ function EstimatedMdeBadge({ isSelectedOption, isEstimatingMde, estimatedMdePct,
     <Flex align="center" style={{ minHeight: '24px' }}>
       {isSelectedOption &&
         (isEstimatingMde ? (
-          <Badge color="purple" variant="soft" size="2">
+          <Badge variant="soft" size="2">
             Estimated MDE: …
             <Spinner size="1" />
           </Badge>
         ) : estimatedMdePct !== undefined ? (
-          <Badge color="purple" variant="soft" size="2">
+          <Badge variant="soft" size="2">
             Estimated MDE: {estimatedMdePct}%
           </Badge>
         ) : error ? (
@@ -284,7 +284,7 @@ export function PowerCheckSampleSizeSelector({
               </Flex>
               <Flex align="center" style={{ minHeight: '24px' }}>
                 {targetMde !== undefined ? (
-                  <Badge color="purple" variant="soft" size="2">
+                  <Badge variant="soft" size="2">
                     Target MDE: {targetMde}%
                   </Badge>
                 ) : null}

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -274,7 +274,7 @@ export function PowerCheckSampleSizeSelector({
           >
             <Flex align="center" direction="column" gap="2">
               <Text size="2">Use the minimum required sample size:</Text>
-              <Flex height="32px" align="center">
+              <Flex minHeight="32px" align="center">
                 <MetricSampleSizeDisplay
                   analysis={primaryAnalysis}
                   isClustered={isClustered}
@@ -297,7 +297,7 @@ export function PowerCheckSampleSizeSelector({
           >
             <Flex align="center" direction="column" gap="2">
               <Text size="2">Use the maximum available sample size:</Text>
-              <Flex height="32px" align="center">
+              <Flex minHeight="32px" align="center">
                 <MetricSampleSizeDisplay
                   analysis={primaryAnalysis}
                   isClustered={isClustered}

--- a/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-sample-size-selector.tsx
@@ -7,7 +7,6 @@ import { PowerCheckDesiredNInput } from './power-check-desired-n-input';
 import { PowerCheckOption } from './experiment-form-types';
 import {
   MetricSampleSizeDisplay,
-  estimateClusterN,
   estimateParticipantNFromClusters,
 } from '@/components/features/experiments/metric-sample-size-display';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
@@ -125,10 +124,8 @@ export function PowerCheckSampleSizeSelector({
   const primaryAnalysis = getPowerAnalysis(powerCheckResponse, primaryMetricFieldName);
   const targetN = primaryAnalysis?.target_n ?? undefined;
   const targetNClusters = primaryAnalysis?.num_clusters_total ?? undefined;
-  const nonNullSamples = primaryAnalysis?.metric_spec.available_nonnull_n ?? 0;
   const allSamples = primaryAnalysis?.metric_spec.available_n ?? 0;
   const avgClusterSize = primaryAnalysis?.metric_spec.avg_cluster_size ?? undefined;
-  const nonNullClusters = estimateClusterN(nonNullSamples, avgClusterSize);
   const maxClusters =
     avgClusterSize !== undefined && avgClusterSize > 0 ? Math.floor(allSamples / avgClusterSize) : undefined;
   const clusterInputValue = desiredNClusters !== undefined ? String(desiredNClusters) : '';
@@ -190,26 +187,26 @@ export function PowerCheckSampleSizeSelector({
       case PowerCheckOption.USE_ALL_NON_NULL_SAMPLES:
         useCachedResponse =
           mdePowerCheckResponse !== undefined &&
-          desiredN === nonNullSamples &&
-          (!isClustered || desiredNClusters === nonNullClusters);
+          desiredN === allSamples &&
+          (!isClustered || desiredNClusters === maxClusters);
         onOptionChange({
           sampleSizeOption: option,
-          desiredN: nonNullSamples,
-          desiredNClusters: isClustered ? nonNullClusters : undefined,
+          desiredN: allSamples,
+          desiredNClusters: isClustered ? maxClusters : undefined,
           response: useCachedResponse ? mdePowerCheckResponse : undefined,
         });
         if (!useCachedResponse) {
-          estimateMde(option, nonNullSamples, isClustered ? nonNullClusters : undefined);
+          estimateMde(option, allSamples, isClustered ? maxClusters : undefined);
         }
         break;
       case PowerCheckOption.ENTER_OWN:
-        // Switching away from ENTER_OWN will either keep desiredN set to nonNullSamples or change
+        // Switching away from ENTER_OWN will either keep desiredN set to allSamples or change
         // it away, so switching back to ENTER_OWN will not reuse a stale custom response with the
         // following restricted reuse check.
         useCachedResponse =
           mdePowerCheckResponse !== undefined &&
-          desiredN === nonNullSamples &&
-          (!isClustered || desiredNClusters === nonNullClusters);
+          desiredN === allSamples &&
+          (!isClustered || desiredNClusters === maxClusters);
         onOptionChange({
           sampleSizeOption: option,
           desiredN: desiredN,
@@ -276,7 +273,7 @@ export function PowerCheckSampleSizeSelector({
             disabled={targetN === undefined || targetN === 0 || targetN > allSamples}
           >
             <Flex align="center" direction="column" gap="2">
-              <Text size="2">Use the minimum required sample:</Text>
+              <Text size="2">Use the minimum required sample size:</Text>
               <Flex height="32px" align="center">
                 <MetricSampleSizeDisplay
                   analysis={primaryAnalysis}
@@ -296,15 +293,15 @@ export function PowerCheckSampleSizeSelector({
           </RadioCards.Item>
           <RadioCards.Item
             value={PowerCheckOption.USE_ALL_NON_NULL_SAMPLES}
-            disabled={nonNullSamples === undefined || nonNullSamples === 0}
+            disabled={allSamples === undefined || allSamples === 0}
           >
             <Flex align="center" direction="column" gap="2">
-              <Text size="2">Use all non-null samples:</Text>
+              <Text size="2">Use the maximum available sample size:</Text>
               <Flex height="32px" align="center">
                 <MetricSampleSizeDisplay
                   analysis={primaryAnalysis}
                   isClustered={isClustered}
-                  variant="available-nonnull"
+                  variant="available"
                   align="center"
                 />
               </Flex>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -2,7 +2,6 @@
 
 import {
   Badge,
-  Box,
   Button,
   Callout,
   Card,
@@ -25,7 +24,7 @@ import { CheckCircledIcon, CrossCircledIcon, ExclamationTriangleIcon, LightningB
 import { ExperimentFormData, isClusteredExperimentFormData, PowerCheckOption } from './experiment-form-types';
 import { usePowerCheck } from '@/api/admin';
 import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
-import { getPowerAnalysis } from '@/services/experiment-utils';
+import { getPowerAnalysis, metricHasMissingValues } from '@/services/experiment-utils';
 import { MetricSampleSizeDisplay } from '@/components/features/experiments/metric-sample-size-display';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { ZodError } from 'zod';
@@ -157,6 +156,11 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
       ? data.powerCheckResponse.analyses.filter((a) => a.metric_spec.field_name !== primaryMetricFieldName)
       : undefined;
   const primaryPowerClusterSizeCv = primaryPower?.msg?.values?.cluster_size_cv ?? primaryPower?.metric_spec.cv;
+  const primaryHasMissingValues = primaryPower != null && metricHasMissingValues(primaryPower);
+  const metricsWithMissingValues = [
+    ...(primaryPower != null && primaryHasMissingValues ? [`${primaryPower.metric_spec.field_name} (primary)`] : []),
+    ...(restPower ?? []).filter(metricHasMissingValues).map((analysis) => analysis.metric_spec.field_name),
+  ];
 
   return (
     <Flex direction="column" gap={'3'}>
@@ -230,26 +234,28 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                       : 'The experiment does not have sufficient power.')}
                 </Callout.Text>
                 {primaryPower.msg?.high_cluster_variation && primaryPowerClusterSizeCv != null && (
-                  <Box
-                    p="2"
-                    style={{
-                      backgroundColor: 'var(--amber-a3)',
-                      border: '1px solid var(--amber-a5)',
-                      borderRadius: 'var(--radius-3)',
-                    }}
-                  >
-                    <Flex gap="2" align="start">
-                      <Flex flexShrink="0">
-                        <ExclamationTriangleIcon color="var(--amber-11)" />
-                      </Flex>
-                      <Text size="2" color="amber">
-                        Because your cluster sizes vary so widely, your experiment is sensitive to enrolling fewer
-                        participants or clusters. Consider adding filters to exclude extreme cluster sizes or adding
-                        more clusters to be safer.
-                      </Text>
-                    </Flex>
-                  </Box>
+                  <Callout.Root color="amber" variant="surface" size="1">
+                    <Callout.Icon>
+                      <ExclamationTriangleIcon />
+                    </Callout.Icon>
+                    <Callout.Text>
+                      Because your cluster sizes vary so widely, your experiment is sensitive to enrolling fewer
+                      participants or clusters. Consider adding filters to exclude extreme cluster sizes or adding more
+                      clusters to be safer.
+                    </Callout.Text>
+                  </Callout.Root>
                 )}
+                {metricsWithMissingValues.length > 0 ? (
+                  <Callout.Root color="amber" variant="surface" size="1">
+                    <Callout.Icon>
+                      <ExclamationTriangleIcon />
+                    </Callout.Icon>
+                    <Callout.Text>
+                      Some participants are missing a value for: {metricsWithMissingValues.join(', ')}. Estimates assume
+                      the values will be filled in — if not, add a filter to exclude these participants.
+                    </Callout.Text>
+                  </Callout.Root>
+                ) : null}
               </Flex>
             </Callout.Root>
           )}
@@ -282,7 +288,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         </DataList.Value>
                       </DataList.Item>
                       <DataList.Item>
-                        <DataList.Label>Available</DataList.Label>
+                        <DataList.Label>{primaryHasMissingValues ? 'All available' : 'Available'}</DataList.Label>
                         <DataList.Value>
                           <MetricSampleSizeDisplay
                             analysis={primaryPower}
@@ -291,16 +297,18 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                           />
                         </DataList.Value>
                       </DataList.Item>
-                      <DataList.Item>
-                        <DataList.Label>Available (non-null)</DataList.Label>
-                        <DataList.Value>
-                          <MetricSampleSizeDisplay
-                            analysis={primaryPower}
-                            isClustered={isClustered}
-                            variant="available-nonnull"
-                          />
-                        </DataList.Value>
-                      </DataList.Item>
+                      {primaryHasMissingValues ? (
+                        <DataList.Item>
+                          <DataList.Label>Available with values</DataList.Label>
+                          <DataList.Value>
+                            <MetricSampleSizeDisplay
+                              analysis={primaryPower}
+                              isClustered={isClustered}
+                              variant="available-nonnull"
+                            />
+                          </DataList.Value>
+                        </DataList.Item>
+                      ) : null}
                       {primaryPower.pct_change_possible !== null && primaryPower.pct_change_possible !== undefined && (
                         <DataList.Item>
                           <DataList.Label>MDE</DataList.Label>
@@ -322,8 +330,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         <Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell>Required</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Available</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Available (non-null)</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Available with values</Table.ColumnHeaderCell>
                       </Table.Row>
                     </Table.Header>
                     <Table.Body>
@@ -345,18 +352,20 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             />
                           </Table.Cell>
                           <Table.Cell align={'right'}>
-                            <MetricSampleSizeDisplay
-                              analysis={metricAnalysis}
-                              isClustered={isClustered}
-                              variant="available"
-                            />
-                          </Table.Cell>
-                          <Table.Cell align={'right'}>
-                            <MetricSampleSizeDisplay
-                              analysis={metricAnalysis}
-                              isClustered={isClustered}
-                              variant="available-nonnull"
-                            />
+                            {metricHasMissingValues(metricAnalysis) ? (
+                              <Flex direction="column" align="end" gap="0">
+                                <Text>{metricAnalysis.metric_spec.available_nonnull_n?.toLocaleString()}</Text>
+                                <Text size="1" color="gray">
+                                  of {metricAnalysis.metric_spec.available_n?.toLocaleString()}
+                                </Text>
+                              </Flex>
+                            ) : (
+                              <MetricSampleSizeDisplay
+                                analysis={metricAnalysis}
+                                isClustered={isClustered}
+                                variant="available-nonnull"
+                              />
+                            )}
                           </Table.Cell>
                         </Table.Row>
                       ))}

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -151,12 +151,14 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
     data.powerCheckResponse !== undefined && !validationError
       ? getPowerAnalysis(data.powerCheckResponse, primaryMetricFieldName)
       : undefined;
-  const restPower =
+  const restPowerAnalyses =
     data.powerCheckResponse !== undefined && !validationError
       ? data.powerCheckResponse.analyses.filter((a) => a.metric_spec.field_name !== primaryMetricFieldName)
       : undefined;
+  const restPower = restPowerAnalyses !== undefined && restPowerAnalyses.length > 0 ? restPowerAnalyses : undefined;
   const primaryPowerClusterSizeCv = primaryPower?.msg?.values?.cluster_size_cv ?? primaryPower?.metric_spec.cv;
   const primaryHasMissingValues = primaryPower != null && metricHasMissingValues(primaryPower);
+  const secondaryHasMissingValues = (restPower ?? []).some(metricHasMissingValues);
   const metricsWithMissingValues = [
     ...(primaryPower != null && primaryHasMissingValues ? [`${primaryPower.metric_spec.field_name} (primary)`] : []),
     ...(restPower ?? []).filter(metricHasMissingValues).map((analysis) => analysis.metric_spec.field_name),
@@ -331,8 +333,12 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         <Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell>Required</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Available</Table.ColumnHeaderCell>
-                        <Table.ColumnHeaderCell>Available with values</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>
+                          {secondaryHasMissingValues ? 'All available' : 'Available'}
+                        </Table.ColumnHeaderCell>
+                        {secondaryHasMissingValues ? (
+                          <Table.ColumnHeaderCell>Available with values</Table.ColumnHeaderCell>
+                        ) : null}
                       </Table.Row>
                     </Table.Header>
                     <Table.Body>
@@ -360,13 +366,15 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                               variant="available"
                             />
                           </Table.Cell>
-                          <Table.Cell align={'right'}>
-                            <MetricSampleSizeDisplay
-                              analysis={metricAnalysis}
-                              isClustered={isClustered}
-                              variant="available-nonnull"
-                            />
-                          </Table.Cell>
+                          {secondaryHasMissingValues ? (
+                            <Table.Cell align={'right'}>
+                              <MetricSampleSizeDisplay
+                                analysis={metricAnalysis}
+                                isClustered={isClustered}
+                                variant="available-nonnull"
+                              />
+                            </Table.Cell>
+                          ) : null}
                         </Table.Row>
                       ))}
                     </Table.Body>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -252,7 +252,8 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                     </Callout.Icon>
                     <Callout.Text>
                       Some participants are missing a value for: {metricsWithMissingValues.join(', ')}. Estimates assume
-                      the values will be filled in — if not, add a filter to exclude these participants.
+                      that these participants will receive a value during the experiment. If you&apos;re unsure, add a
+                      filter to exclude these participants.
                     </Callout.Text>
                   </Callout.Root>
                 ) : null}
@@ -330,6 +331,7 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         <Table.ColumnHeaderCell>Metric</Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell>Required</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Available</Table.ColumnHeaderCell>
                         <Table.ColumnHeaderCell>Available with values</Table.ColumnHeaderCell>
                       </Table.Row>
                     </Table.Header>
@@ -352,20 +354,18 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                             />
                           </Table.Cell>
                           <Table.Cell align={'right'}>
-                            {metricHasMissingValues(metricAnalysis) ? (
-                              <Flex direction="column" align="end" gap="0">
-                                <Text>{metricAnalysis.metric_spec.available_nonnull_n?.toLocaleString()}</Text>
-                                <Text size="1" color="gray">
-                                  of {metricAnalysis.metric_spec.available_n?.toLocaleString()}
-                                </Text>
-                              </Flex>
-                            ) : (
-                              <MetricSampleSizeDisplay
-                                analysis={metricAnalysis}
-                                isClustered={isClustered}
-                                variant="available-nonnull"
-                              />
-                            )}
+                            <MetricSampleSizeDisplay
+                              analysis={metricAnalysis}
+                              isClustered={isClustered}
+                              variant="available"
+                            />
+                          </Table.Cell>
+                          <Table.Cell align={'right'}>
+                            <MetricSampleSizeDisplay
+                              analysis={metricAnalysis}
+                              isClustered={isClustered}
+                              variant="available-nonnull"
+                            />
                           </Table.Cell>
                         </Table.Row>
                       ))}

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/api/methods.schemas';
 import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
 import { PowerBalanceSection } from '@/components/features/experiments/sections/power-balance-section';
-import { isClusteredPreassignedSpec } from '@/services/experiment-utils';
+import { isClusteredPreassignedSpec, metricHasMissingValues } from '@/services/experiment-utils';
 
 interface DesignDetailsDialogProps {
   designSpec: AnyFrequentistDesignSpec;
@@ -36,6 +36,9 @@ export function FreqDesignDetailsDialog({
   const estimatedMdeByField = new Map(
     (powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis.pct_change_with_desired_n]),
   );
+  const missingValuesByField = new Map(
+    (powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, metricHasMissingValues(analysis)]),
+  );
   const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
     const estimatedRaw = estimatedMdeByField.get(fieldName);
     return {
@@ -43,6 +46,7 @@ export function FreqDesignDetailsDialog({
       data_type: fieldTypeByName.get(fieldName) ?? DataType.unknown,
       mde: toMdePercent(mdePct),
       estimatedMde: estimatedRaw != null ? (estimatedRaw * 100).toFixed(1) : null,
+      hasMissingValues: missingValuesByField.get(fieldName) ?? false,
     };
   };
 

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -26,7 +26,7 @@ const MDE_COPY: Record<MdeKind, { label: string; tooltip: string }> = {
 };
 
 const MISSING_VALUES_NOTE =
-  'Some participants are missing values for this metric. This MDE assumes they will be filled in during the experiment; otherwise the experiment can only detect a larger effect.';
+  "Some participants are missing values for this metric. This MDE assumes they will be filled in during the experiment; otherwise the experiment can only reliably detect effects larger than what's shown.";
 
 export function MdeBadge({ value, size = '2', kind = 'target', hasMissingValues = false }: MdeBadgeProps) {
   const displayValue = value === null || value === undefined ? 'unknown' : String(value);

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -26,7 +26,7 @@ const MDE_COPY: Record<MdeKind, { label: string; tooltip: string }> = {
 };
 
 const MISSING_VALUES_NOTE =
-  "Some participants are missing values for this metric. This MDE assumes they will be filled in during the experiment; otherwise the experiment can only reliably detect effects larger than what's shown.";
+  "Some eligible participants were missing values for this metric. This MDE assumes they will be filled in during the experiment; otherwise the experiment can only reliably detect effects larger than what's shown.";
 
 export function MdeBadge({ value, size = '2', kind = 'target', hasMissingValues = false }: MdeBadgeProps) {
   const displayValue = value === null || value === undefined ? 'unknown' : String(value);

--- a/src/components/features/experiments/mde-badge.tsx
+++ b/src/components/features/experiments/mde-badge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { ExclamationTriangleIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import { Badge, Flex, Heading, Text, Tooltip as RadixTooltip } from '@radix-ui/themes';
 
 type MdeKind = 'target' | 'estimated';
@@ -9,6 +9,7 @@ type MdeBadgeProps = {
   value?: string | number | null;
   size?: '1' | '2' | '3';
   kind?: MdeKind;
+  hasMissingValues?: boolean;
 };
 
 const MDE_COPY: Record<MdeKind, { label: string; tooltip: string }> = {
@@ -24,7 +25,10 @@ const MDE_COPY: Record<MdeKind, { label: string; tooltip: string }> = {
   },
 };
 
-export function MdeBadge({ value, size = '2', kind = 'target' }: MdeBadgeProps) {
+const MISSING_VALUES_NOTE =
+  'Some participants are missing values for this metric. This MDE assumes they will be filled in during the experiment; otherwise the experiment can only detect a larger effect.';
+
+export function MdeBadge({ value, size = '2', kind = 'target', hasMissingValues = false }: MdeBadgeProps) {
   const displayValue = value === null || value === undefined ? 'unknown' : String(value);
   const { label, tooltip } = MDE_COPY[kind];
   return (
@@ -36,6 +40,11 @@ export function MdeBadge({ value, size = '2', kind = 'target' }: MdeBadgeProps) 
           <RadixTooltip content={tooltip}>
             <InfoCircledIcon />
           </RadixTooltip>
+          {hasMissingValues ? (
+            <RadixTooltip content={MISSING_VALUES_NOTE}>
+              <ExclamationTriangleIcon color="var(--amber-11)" />
+            </RadixTooltip>
+          ) : null}
         </Flex>
       </Flex>
     </Badge>

--- a/src/components/features/experiments/metric-sample-size-display.tsx
+++ b/src/components/features/experiments/metric-sample-size-display.tsx
@@ -105,15 +105,12 @@ const getDisplayModel = (
     }
     case 'available-nonnull': {
       const participantN = analysis.metric_spec.available_nonnull_n ?? undefined;
-      const availableN = analysis.metric_spec.available_n;
       return {
         participantN,
         clusterN: isClustered ? estimateClusterN(participantN, avgClusterSize) : undefined,
+        // Crimson only when the non-null count is insufficient for the required n.
         color:
-          participantN === undefined ||
-          participantN === 0 ||
-          (targetN != null && participantN < targetN) ||
-          (availableN != null && participantN < availableN)
+          participantN === undefined || participantN === 0 || (targetN != null && participantN < targetN)
             ? 'crimson'
             : undefined,
       };

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -12,6 +12,7 @@ export interface MetricDisplay {
   data_type: DataType;
   mde: string | number;
   estimatedMde?: string | number | null;
+  hasMissingValues?: boolean;
 }
 
 export interface MetricsSectionProps {
@@ -47,7 +48,12 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                   <DataTypeBadge type={metrics.primary.data_type} />
                 </Flex>
                 <Flex direction="row" gap="2" align="start">
-                  <MdeBadge value={metrics.primary.mde} kind="target" size="1" />
+                  <MdeBadge
+                    value={metrics.primary.mde}
+                    kind="target"
+                    size="1"
+                    hasMissingValues={metrics.primary.hasMissingValues}
+                  />
                   {metrics.primary.estimatedMde != null && (
                     <MdeBadge value={metrics.primary.estimatedMde} kind="estimated" size="1" />
                   )}
@@ -70,7 +76,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                       <DataTypeBadge type={metric.data_type} />
                     </Flex>
                     <Flex direction="row" gap="2" align="start">
-                      <MdeBadge value={metric.mde} kind="target" size="1" />
+                      <MdeBadge value={metric.mde} kind="target" size="1" hasMissingValues={metric.hasMissingValues} />
                       {metric.estimatedMde != null && (
                         <MdeBadge value={metric.estimatedMde} kind="estimated" size="1" />
                       )}

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -55,7 +55,12 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                     hasMissingValues={metrics.primary.hasMissingValues}
                   />
                   {metrics.primary.estimatedMde != null && (
-                    <MdeBadge value={metrics.primary.estimatedMde} kind="estimated" size="1" />
+                    <MdeBadge
+                      value={metrics.primary.estimatedMde}
+                      kind="estimated"
+                      size="1"
+                      hasMissingValues={metrics.primary.hasMissingValues}
+                    />
                   )}
                 </Flex>
               </Flex>
@@ -78,7 +83,12 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                     <Flex direction="row" gap="2" align="start">
                       <MdeBadge value={metric.mde} kind="target" size="1" hasMissingValues={metric.hasMissingValues} />
                       {metric.estimatedMde != null && (
-                        <MdeBadge value={metric.estimatedMde} kind="estimated" size="1" />
+                        <MdeBadge
+                          value={metric.estimatedMde}
+                          kind="estimated"
+                          size="1"
+                          hasMissingValues={metric.hasMissingValues}
+                        />
                       )}
                     </Flex>
                   </Flex>

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, DataList, Flex, Text } from '@radix-ui/themes';
+import { Button, DataList, Flex, Separator, Text } from '@radix-ui/themes';
 import { Pencil2Icon } from '@radix-ui/react-icons';
 import { DataType } from '@/api/methods.schemas';
 import { SectionCard } from '@/components/ui/cards/section-card';
@@ -47,7 +47,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                   <Text>{metrics.primary.field_name}</Text>
                   <DataTypeBadge type={metrics.primary.data_type} />
                 </Flex>
-                <Flex direction="row" gap="2" align="start">
+                <Flex direction="row" gap="2" align="start" wrap="wrap">
                   <MdeBadge
                     value={metrics.primary.mde}
                     kind="target"
@@ -63,6 +63,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                     />
                   )}
                 </Flex>
+                {metrics?.secondary && metrics.secondary.length >= 1 && <Separator orientation="horizontal" size="4" />}
               </Flex>
             ) : (
               <Text>-</Text>
@@ -80,7 +81,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                       <Text>{metric.field_name}</Text>
                       <DataTypeBadge type={metric.data_type} />
                     </Flex>
-                    <Flex direction="row" gap="2" align="start">
+                    <Flex direction="row" gap="2" align="start" wrap="wrap">
                       <MdeBadge value={metric.mde} kind="target" size="1" hasMissingValues={metric.hasMissingValues} />
                       {metric.estimatedMde != null && (
                         <MdeBadge
@@ -91,6 +92,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                         />
                       )}
                     </Flex>
+                    <Separator orientation="horizontal" size="4" />
                   </Flex>
                 ))}
               </Flex>

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -12,7 +12,7 @@ export interface MetricDisplay {
   data_type: DataType;
   mde: string | number;
   estimatedMde?: string | number | null;
-  hasMissingValues?: boolean;
+  hasMissingValues: boolean;
 }
 
 export interface MetricsSectionProps {

--- a/src/services/experiment-utils.ts
+++ b/src/services/experiment-utils.ts
@@ -48,7 +48,7 @@ export const getPowerAnalysis = (
  */
 export const metricHasMissingValues = (analysis: MetricPowerAnalysis): boolean => {
   const { available_n, available_nonnull_n } = analysis.metric_spec;
-  return available_n != null && available_nonnull_n != null && available_n !== available_nonnull_n;
+  return available_n != null && available_nonnull_n != null && available_n > available_nonnull_n;
 };
 
 export const isFreqExperimentType = (

--- a/src/services/experiment-utils.ts
+++ b/src/services/experiment-utils.ts
@@ -42,6 +42,15 @@ export const getPowerAnalysis = (
   return analyses.find((analysis) => analysis.metric_spec.field_name === metricName);
 };
 
+/**
+ * True when a metric has participants that meet the filters but are missing a value for it, i.e. the
+ * targeted population (available_n) is larger than those with a value (available_nonnull_n).
+ */
+export const metricHasMissingValues = (analysis: MetricPowerAnalysis): boolean => {
+  const { available_n, available_nonnull_n } = analysis.metric_spec;
+  return available_n != null && available_nonnull_n != null && available_n !== available_nonnull_n;
+};
+
 export const isFreqExperimentType = (
   experimentType?: ExperimentType,
 ): experimentType is AnyFrequentistDesignSpecExperimentType =>


### PR DESCRIPTION
Fixes agency-fund/evidential-be#229.

## What changed

- **Primary metric card**: 
  +  one `Available` row when all participants have data; 
  + `All available` and `Available with values` when they differ.
- **Secondary metrics table**: 
  + single `Available with values` column; 
  + shows `500,000` over `of 1,000,000` when values are missing.
- **New warning callout** listing every metric with missing values (previously nothing fired when only a secondary metric had them):
  > Some participants are missing a value for: is_onboarded_onetime, is_retained. Estimates
  > assume the values will be filled in — if not, add a filter to exclude these participants.
- **Behavior change** — "Use all non-null samples" is now **"Use the maximum available sample size"** (the three cards read "minimum required sample size" / "maximum available sample size" / "custom sample size"): it sets `desired_n = available_n` (was `available_nonnull_n`) and estimates the MDE for that same number. Rationale: assignment draws from everyone anyway, so enrolling only the with-data count randomly drops ~half of the participants. Trade-off: if values stay missing, the MDE is optimistic — covered by the warning. 
- **Summary screen**: a ⚠️ tooltip on the Target MDE badge for metrics with missing values.

~## Filter null handling (replaces "+ OR NULL")~

~- Removed the `+ OR NULL` toggle. Each filter row now has a **missing-values dropdown**: **With or without a value** (default) · **Has a value** · **Is missing**, mapped to the right `{relation, value}` by a relation-aware helper (`Has a value` → `IS NOT NULL`, `Is missing` → `IS NULL`; a NULL in the value array means opposite things for `includes` vs `excludes`, handled in one place). `IncludeNullButton` was deleted and the five type-specific inputs shed around 200 lines of null bookkeeping.~
~- The **value condition is now optional**: the operator dropdown defaults to an **"Add a condition…"** placeholder with a **"No condition"** revert item, so you can express e.g. `ethnicity IS NOT NULL` (Has a value + no condition). A row that constrains nothing isn't sent.~

## Screenshots

[
<img width="1315" height="877" alt="Screenshot 2026-07-06 at 9 59 06 PM" src="https://github.com/user-attachments/assets/bf05ef95-d3bf-4596-b82a-35b0af6662e1" />
](url)

<img width="1149" height="766" alt="Screenshot 2026-07-06 at 9 59 59 PM" src="https://github.com/user-attachments/assets/b4b8d82d-e70a-4e42-b2d6-a5bd9ac4c14f" />

<img width="1138" height="720" alt="Screenshot 2026-07-06 at 10 00 28 PM" src="https://github.com/user-attachments/assets/884a2094-7438-4245-888b-8f8d33ecd7f9" />

## Follow-ups (for discussion, out of scope)

1. **When `available_n` and `available_nonnull_n` differ, the estimated MDE may not be achieved.**
   Estimates assume every enrolled participant has data, but assignment enrolls from everyone — so if values stay missing, only part of the sample contributes data and the real detectable effect is larger than shown. ~Users can now exclude missing values with the new "Has a value" filter to make the two counts match;~ the remaining gap is doing it automatically — e.g. let the user state whether missing values will be filled in during the experiment, and compute enrollment/MDE accordingly if they won't be (e.g. "enroll 15,056 so ~7,528 have data, MDE given for values with data").
2. **The backend message duplicates the new warning.** The green power-check result still contains its own "WARNING: Of the available units…" sentence, now redundant with the callout.

## Testing

tsc, eslint, and pre-commit pass; manual walkthrough with/without missing values across all three sample-size options and every filter combination, including the power check end-to-end.
