### PR TITLE
removed strata from online A/B testing

### DIFF
--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -200,7 +200,7 @@ export const ExperimentFreqStackScreen = ({
               />
             </Card>
           </>
-        )}     
+        )}
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>
             <Heading as="h3" size="3">

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -187,7 +187,7 @@ export const ExperimentFreqStackScreen = ({
           />
         </Card>
 
-        {!data.clusterKey && (
+        {!data.clusterKey && data.experimentType !== 'freq_online' && (
           <>
             <Heading as="h3" size="3">
               Strata
@@ -200,8 +200,9 @@ export const ExperimentFreqStackScreen = ({
               />
             </Card>
           </>
-        )}
-
+        )}     
+          
+        
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>
             <Heading as="h3" size="3">

--- a/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-freq-stack-screen.tsx
@@ -201,8 +201,6 @@ export const ExperimentFreqStackScreen = ({
             </Card>
           </>
         )}     
-          
-        
         {data.experimentType == 'freq_preassigned' && (
           <Flex direction="column" gap={'3'}>
             <Heading as="h3" size="3">


### PR DESCRIPTION
## Ticket
Fixes: [EVE-134](https://idinsight.atlassian.net/browse/EVE-134)

## Description
Remove strata from online A/B testing, as it is not functional.

### Changes
- Added a condition to hide the Strata section when `experimentType` is `freq_online`
- The Strata UI now only renders when there is no cluster key and the experiment type is not `freq_online`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts