### PR TITLE
Declutter experiment summary screen

### DIFF
--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -511,6 +511,48 @@ export default function ExperimentViewPage() {
           headerLeft={
             <Flex gap="3" align="center" wrap="wrap">
               <Heading size="3">Analysis</Heading>
+              <Badge size="2" style={{ height: '26px' }}>
+                <Flex gap="2" align="center">
+                  <Heading size="2">Viewing:</Heading>
+                  {analysisHistory.length == 0 ? (
+                    <Text>{liveAnalysis.label}</Text>
+                  ) : (
+                    <>
+                      <Select.Root size="1" value={activeAnalysisKey} onValueChange={handleSelectAnalysis}>
+                        <Select.Trigger style={{ height: 18 }} />
+                        <Select.Content>
+                          <Select.Group>
+                            <Select.Item key="live" value="live">
+                              <Box minWidth="136px">{liveAnalysis.label}</Box>
+                            </Select.Item>
+                          </Select.Group>
+                          <Select.Separator />
+                          <Select.Group>
+                            {analysisHistory.map((opt) => (
+                              <Select.Item key={opt.key} value={opt.key}>
+                                <Box minWidth="136px">{opt.label}</Box>
+                              </Select.Item>
+                            ))}
+                          </Select.Group>
+                        </Select.Content>
+                      </Select.Root>
+                      {isLastSnapshotErrorRelevant ? (
+                        <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
+                          <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
+                            <ExclamationTriangleIcon color={'red'} />
+                          </Link>
+                        </Tooltip>
+                      ) : (
+                        <Tooltip content={'View snapshot log'}>
+                          <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
+                            <ActivityLogIcon />
+                          </Link>
+                        </Tooltip>
+                      )}
+                    </>
+                  )}
+                </Flex>
+              </Badge>
               {isFrequentistSpec(design_spec) ? (
                 <Flex gap="3" align="center" wrap="wrap">
                   <Badge size="2">
@@ -541,12 +583,6 @@ export default function ExperimentViewPage() {
                     </Flex>
                   </Badge>
                   <MdeBadge value={mdePct} kind={estimatedMdePct != null ? 'estimated' : 'target'} />
-                  <FreqDesignDetailsDialog
-                    designSpec={design_spec}
-                    experimentSchema={experiment.experiment_schema}
-                    assignSummary={assign_summary}
-                    powerAnalyses={experiment.config.power_analyses?.analyses}
-                  />
                 </Flex>
               ) : isBanditAnalysis(selectedAnalysisState.data) &&
                 selectedAnalysisState.banditEffects &&
@@ -577,51 +613,15 @@ export default function ExperimentViewPage() {
             </Flex>
           }
           headerRight={
-            <Flex gap="3" wrap="wrap">
-              <Flex gap="3" wrap="wrap" align="center" justify="between">
-                <Badge size="2" style={{ height: '26px' }}>
-                  <Flex gap="2" align="center">
-                    <Heading size="2">Viewing:</Heading>
-                    {analysisHistory.length == 0 ? (
-                      <Text>{liveAnalysis.label}</Text>
-                    ) : (
-                      <>
-                        <Select.Root size="1" value={activeAnalysisKey} onValueChange={handleSelectAnalysis}>
-                          <Select.Trigger style={{ height: 18 }} />
-                          <Select.Content>
-                            <Select.Group>
-                              <Select.Item key="live" value="live">
-                                <Box minWidth="136px">{liveAnalysis.label}</Box>
-                              </Select.Item>
-                            </Select.Group>
-                            <Select.Separator />
-                            <Select.Group>
-                              {analysisHistory.map((opt) => (
-                                <Select.Item key={opt.key} value={opt.key}>
-                                  <Box minWidth="136px">{opt.label}</Box>
-                                </Select.Item>
-                              ))}
-                            </Select.Group>
-                          </Select.Content>
-                        </Select.Root>
-                        {isLastSnapshotErrorRelevant ? (
-                          <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
-                            <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
-                              <ExclamationTriangleIcon color={'red'} />
-                            </Link>
-                          </Tooltip>
-                        ) : (
-                          <Tooltip content={'View snapshot log'}>
-                            <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
-                              <ActivityLogIcon />
-                            </Link>
-                          </Tooltip>
-                        )}
-                      </>
-                    )}
-                  </Flex>
-                </Badge>
-              </Flex>
+            <Flex gap="3" wrap="wrap" align="center">
+              {isFrequentistSpec(design_spec) ? (
+                <FreqDesignDetailsDialog
+                  designSpec={design_spec}
+                  experimentSchema={experiment.experiment_schema}
+                  assignSummary={assign_summary}
+                  powerAnalyses={experiment.config.power_analyses?.analyses}
+                />
+              ) : null}
               {!isFrequentistExperiment && (
                 <Badge size="2">
                   <Flex gap="4" align="center">

--- a/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
+++ b/src/app/datasources/[datasourceId]/experiments/[experimentId]/page.tsx
@@ -4,16 +4,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { mutate } from 'swr';
 import { Badge, Box, Flex, Heading, Select, Separator, Tabs, Text, Tooltip } from '@radix-ui/themes';
-import {
-  ActivityLogIcon,
-  CalendarIcon,
-  CodeIcon,
-  ExclamationTriangleIcon,
-  FileTextIcon,
-  InfoCircledIcon,
-  LayersIcon,
-  PersonIcon,
-} from '@radix-ui/react-icons';
+import { CalendarIcon, CodeIcon, FileTextIcon, InfoCircledIcon, LayersIcon, PersonIcon } from '@radix-ui/react-icons';
 import {
   getGetExperimentForUiKey,
   useAnalyzeCmabExperiment,
@@ -46,6 +37,7 @@ import ForestTimeseriesPlot from '@/components/features/experiments/plots/forest
 import { ExperimentTypeBadge } from '@/components/features/experiments/experiment-type-badge';
 import { ExperimentStatusBadge } from '@/components/features/experiments/experiment-status-badge';
 import { MdeBadge } from '@/components/features/experiments/mde-badge';
+import { AnalysisSnapshotSelector } from '@/components/features/experiments/analysis-snapshot-selector';
 import { ArmsAndAllocationsTable } from '@/components/features/experiments/arms-and-allocations-table';
 import { IntegrationGuideDialog } from '@/components/features/experiments/integration-guide-dialog';
 import { DownloadAssignmentsCsvButton } from '@/components/features/experiments/download-assignments-csv-button';
@@ -75,8 +67,6 @@ import { ContextConfigBox } from '@/components/features/experiments/context-conf
 import { TableNameBadge } from '@/components/features/participants/table-name-badge';
 import { TargetingDialog } from '@/components/features/experiments/targeting-dialog';
 import { FreqDesignDetailsDialog } from '@/components/features/experiments/freq-design-details-dialog';
-
-const SNAPSHOT_ERROR_ALERT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
 
 /**
  * Returns the metric's analysis corresponding to the selectedMetricName from a list of analyses.
@@ -389,9 +379,6 @@ export default function ExperimentViewPage() {
     activeMetricName,
   );
 
-  const isLastSnapshotErrorRelevant =
-    lastErrorTimestamp !== null && Date.now() - lastErrorTimestamp.getTime() <= SNAPSHOT_ERROR_ALERT_THRESHOLD_MS;
-
   return (
     <Flex direction="column" gap="6">
       <Flex direction="column" gap="3">
@@ -511,48 +498,15 @@ export default function ExperimentViewPage() {
           headerLeft={
             <Flex gap="3" align="center" wrap="wrap">
               <Heading size="3">Analysis</Heading>
-              <Badge size="2" style={{ height: '26px' }}>
-                <Flex gap="2" align="center">
-                  <Heading size="2">Viewing:</Heading>
-                  {analysisHistory.length == 0 ? (
-                    <Text>{liveAnalysis.label}</Text>
-                  ) : (
-                    <>
-                      <Select.Root size="1" value={activeAnalysisKey} onValueChange={handleSelectAnalysis}>
-                        <Select.Trigger style={{ height: 18 }} />
-                        <Select.Content>
-                          <Select.Group>
-                            <Select.Item key="live" value="live">
-                              <Box minWidth="136px">{liveAnalysis.label}</Box>
-                            </Select.Item>
-                          </Select.Group>
-                          <Select.Separator />
-                          <Select.Group>
-                            {analysisHistory.map((opt) => (
-                              <Select.Item key={opt.key} value={opt.key}>
-                                <Box minWidth="136px">{opt.label}</Box>
-                              </Select.Item>
-                            ))}
-                          </Select.Group>
-                        </Select.Content>
-                      </Select.Root>
-                      {isLastSnapshotErrorRelevant ? (
-                        <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
-                          <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
-                            <ExclamationTriangleIcon color={'red'} />
-                          </Link>
-                        </Tooltip>
-                      ) : (
-                        <Tooltip content={'View snapshot log'}>
-                          <Link href={`/datasources/${datasourceId}/experiments/${experimentId}/snapshots`}>
-                            <ActivityLogIcon />
-                          </Link>
-                        </Tooltip>
-                      )}
-                    </>
-                  )}
-                </Flex>
-              </Badge>
+              <AnalysisSnapshotSelector
+                datasourceId={datasourceId}
+                experimentId={experimentId}
+                liveAnalysisLabel={liveAnalysis.label}
+                analysisHistory={analysisHistory}
+                activeAnalysisKey={activeAnalysisKey}
+                onSelectAnalysis={handleSelectAnalysis}
+                lastErrorTimestamp={lastErrorTimestamp}
+              />
               {isFrequentistSpec(design_spec) ? (
                 <Flex gap="3" align="center" wrap="wrap">
                   <Badge size="2">

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -30,6 +30,11 @@ export const ExperimentsSummarizeFreqScreen = ({
   );
   const hasMissingValuesFor = (fieldName: string): boolean => missingValuesByField.get(fieldName) ?? false;
 
+  const sufficientNByField = new Map(
+    (data.powerCheckResponse?.analyses ?? []).map((a) => [a.metric_spec.field_name, a.sufficient_n]),
+  );
+  const sufficientNFor = (fieldName: string): boolean | null | undefined => sufficientNByField.get(fieldName);
+
   // Specifically, data_type is not available in the createExperimentResponse, so we provide it here
   // along with other related info for convenience.
   const metrics: ExperimentConfirmationDisplayProps['metrics'] = {
@@ -40,6 +45,7 @@ export const ExperimentsSummarizeFreqScreen = ({
           mde: data.primaryMetric.mde,
           estimatedMde: estimatedMdeFor(data.primaryMetric.metric.field_name),
           hasMissingValues: hasMissingValuesFor(data.primaryMetric.metric.field_name),
+          sufficientN: sufficientNFor(data.primaryMetric.metric.field_name),
         }
       : undefined,
     secondary: (data.secondaryMetrics ?? []).map((m) => ({
@@ -48,6 +54,7 @@ export const ExperimentsSummarizeFreqScreen = ({
       mde: m.mde,
       estimatedMde: estimatedMdeFor(m.metric.field_name),
       hasMissingValues: hasMissingValuesFor(m.metric.field_name),
+      sufficientN: sufficientNFor(m.metric.field_name),
     })),
   };
 
@@ -68,7 +75,6 @@ export const ExperimentsSummarizeFreqScreen = ({
         datasource: 'freq-select-datasource',
         filters: 'freq-stack',
         metrics: 'freq-stack',
-        powerBalance: 'freq-stack',
       }}
       frequentistInfo={{ metrics }}
     />

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { ScreenProps } from '@/services/wizard/wizard-types';
-import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
+import {
+  ExperimentFormData,
+  ExperimentScreenId,
+  isClusteredExperimentFormData,
+} from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { ErrorType } from '@/services/orval-fetch';
 import { ExperimentConfirmationDisplayProps } from '@/components/features/experiments/experiment-confirmation-display';
 import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';
@@ -30,10 +34,21 @@ export const ExperimentsSummarizeFreqScreen = ({
   );
   const hasMissingValuesFor = (fieldName: string): boolean => missingValuesByField.get(fieldName) ?? false;
 
-  const sufficientNByField = new Map(
-    (data.powerCheckResponse?.analyses ?? []).map((a) => [a.metric_spec.field_name, a.sufficient_n]),
-  );
-  const sufficientNFor = (fieldName: string): boolean | null | undefined => sufficientNByField.get(fieldName);
+  const isClustered = isClusteredExperimentFormData(data);
+  const analysisByField = new Map((data.powerCheckResponse?.analyses ?? []).map((a) => [a.metric_spec.field_name, a]));
+  // Sufficiency compares the chosen sample size against the minimum required for the metric's
+  // target MDE, since assignment enrolls exactly the chosen sample (including participants with
+  // missing values) regardless of how many participants the datasource could supply.
+  const sufficientNFor = (fieldName: string): boolean | undefined => {
+    const analysis = analysisByField.get(fieldName);
+    if (analysis === undefined) return undefined;
+    if (isClustered) {
+      return analysis.num_clusters_total != null && data.desiredNClusters != null
+        ? data.desiredNClusters >= analysis.num_clusters_total
+        : undefined;
+    }
+    return analysis.target_n != null && data.desiredN != null ? data.desiredN >= analysis.target_n : undefined;
+  };
 
   // Specifically, data_type is not available in the createExperimentResponse, so we provide it here
   // along with other related info for convenience.

--- a/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-freq-screen.tsx
@@ -9,7 +9,7 @@ import {
 import { ErrorType } from '@/services/orval-fetch';
 import { ExperimentConfirmationDisplayProps } from '@/components/features/experiments/experiment-confirmation-display';
 import { ExperimentsSummarizeScreenBase } from '@/app/experiments/create/experiment-form/experiment-summarize-screen-base';
-import { metricHasMissingValues } from '@/services/experiment-utils';
+import { isChosenSampleSufficient, metricHasMissingValues } from '@/services/experiment-utils';
 
 type ExperimentsSummarizeFreqScreenMessage = { type: 'set-commit-error'; response: ErrorType<unknown> };
 
@@ -36,19 +36,8 @@ export const ExperimentsSummarizeFreqScreen = ({
 
   const isClustered = isClusteredExperimentFormData(data);
   const analysisByField = new Map((data.powerCheckResponse?.analyses ?? []).map((a) => [a.metric_spec.field_name, a]));
-  // Sufficiency compares the chosen sample size against the minimum required for the metric's
-  // target MDE, since assignment enrolls exactly the chosen sample (including participants with
-  // missing values) regardless of how many participants the datasource could supply.
-  const sufficientNFor = (fieldName: string): boolean | undefined => {
-    const analysis = analysisByField.get(fieldName);
-    if (analysis === undefined) return undefined;
-    if (isClustered) {
-      return analysis.num_clusters_total != null && data.desiredNClusters != null
-        ? data.desiredNClusters >= analysis.num_clusters_total
-        : undefined;
-    }
-    return analysis.target_n != null && data.desiredN != null ? data.desiredN >= analysis.target_n : undefined;
-  };
+  const sufficientNFor = (fieldName: string): boolean | undefined =>
+    isChosenSampleSufficient(analysisByField.get(fieldName), isClustered, data.desiredN, data.desiredNClusters);
 
   // Specifically, data_type is not available in the createExperimentResponse, so we provide it here
   // along with other related info for convenience.

--- a/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-summarize-screen-base.tsx
@@ -24,7 +24,6 @@ type EditTargets = {
   outcomesPrior?: ExperimentScreenId;
   contexts?: ExperimentScreenId;
   metrics?: ExperimentScreenId;
-  powerBalance?: ExperimentScreenId;
 };
 
 interface ExperimentsSummarizeScreenBaseProps {
@@ -101,7 +100,6 @@ export function ExperimentsSummarizeScreenBase({
               onEditOutcomesPrior={toEditHandler(editTargets.outcomesPrior)}
               onEditContexts={toEditHandler(editTargets.contexts)}
               onEditMetrics={toEditHandler(editTargets.metrics)}
-              onEditPowerBalance={toEditHandler(editTargets.powerBalance)}
             />
             <Callout.Root>
               <Callout.Icon>

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  Badge,
   Button,
   Callout,
   Card,
@@ -27,6 +26,7 @@ import { convertToFrequentistDesignSpec } from './experiment-form-helpers';
 import { getPowerAnalysis, metricHasMissingValues } from '@/services/experiment-utils';
 import { MetricSampleSizeDisplay } from '@/components/features/experiments/metric-sample-size-display';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
+import { InfoBadge } from '@/components/ui/info-badge';
 import { ZodError } from 'zod';
 import { useState } from 'react';
 import { SectionCard } from '@/components/ui/cards/section-card';
@@ -42,6 +42,22 @@ interface PowerCheckSectionProps {
   data: ExperimentFormData;
   dispatch: (action: PowerCheckSectionAction | ClusterStatisticsSectionAction) => void;
 }
+
+const availableSampleSufficientBadge = (
+  <InfoBadge
+    label="Sufficient"
+    color="green"
+    tooltip="There are enough participants available to sample to detect this metric's target MDE."
+  />
+);
+
+const availableSampleInsufficientBadge = (
+  <InfoBadge
+    label="Insufficient"
+    color="red"
+    tooltip="There are not enough participants available to sample to detect this metric's target MDE."
+  />
+);
 
 const isPowerCheckButtonEnabled = (isMutating: boolean, data: ExperimentFormData) => {
   const reasons = [];
@@ -273,11 +289,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                       <DataList.Item>
                         <DataList.Label>Status</DataList.Label>
                         <DataList.Value>
-                          {primaryPower.sufficient_n ? (
-                            <Badge color={'green'}>Sufficient</Badge>
-                          ) : (
-                            <Badge color={'red'}>Insufficient</Badge>
-                          )}
+                          {primaryPower.sufficient_n
+                            ? availableSampleSufficientBadge
+                            : availableSampleInsufficientBadge}
                         </DataList.Value>
                       </DataList.Item>
                       <DataList.Item>
@@ -346,11 +360,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         <Table.Row key={`rest${i}`}>
                           <Table.Cell>{metricAnalysis.metric_spec.field_name}</Table.Cell>
                           <Table.Cell>
-                            {metricAnalysis.sufficient_n ? (
-                              <Badge color={'green'}>Sufficient</Badge>
-                            ) : (
-                              <Badge color={'red'}>Insufficient</Badge>
-                            )}
+                            {metricAnalysis.sufficient_n
+                              ? availableSampleSufficientBadge
+                              : availableSampleInsufficientBadge}
                           </Table.Cell>
                           <Table.Cell align={'right'}>
                             <MetricSampleSizeDisplay

--- a/src/app/experiments/create/experiment-form/power-check-section.tsx
+++ b/src/app/experiments/create/experiment-form/power-check-section.tsx
@@ -274,9 +274,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                         <DataList.Label>Status</DataList.Label>
                         <DataList.Value>
                           {primaryPower.sufficient_n ? (
-                            <Badge color={'green'}>OK</Badge>
+                            <Badge color={'green'}>Sufficient</Badge>
                           ) : (
-                            <Badge color={'red'}>Too Few</Badge>
+                            <Badge color={'red'}>Insufficient</Badge>
                           )}
                         </DataList.Value>
                       </DataList.Item>
@@ -347,9 +347,9 @@ export function PowerCheckSection({ data, dispatch }: PowerCheckSectionProps) {
                           <Table.Cell>{metricAnalysis.metric_spec.field_name}</Table.Cell>
                           <Table.Cell>
                             {metricAnalysis.sufficient_n ? (
-                              <Badge color={'green'}>OK</Badge>
+                              <Badge color={'green'}>Sufficient</Badge>
                             ) : (
-                              <Badge color={'red'}>Too Few</Badge>
+                              <Badge color={'red'}>Insufficient</Badge>
                             )}
                           </Table.Cell>
                           <Table.Cell align={'right'}>

--- a/src/components/features/experiments/analysis-snapshot-selector.tsx
+++ b/src/components/features/experiments/analysis-snapshot-selector.tsx
@@ -85,7 +85,7 @@ export function AnalysisSnapshotSelector({
         ) : null}
         {analysisHistory.length > 0 ? (
           isLastSnapshotErrorRelevant ? (
-            <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
+            <Tooltip content={`Last snapshot error at ${lastErrorTimestamp?.toLocaleTimeString()}.`}>
               <IconButton size="1" variant="ghost" color="red" asChild>
                 <Link href={snapshotsHref} aria-label="View snapshot log">
                   <ExclamationTriangleIcon />
@@ -93,7 +93,7 @@ export function AnalysisSnapshotSelector({
               </IconButton>
             </Tooltip>
           ) : (
-            <Tooltip content={'View snapshot log'}>
+            <Tooltip content="View snapshot log">
               <IconButton size="1" variant="ghost" color="gray" asChild>
                 <Link href={snapshotsHref} aria-label="View snapshot log">
                   <ActivityLogIcon />

--- a/src/components/features/experiments/analysis-snapshot-selector.tsx
+++ b/src/components/features/experiments/analysis-snapshot-selector.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Link from 'next/link';
+import { ActivityLogIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons';
+import { Badge, Box, Flex, Heading, Select, Text, Tooltip } from '@radix-ui/themes';
+
+const SNAPSHOT_ERROR_ALERT_THRESHOLD_MS = 8 * 60 * 60 * 1000;
+
+type AnalysisOption = {
+  key: string;
+  label: string;
+};
+
+interface AnalysisSnapshotSelectorProps {
+  datasourceId: string;
+  experimentId: string;
+  liveAnalysisLabel: string;
+  analysisHistory: AnalysisOption[];
+  activeAnalysisKey: string;
+  onSelectAnalysis: (key: string) => void;
+  lastErrorTimestamp: Date | null;
+}
+
+export function AnalysisSnapshotSelector({
+  datasourceId,
+  experimentId,
+  liveAnalysisLabel,
+  analysisHistory,
+  activeAnalysisKey,
+  onSelectAnalysis,
+  lastErrorTimestamp,
+}: AnalysisSnapshotSelectorProps) {
+  const isLastSnapshotErrorRelevant =
+    lastErrorTimestamp !== null && Date.now() - lastErrorTimestamp.getTime() <= SNAPSHOT_ERROR_ALERT_THRESHOLD_MS;
+
+  const snapshotsHref = `/datasources/${datasourceId}/experiments/${experimentId}/snapshots`;
+
+  return (
+    <Badge size="2" style={{ height: '26px' }}>
+      <Flex gap="2" align="center">
+        <Heading size="2">Viewing:</Heading>
+        {analysisHistory.length == 0 ? (
+          <Text>{liveAnalysisLabel}</Text>
+        ) : (
+          <>
+            <Select.Root size="1" value={activeAnalysisKey} onValueChange={onSelectAnalysis}>
+              <Select.Trigger style={{ height: 18 }} />
+              <Select.Content>
+                <Select.Group>
+                  <Select.Item key="live" value="live">
+                    <Box minWidth="136px">{liveAnalysisLabel}</Box>
+                  </Select.Item>
+                </Select.Group>
+                <Select.Separator />
+                <Select.Group>
+                  {analysisHistory.map((opt) => (
+                    <Select.Item key={opt.key} value={opt.key}>
+                      <Box minWidth="136px">{opt.label}</Box>
+                    </Select.Item>
+                  ))}
+                </Select.Group>
+              </Select.Content>
+            </Select.Root>
+            {isLastSnapshotErrorRelevant ? (
+              <Tooltip content={'Last snapshot error: ' + lastErrorTimestamp?.toLocaleTimeString()}>
+                <Link href={snapshotsHref}>
+                  <ExclamationTriangleIcon color={'red'} />
+                </Link>
+              </Tooltip>
+            ) : (
+              <Tooltip content={'View snapshot log'}>
+                <Link href={snapshotsHref}>
+                  <ActivityLogIcon />
+                </Link>
+              </Tooltip>
+            )}
+          </>
+        )}
+      </Flex>
+    </Badge>
+  );
+}

--- a/src/components/features/experiments/experiment-confirmation-display.tsx
+++ b/src/components/features/experiments/experiment-confirmation-display.tsx
@@ -6,7 +6,6 @@ import {
   isBanditSpec,
   isClusteredPreassignedSpec,
   isCmabSpec,
-  isFreqPreassignedSpec,
   isFrequentistSpec,
 } from '@/services/experiment-utils';
 import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
@@ -14,7 +13,7 @@ import { ExperimentDescriptionSection } from '@/components/features/experiments/
 import { TreatmentArmsSection } from '@/components/features/experiments/sections/treatment-arms-section';
 import { ContextsSection } from '@/components/features/experiments/sections/contexts-section';
 import { DatasourceTargetingSection } from '@/components/features/experiments/sections/datasource-targeting-section';
-import { PowerBalanceSection } from '@/components/features/experiments/sections/power-balance-section';
+import { FreqDesignDetailsDialog } from '@/components/features/experiments/freq-design-details-dialog';
 import { OutcomesPriorSection } from '@/components/features/experiments/sections/outcomes-prior-section';
 export interface ExperimentConfirmationDisplayProps {
   response: CreateExperimentResponse;
@@ -30,7 +29,6 @@ export interface ExperimentConfirmationDisplayProps {
   onEditOutcomesPrior?: () => void;
   onEditContexts?: () => void;
   onEditMetrics?: () => void;
-  onEditPowerBalance?: () => void;
   // Optional footer for actions (commit/abandon in old flow, nothing in new flow)
   footer?: React.ReactNode;
 }
@@ -45,27 +43,20 @@ export function ExperimentConfirmationDisplay({
   onEditOutcomesPrior,
   onEditContexts,
   onEditMetrics,
-  onEditPowerBalance,
   footer,
 }: ExperimentConfirmationDisplayProps) {
   const designSpec = response.design_spec;
   const isFreq = isFrequentistSpec(designSpec);
-  const isFreqPreassigned = isFreqPreassignedSpec(designSpec);
   const isBandit = isBanditSpec(designSpec);
   const isCmab = isCmabSpec(designSpec);
   const clusterKey = isClusteredPreassignedSpec(designSpec) ? (designSpec.cluster_key ?? undefined) : undefined;
 
-  // Extract frequentist-specific properties (confidence/power/filters/strata)
+  // Extract frequentist-specific properties (filters/strata)
   // For non-frequentist experiments, these will be undefined
-  let confidence = 95;
-  let power = 80;
   let filters: Filter[] = [];
   let strata: string[] | undefined;
 
   if (isFreq) {
-    const alpha = designSpec.alpha ?? 0.05;
-    confidence = Math.round((1 - alpha) * 100);
-    power = Math.round((designSpec.power ?? 0.8) * 100);
     filters = designSpec.filters;
     strata = designSpec.strata?.map((s) => s.field_name);
   }
@@ -90,19 +81,19 @@ export function ExperimentConfirmationDisplay({
               onEditDatasource={onEditDatasource}
               onEditFilters={onEditFilters}
             />
-            <MetricsSection metrics={metrics} strata={strata} onEdit={onEditMetrics} />
-            {isFreqPreassigned && (
-              <PowerBalanceSection
-                confidence={confidence}
-                power={power}
-                desiredN={designSpec.desired_n ?? undefined}
-                assignSummary={response.assign_summary}
-                powerAnalyses={response.power_analyses?.analyses}
-                primaryMetricFieldName={designSpec.metrics[0]?.field_name}
-                isClustered={clusterKey !== undefined}
-                onEdit={onEditPowerBalance}
-              />
-            )}
+            <MetricsSection
+              metrics={metrics}
+              strata={strata}
+              onEdit={onEditMetrics}
+              headerRight={
+                <FreqDesignDetailsDialog
+                  designSpec={designSpec}
+                  assignSummary={response.assign_summary}
+                  powerAnalyses={response.power_analyses?.analyses}
+                  metrics={metrics}
+                />
+              }
+            />
           </>
         )}
         {isBandit && (

--- a/src/components/features/experiments/experiment-confirmation-display.tsx
+++ b/src/components/features/experiments/experiment-confirmation-display.tsx
@@ -2,12 +2,7 @@
 
 import { Flex, Grid } from '@radix-ui/themes';
 import { CreateExperimentResponse, Filter } from '@/api/methods.schemas';
-import {
-  isBanditSpec,
-  isClusteredPreassignedSpec,
-  isCmabSpec,
-  isFrequentistSpec,
-} from '@/services/experiment-utils';
+import { isBanditSpec, isClusteredPreassignedSpec, isCmabSpec, isFrequentistSpec } from '@/services/experiment-utils';
 import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
 import { ExperimentDescriptionSection } from '@/components/features/experiments/sections/experiment-description-section';
 import { TreatmentArmsSection } from '@/components/features/experiments/sections/treatment-arms-section';
@@ -90,7 +85,7 @@ export function ExperimentConfirmationDisplay({
                   designSpec={designSpec}
                   assignSummary={response.assign_summary}
                   powerAnalyses={response.power_analyses?.analyses}
-                  metrics={metrics}
+                  showMetrics={false}
                 />
               }
             />

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -15,6 +15,7 @@ import { PowerBalanceSection } from '@/components/features/experiments/sections/
 import {
   isChosenSampleSufficient,
   isClusteredPreassignedSpec,
+  isFreqPreassignedSpec,
   metricHasMissingValues,
 } from '@/services/experiment-utils';
 
@@ -43,6 +44,7 @@ export function FreqDesignDetailsDialog({
   const [open, setOpen] = useState(false);
 
   const desiredN = designSpec.desired_n ?? undefined;
+  const isPreassigned = isFreqPreassignedSpec(designSpec);
   const isClustered = isClusteredPreassignedSpec(designSpec);
   const clusterKey = isClustered ? (designSpec.cluster_key ?? undefined) : undefined;
   const desiredNClusters = isClustered ? (designSpec.desired_n_clusters ?? undefined) : undefined;
@@ -92,6 +94,8 @@ export function FreqDesignDetailsDialog({
                 powerAnalyses={powerAnalyses}
                 primaryMetricFieldName={primary?.field_name}
                 isClustered={clusterKey !== undefined}
+                showPower={isPreassigned}
+                showDesiredSampleSize={isPreassigned}
                 showActualSampleSize={false}
               />
             </Flex>

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -15,7 +15,6 @@ import { PowerBalanceSection } from '@/components/features/experiments/sections/
 import {
   isChosenSampleSufficient,
   isClusteredPreassignedSpec,
-  isFreqPreassignedSpec,
   metricHasMissingValues,
 } from '@/services/experiment-utils';
 
@@ -44,7 +43,6 @@ export function FreqDesignDetailsDialog({
   const [open, setOpen] = useState(false);
 
   const desiredN = designSpec.desired_n ?? undefined;
-  const isPreassigned = isFreqPreassignedSpec(designSpec);
   const isClustered = isClusteredPreassignedSpec(designSpec);
   const clusterKey = isClustered ? (designSpec.cluster_key ?? undefined) : undefined;
   const desiredNClusters = isClustered ? (designSpec.desired_n_clusters ?? undefined) : undefined;
@@ -94,8 +92,6 @@ export function FreqDesignDetailsDialog({
                 powerAnalyses={powerAnalyses}
                 primaryMetricFieldName={primary?.field_name}
                 isClustered={clusterKey !== undefined}
-                showPower={isPreassigned}
-                showDesiredSampleSize={isPreassigned}
                 showActualSampleSize={false}
               />
             </Flex>

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -23,11 +23,8 @@ interface DesignDetailsDialogProps {
   experimentSchema?: ParticipantsSchema | null;
   assignSummary: AssignSummary | null | undefined;
   powerAnalyses?: MetricPowerAnalysis[];
-  /** Precomputed metric displays; when omitted, they are derived from the design spec and schema. */
-  metrics?: {
-    primary?: MetricDisplay;
-    secondary?: MetricDisplay[];
-  };
+  /** When false, omit the Metrics section (e.g. create summary already shows a Metrics card). Defaults to true. */
+  showMetrics?: boolean;
 }
 
 const toMdePercent = (value: number | null | undefined): string =>
@@ -38,7 +35,7 @@ export function FreqDesignDetailsDialog({
   experimentSchema,
   assignSummary,
   powerAnalyses,
-  metrics: metricsOverride,
+  showMetrics = true,
 }: DesignDetailsDialogProps) {
   const [open, setOpen] = useState(false);
 
@@ -47,29 +44,37 @@ export function FreqDesignDetailsDialog({
   const clusterKey = isClustered ? (designSpec.cluster_key ?? undefined) : undefined;
   const desiredNClusters = isClustered ? (designSpec.desired_n_clusters ?? undefined) : undefined;
 
-  const fieldTypeByName = new Map((experimentSchema?.fields ?? []).map((field) => [field.field_name, field.data_type]));
-  const analysisByField = new Map((powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis]));
-  const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
-    const analysis = analysisByField.get(fieldName);
-    const estimatedRaw = analysis?.pct_change_with_desired_n;
-    return {
-      field_name: fieldName,
-      data_type: fieldTypeByName.get(fieldName) ?? DataType.unknown,
-      mde: toMdePercent(mdePct),
-      estimatedMde: estimatedRaw != null ? (estimatedRaw * 100).toFixed(1) : null,
-      hasMissingValues: analysis !== undefined && metricHasMissingValues(analysis),
-      sufficientN: isChosenSampleSufficient(analysis, isClustered, desiredN, desiredNClusters),
-    };
-  };
-
-  const [primary, ...secondary] = designSpec.metrics;
-  const metrics = metricsOverride ?? {
-    primary: primary ? toMetricDisplay(primary.field_name, primary.metric_pct_change) : undefined,
-    secondary: secondary.map((m) => toMetricDisplay(m.field_name, m.metric_pct_change)),
-  };
-  const strata = designSpec.strata?.map((s) => s.field_name) ?? [];
   const confidence = Math.round((1 - (designSpec.alpha ?? 0.05)) * 100);
   const power = Math.round((designSpec.power ?? 0.8) * 100);
+
+  const [primary, ...secondary] = designSpec.metrics;
+  let metrics: { primary?: MetricDisplay; secondary?: MetricDisplay[] } | undefined;
+  let strata: string[] | undefined;
+  if (showMetrics) {
+    const fieldTypeByName = new Map(
+      (experimentSchema?.fields ?? []).map((field) => [field.field_name, field.data_type]),
+    );
+    const analysisByField = new Map(
+      (powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis]),
+    );
+    const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
+      const analysis = analysisByField.get(fieldName);
+      const estimatedRaw = analysis?.pct_change_with_desired_n;
+      return {
+        field_name: fieldName,
+        data_type: fieldTypeByName.get(fieldName) ?? DataType.unknown,
+        mde: toMdePercent(mdePct),
+        estimatedMde: estimatedRaw != null ? (estimatedRaw * 100).toFixed(1) : null,
+        hasMissingValues: analysis !== undefined && metricHasMissingValues(analysis),
+        sufficientN: isChosenSampleSufficient(analysis, isClustered, desiredN, desiredNClusters),
+      };
+    };
+    metrics = {
+      primary: primary ? toMetricDisplay(primary.field_name, primary.metric_pct_change) : undefined,
+      secondary: secondary.map((m) => toMetricDisplay(m.field_name, m.metric_pct_change)),
+    };
+    strata = designSpec.strata?.map((s) => s.field_name) ?? [];
+  }
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
@@ -83,7 +88,7 @@ export function FreqDesignDetailsDialog({
           <Dialog.Title>Design Details</Dialog.Title>
           <Box maxHeight="70vh" overflow="auto" pr="1">
             <Flex direction="column" gap="4">
-              <MetricsSection metrics={metrics} strata={strata} />
+              {showMetrics ? <MetricsSection metrics={metrics} strata={strata} /> : null}
               <PowerBalanceSection
                 confidence={confidence}
                 power={power}

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -38,8 +38,25 @@ export function FreqDesignDetailsDialog({
 }: DesignDetailsDialogProps) {
   const [open, setOpen] = useState(false);
 
+  const desiredN = designSpec.desired_n ?? undefined;
+  const isClustered = isClusteredPreassignedSpec(designSpec);
+  const clusterKey = isClustered ? (designSpec.cluster_key ?? undefined) : undefined;
+  const desiredNClusters = isClustered ? (designSpec.desired_n_clusters ?? undefined) : undefined;
+
   const fieldTypeByName = new Map((experimentSchema?.fields ?? []).map((field) => [field.field_name, field.data_type]));
   const analysisByField = new Map((powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis]));
+  // Sufficiency compares the chosen sample size against the minimum required for the metric's
+  // target MDE, since assignment enrolls exactly the chosen sample (including participants with
+  // missing values) regardless of how many participants the datasource could supply.
+  const sufficientNFor = (analysis: MetricPowerAnalysis | undefined): boolean | undefined => {
+    if (analysis === undefined) return undefined;
+    if (isClustered) {
+      return analysis.num_clusters_total != null && desiredNClusters != null
+        ? desiredNClusters >= analysis.num_clusters_total
+        : undefined;
+    }
+    return analysis.target_n != null && desiredN != null ? desiredN >= analysis.target_n : undefined;
+  };
   const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
     const analysis = analysisByField.get(fieldName);
     const estimatedRaw = analysis?.pct_change_with_desired_n;
@@ -49,7 +66,7 @@ export function FreqDesignDetailsDialog({
       mde: toMdePercent(mdePct),
       estimatedMde: estimatedRaw != null ? (estimatedRaw * 100).toFixed(1) : null,
       hasMissingValues: analysis !== undefined && metricHasMissingValues(analysis),
-      sufficientN: analysis?.sufficient_n,
+      sufficientN: sufficientNFor(analysis),
     };
   };
 
@@ -61,8 +78,6 @@ export function FreqDesignDetailsDialog({
   const strata = designSpec.strata?.map((s) => s.field_name) ?? [];
   const confidence = Math.round((1 - (designSpec.alpha ?? 0.05)) * 100);
   const power = Math.round((designSpec.power ?? 0.8) * 100);
-  const desiredN = designSpec.desired_n ?? undefined;
-  const clusterKey = isClusteredPreassignedSpec(designSpec) ? (designSpec.cluster_key ?? undefined) : undefined;
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -16,9 +16,14 @@ import { isClusteredPreassignedSpec, metricHasMissingValues } from '@/services/e
 
 interface DesignDetailsDialogProps {
   designSpec: AnyFrequentistDesignSpec;
-  experimentSchema: ParticipantsSchema | null | undefined;
+  experimentSchema?: ParticipantsSchema | null;
   assignSummary: AssignSummary | null | undefined;
   powerAnalyses?: MetricPowerAnalysis[];
+  /** Precomputed metric displays; when omitted, they are derived from the design spec and schema. */
+  metrics?: {
+    primary?: MetricDisplay;
+    secondary?: MetricDisplay[];
+  };
 }
 
 const toMdePercent = (value: number | null | undefined): string =>
@@ -29,29 +34,27 @@ export function FreqDesignDetailsDialog({
   experimentSchema,
   assignSummary,
   powerAnalyses,
+  metrics: metricsOverride,
 }: DesignDetailsDialogProps) {
   const [open, setOpen] = useState(false);
 
   const fieldTypeByName = new Map((experimentSchema?.fields ?? []).map((field) => [field.field_name, field.data_type]));
-  const estimatedMdeByField = new Map(
-    (powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis.pct_change_with_desired_n]),
-  );
-  const missingValuesByField = new Map(
-    (powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, metricHasMissingValues(analysis)]),
-  );
+  const analysisByField = new Map((powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis]));
   const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
-    const estimatedRaw = estimatedMdeByField.get(fieldName);
+    const analysis = analysisByField.get(fieldName);
+    const estimatedRaw = analysis?.pct_change_with_desired_n;
     return {
       field_name: fieldName,
       data_type: fieldTypeByName.get(fieldName) ?? DataType.unknown,
       mde: toMdePercent(mdePct),
       estimatedMde: estimatedRaw != null ? (estimatedRaw * 100).toFixed(1) : null,
-      hasMissingValues: missingValuesByField.get(fieldName) ?? false,
+      hasMissingValues: analysis !== undefined && metricHasMissingValues(analysis),
+      sufficientN: analysis?.sufficient_n,
     };
   };
 
   const [primary, ...secondary] = designSpec.metrics;
-  const metrics = {
+  const metrics = metricsOverride ?? {
     primary: primary ? toMetricDisplay(primary.field_name, primary.metric_pct_change) : undefined,
     secondary: secondary.map((m) => toMetricDisplay(m.field_name, m.metric_pct_change)),
   };

--- a/src/components/features/experiments/freq-design-details-dialog.tsx
+++ b/src/components/features/experiments/freq-design-details-dialog.tsx
@@ -12,7 +12,11 @@ import {
 } from '@/api/methods.schemas';
 import { MetricDisplay, MetricsSection } from '@/components/features/experiments/sections/metrics-section';
 import { PowerBalanceSection } from '@/components/features/experiments/sections/power-balance-section';
-import { isClusteredPreassignedSpec, metricHasMissingValues } from '@/services/experiment-utils';
+import {
+  isChosenSampleSufficient,
+  isClusteredPreassignedSpec,
+  metricHasMissingValues,
+} from '@/services/experiment-utils';
 
 interface DesignDetailsDialogProps {
   designSpec: AnyFrequentistDesignSpec;
@@ -45,18 +49,6 @@ export function FreqDesignDetailsDialog({
 
   const fieldTypeByName = new Map((experimentSchema?.fields ?? []).map((field) => [field.field_name, field.data_type]));
   const analysisByField = new Map((powerAnalyses ?? []).map((analysis) => [analysis.metric_spec.field_name, analysis]));
-  // Sufficiency compares the chosen sample size against the minimum required for the metric's
-  // target MDE, since assignment enrolls exactly the chosen sample (including participants with
-  // missing values) regardless of how many participants the datasource could supply.
-  const sufficientNFor = (analysis: MetricPowerAnalysis | undefined): boolean | undefined => {
-    if (analysis === undefined) return undefined;
-    if (isClustered) {
-      return analysis.num_clusters_total != null && desiredNClusters != null
-        ? desiredNClusters >= analysis.num_clusters_total
-        : undefined;
-    }
-    return analysis.target_n != null && desiredN != null ? desiredN >= analysis.target_n : undefined;
-  };
   const toMetricDisplay = (fieldName: string, mdePct: number | null | undefined): MetricDisplay => {
     const analysis = analysisByField.get(fieldName);
     const estimatedRaw = analysis?.pct_change_with_desired_n;
@@ -66,7 +58,7 @@ export function FreqDesignDetailsDialog({
       mde: toMdePercent(mdePct),
       estimatedMde: estimatedRaw != null ? (estimatedRaw * 100).toFixed(1) : null,
       hasMissingValues: analysis !== undefined && metricHasMissingValues(analysis),
-      sufficientN: sufficientNFor(analysis),
+      sufficientN: isChosenSampleSufficient(analysis, isClustered, desiredN, desiredNClusters),
     };
   };
 

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge, Button, DataList, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon, Pencil2Icon } from '@radix-ui/react-icons';
+import { Pencil2Icon } from '@radix-ui/react-icons';
 import { DataType } from '@/api/methods.schemas';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
@@ -20,17 +20,11 @@ export interface MetricDisplay {
 function SampleSufficiencyBadge({ sufficientN }: { sufficientN: boolean }) {
   return sufficientN ? (
     <Tooltip content="There are enough eligible participants to detect this metric's target MDE.">
-      <Badge color="green">
-        OK
-        <InfoCircledIcon />
-      </Badge>
+      <Badge color="green">OK</Badge>
     </Tooltip>
   ) : (
     <Tooltip content="There are not enough eligible participants to detect this metric's target MDE.">
-      <Badge color="red">
-        Too Few
-        <InfoCircledIcon />
-      </Badge>
+      <Badge color="red">Too Few</Badge>
     </Tooltip>
   );
 }

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Badge, Button, DataList, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon, Pencil2Icon } from '@radix-ui/react-icons';
+import { Button, DataList, Flex, Separator, Text } from '@radix-ui/themes';
+import { Pencil2Icon } from '@radix-ui/react-icons';
 import { DataType } from '@/api/methods.schemas';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
+import { InfoBadge } from '@/components/ui/info-badge';
 import { MdeBadge } from '@/components/features/experiments/mde-badge';
 
 export interface MetricDisplay {
@@ -17,25 +18,31 @@ export interface MetricDisplay {
   sufficientN?: boolean | null;
 }
 
-function SampleSufficiencyBadge({ sufficientN }: { sufficientN: boolean }) {
+interface SampleSufficiencyBadgeProps {
+  sufficientN: boolean;
+}
+
+function SampleSufficiencyBadge({ sufficientN }: SampleSufficiencyBadgeProps) {
   return sufficientN ? (
-    <Tooltip content="The chosen sample size is large enough to detect this metric's target MDE.">
-      <Badge color="green">
-        Sufficient
-        <InfoCircledIcon />
-      </Badge>
-    </Tooltip>
+    <InfoBadge
+      label="Sufficient"
+      color="green"
+      tooltip="The chosen sample size is large enough to detect this metric's target MDE."
+    />
   ) : (
-    <Tooltip content="The chosen sample size is too small to detect this metric's target MDE.">
-      <Badge color="red">
-        Insufficient
-        <InfoCircledIcon />
-      </Badge>
-    </Tooltip>
+    <InfoBadge
+      label="Insufficient"
+      color="red"
+      tooltip="The chosen sample size is too small to detect this metric's target MDE."
+    />
   );
 }
 
-function MetricBadges({ metric }: { metric: MetricDisplay }) {
+interface MetricBadgesProps {
+  metric: MetricDisplay;
+}
+
+function MetricBadges({ metric }: MetricBadgesProps) {
   return (
     <Flex direction="column" gap="2" align="start" width="100%">
       <Flex direction="row" gap="2" align="center" justify="between" wrap="wrap" width="100%">

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button, DataList, Flex, Separator, Text } from '@radix-ui/themes';
-import { Pencil2Icon } from '@radix-ui/react-icons';
+import { Badge, Button, DataList, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon, Pencil2Icon } from '@radix-ui/react-icons';
 import { DataType } from '@/api/methods.schemas';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
@@ -13,6 +13,40 @@ export interface MetricDisplay {
   mde: string | number;
   estimatedMde?: string | number | null;
   hasMissingValues: boolean;
+  /** Whether the sample size is sufficient to detect the target MDE. Omitted when no power analysis is available. */
+  sufficientN?: boolean | null;
+}
+
+function SampleSufficiencyBadge({ sufficientN }: { sufficientN: boolean }) {
+  return sufficientN ? (
+    <Tooltip content="There are enough eligible participants to detect this metric's target MDE.">
+      <Badge color="green">
+        OK
+        <InfoCircledIcon />
+      </Badge>
+    </Tooltip>
+  ) : (
+    <Tooltip content="There are not enough eligible participants to detect this metric's target MDE.">
+      <Badge color="red">
+        Too Few
+        <InfoCircledIcon />
+      </Badge>
+    </Tooltip>
+  );
+}
+
+function MetricBadges({ metric }: { metric: MetricDisplay }) {
+  return (
+    <Flex direction="column" gap="2" align="start" width="100%">
+      <Flex direction="row" gap="2" align="center" justify="between" wrap="wrap" width="100%">
+        <MdeBadge value={metric.mde} kind="target" size="1" hasMissingValues={metric.hasMissingValues} />
+        {metric.sufficientN != null ? <SampleSufficiencyBadge sufficientN={metric.sufficientN} /> : null}
+      </Flex>
+      {metric.estimatedMde != null ? (
+        <MdeBadge value={metric.estimatedMde} kind="estimated" size="1" hasMissingValues={metric.hasMissingValues} />
+      ) : null}
+    </Flex>
+  );
 }
 
 export interface MetricsSectionProps {
@@ -22,18 +56,26 @@ export interface MetricsSectionProps {
   };
   strata?: string[];
   onEdit?: () => void;
+  headerRight?: React.ReactNode;
 }
 
-export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps) {
+export function MetricsSection({ metrics, strata, onEdit, headerRight }: MetricsSectionProps) {
+  const editButton = onEdit ? (
+    <Button size="1" onClick={onEdit}>
+      <Pencil2Icon />
+      Edit
+    </Button>
+  ) : undefined;
+
   return (
     <SectionCard
       title="Metrics"
       headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
+        headerRight || editButton ? (
+          <Flex gap="3" align="center">
+            {headerRight}
+            {editButton}
+          </Flex>
         ) : undefined
       }
     >
@@ -47,22 +89,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                   <Text>{metrics.primary.field_name}</Text>
                   <DataTypeBadge type={metrics.primary.data_type} />
                 </Flex>
-                <Flex direction="row" gap="2" align="start" wrap="wrap">
-                  <MdeBadge
-                    value={metrics.primary.mde}
-                    kind="target"
-                    size="1"
-                    hasMissingValues={metrics.primary.hasMissingValues}
-                  />
-                  {metrics.primary.estimatedMde != null && (
-                    <MdeBadge
-                      value={metrics.primary.estimatedMde}
-                      kind="estimated"
-                      size="1"
-                      hasMissingValues={metrics.primary.hasMissingValues}
-                    />
-                  )}
-                </Flex>
+                <MetricBadges metric={metrics.primary} />
                 {metrics?.secondary && metrics.secondary.length >= 1 && <Separator orientation="horizontal" size="4" />}
               </Flex>
             ) : (
@@ -81,17 +108,7 @@ export function MetricsSection({ metrics, strata, onEdit }: MetricsSectionProps)
                       <Text>{metric.field_name}</Text>
                       <DataTypeBadge type={metric.data_type} />
                     </Flex>
-                    <Flex direction="row" gap="2" align="start" wrap="wrap">
-                      <MdeBadge value={metric.mde} kind="target" size="1" hasMissingValues={metric.hasMissingValues} />
-                      {metric.estimatedMde != null && (
-                        <MdeBadge
-                          value={metric.estimatedMde}
-                          kind="estimated"
-                          size="1"
-                          hasMissingValues={metric.hasMissingValues}
-                        />
-                      )}
-                    </Flex>
+                    <MetricBadges metric={metric} />
                     <Separator orientation="horizontal" size="4" />
                   </Flex>
                 ))}

--- a/src/components/features/experiments/sections/metrics-section.tsx
+++ b/src/components/features/experiments/sections/metrics-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge, Button, DataList, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { Pencil2Icon } from '@radix-ui/react-icons';
+import { InfoCircledIcon, Pencil2Icon } from '@radix-ui/react-icons';
 import { DataType } from '@/api/methods.schemas';
 import { SectionCard } from '@/components/ui/cards/section-card';
 import { DataTypeBadge } from '@/components/ui/data-type-badge';
@@ -13,18 +13,24 @@ export interface MetricDisplay {
   mde: string | number;
   estimatedMde?: string | number | null;
   hasMissingValues: boolean;
-  /** Whether the sample size is sufficient to detect the target MDE. Omitted when no power analysis is available. */
+  /** Whether the chosen sample size reaches the minimum required to detect the target MDE. Omitted when unknown. */
   sufficientN?: boolean | null;
 }
 
 function SampleSufficiencyBadge({ sufficientN }: { sufficientN: boolean }) {
   return sufficientN ? (
-    <Tooltip content="There are enough eligible participants to detect this metric's target MDE.">
-      <Badge color="green">OK</Badge>
+    <Tooltip content="The chosen sample size is large enough to detect this metric's target MDE.">
+      <Badge color="green">
+        Sufficient
+        <InfoCircledIcon />
+      </Badge>
     </Tooltip>
   ) : (
-    <Tooltip content="There are not enough eligible participants to detect this metric's target MDE.">
-      <Badge color="red">Too Few</Badge>
+    <Tooltip content="The chosen sample size is too small to detect this metric's target MDE.">
+      <Badge color="red">
+        Insufficient
+        <InfoCircledIcon />
+      </Badge>
     </Tooltip>
   );
 }

--- a/src/components/features/experiments/sections/power-balance-section.tsx
+++ b/src/components/features/experiments/sections/power-balance-section.tsx
@@ -96,12 +96,10 @@ export function PowerBalanceSection({
               <DataList.Label>Confidence</DataList.Label>
               <DataList.Value>{confidenceBadge}</DataList.Value>
             </DataList.Item>
-            {hasPowerAnalyses ? (
-              <DataList.Item>
-                <DataList.Label>Power</DataList.Label>
-                <DataList.Value>{powerBadge}</DataList.Value>
-              </DataList.Item>
-            ) : null}
+            <DataList.Item>
+              <DataList.Label>Power</DataList.Label>
+              <DataList.Value>{hasPowerAnalyses ? powerBadge : <Text>No analysis</Text>}</DataList.Value>
+            </DataList.Item>
             <DataList.Item>
               <DataList.Label>Desired Sample Size</DataList.Label>
               <DataList.Value>{desiredN ?? 'N/A'} participants</DataList.Value>

--- a/src/components/features/experiments/sections/power-balance-section.tsx
+++ b/src/components/features/experiments/sections/power-balance-section.tsx
@@ -19,8 +19,6 @@ export interface PowerBalanceSectionProps {
   primaryMetricFieldName?: string;
   isClustered?: boolean;
   onEdit?: () => void;
-  showPower?: boolean;
-  showDesiredSampleSize?: boolean;
   showActualSampleSize?: boolean;
   showTitle?: boolean;
 }
@@ -34,8 +32,6 @@ export function PowerBalanceSection({
   primaryMetricFieldName,
   isClustered = false,
   onEdit,
-  showPower = true,
-  showDesiredSampleSize = true,
   showActualSampleSize = true,
   showTitle = true,
 }: PowerBalanceSectionProps) {
@@ -46,6 +42,7 @@ export function PowerBalanceSection({
   const actualSampleSize = assignSummary?.sample_size;
   const shouldShowActualSampleSize =
     showActualSampleSize && actualSampleSize !== undefined && actualSampleSize !== desiredN;
+  const hasPowerAnalyses = powerAnalyses != null && powerAnalyses.length > 0;
   const primaryPowerAnalysis = getPowerAnalysis(
     powerAnalyses ? { analyses: powerAnalyses } : undefined,
     primaryMetricFieldName,
@@ -99,26 +96,24 @@ export function PowerBalanceSection({
               <DataList.Label>Confidence</DataList.Label>
               <DataList.Value>{confidenceBadge}</DataList.Value>
             </DataList.Item>
-            {showPower ? (
+            {hasPowerAnalyses ? (
               <DataList.Item>
                 <DataList.Label>Power</DataList.Label>
                 <DataList.Value>{powerBadge}</DataList.Value>
               </DataList.Item>
             ) : null}
-            {showDesiredSampleSize ? (
-              <DataList.Item>
-                <DataList.Label>Desired Sample Size</DataList.Label>
-                <DataList.Value>{desiredN ?? 'N/A'} participants</DataList.Value>
-              </DataList.Item>
-            ) : null}
-            {shouldShowActualSampleSize && (
+            <DataList.Item>
+              <DataList.Label>Desired Sample Size</DataList.Label>
+              <DataList.Value>{desiredN ?? 'N/A'} participants</DataList.Value>
+            </DataList.Item>
+            {shouldShowActualSampleSize ? (
               <DataList.Item>
                 <DataList.Label>Actual Sample Size</DataList.Label>
                 <DataList.Value>{actualSampleSize} participants</DataList.Value>
               </DataList.Item>
-            )}
+            ) : null}
 
-            {powerAnalyses && powerAnalyses.length > 0 && (
+            {hasPowerAnalyses ? (
               <>
                 <DataList.Item>
                   <DataList.Label>
@@ -139,9 +134,9 @@ export function PowerBalanceSection({
                   </DataList.Item>
                 ))}
               </>
-            )}
+            ) : null}
 
-            {showClusteringStats && powerAnalyses && powerAnalyses.length > 0 && (
+            {showClusteringStats && hasPowerAnalyses ? (
               <>
                 <DataList.Item>
                   <DataList.Label>
@@ -161,7 +156,7 @@ export function PowerBalanceSection({
                   <DataList.Value>{formatClusterStat(clusterMetricSpec.icc, 3)}</DataList.Value>
                 </DataList.Item>
               </>
-            )}
+            ) : null}
           </DataList.Root>
         </Flex>
 

--- a/src/components/features/experiments/sections/power-balance-section.tsx
+++ b/src/components/features/experiments/sections/power-balance-section.tsx
@@ -19,6 +19,7 @@ export interface PowerBalanceSectionProps {
   primaryMetricFieldName?: string;
   isClustered?: boolean;
   onEdit?: () => void;
+  showPower?: boolean;
   showDesiredSampleSize?: boolean;
   showActualSampleSize?: boolean;
   showTitle?: boolean;
@@ -33,6 +34,7 @@ export function PowerBalanceSection({
   primaryMetricFieldName,
   isClustered = false,
   onEdit,
+  showPower = true,
   showDesiredSampleSize = true,
   showActualSampleSize = true,
   showTitle = true,
@@ -97,16 +99,18 @@ export function PowerBalanceSection({
               <DataList.Label>Confidence</DataList.Label>
               <DataList.Value>{confidenceBadge}</DataList.Value>
             </DataList.Item>
-            <DataList.Item>
-              <DataList.Label>Power</DataList.Label>
-              <DataList.Value>{powerBadge}</DataList.Value>
-            </DataList.Item>
-            {showDesiredSampleSize && (
+            {showPower ? (
+              <DataList.Item>
+                <DataList.Label>Power</DataList.Label>
+                <DataList.Value>{powerBadge}</DataList.Value>
+              </DataList.Item>
+            ) : null}
+            {showDesiredSampleSize ? (
               <DataList.Item>
                 <DataList.Label>Desired Sample Size</DataList.Label>
                 <DataList.Value>{desiredN ?? 'N/A'} participants</DataList.Value>
               </DataList.Item>
-            )}
+            ) : null}
             {shouldShowActualSampleSize && (
               <DataList.Item>
                 <DataList.Label>Actual Sample Size</DataList.Label>

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -110,14 +110,14 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
         label="Balanced"
         color="green"
         variant="soft"
-        tooltip="A statistical check found your metric and strata values evenly distributed across the arms at assignment."
+        tooltip="A statistical check found your metric and strata values evenly distributed across the arms at assignment. View the Design Details for test results."
       />
     ) : (
       <InfoBadge
         label="Unbalanced"
         color="red"
         variant="soft"
-        tooltip="A statistical check suggests your metric and strata values are unevenly distributed across the arms. See Design Details on the Metrics card for the test results."
+        tooltip="A statistical check suggests your metric and strata values are unevenly distributed across the arms. View the Design Details for test results."
       />
     );
   const editButton = onEdit ? (

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge, Button, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
+import { InfoCircledIcon, LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
 import { ArmBandit, CreateExperimentResponse, PriorTypes } from '@/api/methods.schemas';
 import { isBanditSpec } from '@/services/experiment-utils';
 import { SectionCard } from '@/components/ui/cards/section-card';
@@ -102,14 +102,23 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
   }
 
   // Frequentist experiment display
-  const allArmsBalanced = arms.every((arm) => arm.arm_weight == null);
-  const balanceBadge = allArmsBalanced ? (
-    <Tooltip content="Participants are split evenly across all arms.">
-      <Badge color="green" variant="soft">
-        Balanced
-      </Badge>
-    </Tooltip>
-  ) : undefined;
+  const balanceOk = assignSummary?.balance_check?.balance_ok;
+  const balanceBadge =
+    balanceOk == null ? undefined : balanceOk ? (
+      <Tooltip content="A statistical check found your metric and strata values evenly distributed across the arms at assignment.">
+        <Badge color="green" variant="soft">
+          Balanced
+          <InfoCircledIcon />
+        </Badge>
+      </Tooltip>
+    ) : (
+      <Tooltip content="A statistical check suggests your metric and strata values are unevenly distributed across the arms. See Design Details on the Metrics card for the test results.">
+        <Badge color="red" variant="soft">
+          Unbalanced
+          <InfoCircledIcon />
+        </Badge>
+      </Tooltip>
+    );
   const editButton = onEdit ? (
     <Button size="1" onClick={onEdit}>
       <Pencil2Icon />

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Badge, Button, Flex, Separator, Text } from '@radix-ui/themes';
-import { LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
+import { Badge, Button, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
+import { InfoCircledIcon, LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
 import { ArmBandit, CreateExperimentResponse, PriorTypes } from '@/api/methods.schemas';
 import { isBanditSpec } from '@/services/experiment-utils';
 import { SectionCard } from '@/components/ui/cards/section-card';
@@ -28,9 +28,11 @@ function ArmAssignmentBadges({ armSize, clusterCount, armWeight }: ArmAssignment
           {armSize.toLocaleString()} participants
         </Badge>
       )}
-      <Badge color="gray" variant="soft">
-        {armWeight == null ? 'balanced' : `${armWeight.toFixed(1)}%`}
-      </Badge>
+      {armWeight != null ? (
+        <Badge color="gray" variant="soft">
+          {armWeight.toFixed(1)}%
+        </Badge>
+      ) : null}
     </Flex>
   );
 }
@@ -100,15 +102,31 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
   }
 
   // Frequentist experiment display
+  const allArmsBalanced = arms.every((arm) => arm.arm_weight == null);
+  const balanceBadge = allArmsBalanced ? (
+    <Tooltip content="Participants are split evenly across all arms.">
+      <Badge color="green" variant="soft">
+        Balanced
+        <InfoCircledIcon />
+      </Badge>
+    </Tooltip>
+  ) : undefined;
+  const editButton = onEdit ? (
+    <Button size="1" onClick={onEdit}>
+      <Pencil2Icon />
+      Edit
+    </Button>
+  ) : undefined;
+
   return (
     <SectionCard
       title="Treatment Arms"
       headerRight={
-        onEdit ? (
-          <Button size="1" onClick={onEdit}>
-            <Pencil2Icon />
-            Edit
-          </Button>
+        balanceBadge || editButton ? (
+          <Flex gap="3" align="center">
+            {balanceBadge}
+            {editButton}
+          </Flex>
         ) : undefined
       }
     >

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -110,14 +110,14 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
         label="Balanced"
         color="green"
         variant="soft"
-        tooltip="A statistical check found your metric and strata values evenly distributed across the arms at assignment. View the Design Details for test results."
+        tooltip="A statistical check found your metric and strata values evenly distributed across the arms at assignment. See Design Details for the test results."
       />
     ) : (
       <InfoBadge
         label="Unbalanced"
         color="red"
         variant="soft"
-        tooltip="A statistical check suggests your metric and strata values are unevenly distributed across the arms. View the Design Details for test results."
+        tooltip="A statistical check suggests your metric and strata values are unevenly distributed across the arms. See Design Details for the test results."
       />
     );
   const editButton = onEdit ? (

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge, Button, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon, LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
+import { LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
 import { ArmBandit, CreateExperimentResponse, PriorTypes } from '@/api/methods.schemas';
 import { isBanditSpec } from '@/services/experiment-utils';
 import { SectionCard } from '@/components/ui/cards/section-card';
@@ -107,7 +107,6 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
     <Tooltip content="Participants are split evenly across all arms.">
       <Badge color="green" variant="soft">
         Balanced
-        <InfoCircledIcon />
       </Badge>
     </Tooltip>
   ) : undefined;

--- a/src/components/features/experiments/sections/treatment-arms-section.tsx
+++ b/src/components/features/experiments/sections/treatment-arms-section.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Badge, Button, Flex, Separator, Text, Tooltip } from '@radix-ui/themes';
-import { InfoCircledIcon, LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
+import { Badge, Button, Flex, Separator, Text } from '@radix-ui/themes';
+import { LayersIcon, Pencil2Icon, PersonIcon } from '@radix-ui/react-icons';
 import { ArmBandit, CreateExperimentResponse, PriorTypes } from '@/api/methods.schemas';
 import { isBanditSpec } from '@/services/experiment-utils';
 import { SectionCard } from '@/components/ui/cards/section-card';
+import { InfoBadge } from '@/components/ui/info-badge';
 import { ReadMoreText } from '@/components/ui/read-more-text';
 
 interface ArmAssignmentBadgesProps {
@@ -105,19 +106,19 @@ export function TreatmentArmsSection({ response, onEdit }: TreatmentArmsSectionP
   const balanceOk = assignSummary?.balance_check?.balance_ok;
   const balanceBadge =
     balanceOk == null ? undefined : balanceOk ? (
-      <Tooltip content="A statistical check found your metric and strata values evenly distributed across the arms at assignment.">
-        <Badge color="green" variant="soft">
-          Balanced
-          <InfoCircledIcon />
-        </Badge>
-      </Tooltip>
+      <InfoBadge
+        label="Balanced"
+        color="green"
+        variant="soft"
+        tooltip="A statistical check found your metric and strata values evenly distributed across the arms at assignment."
+      />
     ) : (
-      <Tooltip content="A statistical check suggests your metric and strata values are unevenly distributed across the arms. See Design Details on the Metrics card for the test results.">
-        <Badge color="red" variant="soft">
-          Unbalanced
-          <InfoCircledIcon />
-        </Badge>
-      </Tooltip>
+      <InfoBadge
+        label="Unbalanced"
+        color="red"
+        variant="soft"
+        tooltip="A statistical check suggests your metric and strata values are unevenly distributed across the arms. See Design Details on the Metrics card for the test results."
+      />
     );
   const editButton = onEdit ? (
     <Button size="1" onClick={onEdit}>

--- a/src/components/ui/info-badge.tsx
+++ b/src/components/ui/info-badge.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { InfoCircledIcon } from '@radix-ui/react-icons';
+import { Badge, Flex, Tooltip } from '@radix-ui/themes';
+import type { ComponentProps } from 'react';
+
+interface InfoBadgeProps {
+  label: string;
+  tooltip: string;
+  color?: ComponentProps<typeof Badge>['color'];
+  variant?: ComponentProps<typeof Badge>['variant'];
+  size?: ComponentProps<typeof Badge>['size'];
+}
+
+export function InfoBadge({ label, tooltip, color, variant, size }: InfoBadgeProps) {
+  return (
+    <Badge color={color} variant={variant} size={size}>
+      <Flex gap="1" align="center">
+        {label}
+        <Tooltip content={tooltip}>
+          <InfoCircledIcon />
+        </Tooltip>
+      </Flex>
+    </Badge>
+  );
+}

--- a/src/services/experiment-utils.ts
+++ b/src/services/experiment-utils.ts
@@ -51,6 +51,27 @@ export const metricHasMissingValues = (analysis: MetricPowerAnalysis): boolean =
   return available_n != null && available_nonnull_n != null && available_n > available_nonnull_n;
 };
 
+/**
+ * Whether the chosen sample size reaches the minimum required to detect the metric's target MDE.
+ * Assignment enrolls exactly the chosen sample (including participants with missing values),
+ * regardless of how many participants the datasource could supply.
+ * Returns undefined when the analysis or the relevant sample size value is missing.
+ */
+export const isChosenSampleSufficient = (
+  analysis: MetricPowerAnalysis | undefined,
+  isClustered: boolean,
+  desiredN?: number | null,
+  desiredNClusters?: number | null,
+): boolean | undefined => {
+  if (analysis === undefined) return undefined;
+  if (isClustered) {
+    return analysis.num_clusters_total != null && desiredNClusters != null
+      ? desiredNClusters >= analysis.num_clusters_total
+      : undefined;
+  }
+  return analysis.target_n != null && desiredN != null ? desiredN >= analysis.target_n : undefined;
+};
+
 export const isFreqExperimentType = (
   experimentType?: ExperimentType,
 ): experimentType is AnyFrequentistDesignSpecExperimentType =>


### PR DESCRIPTION
Declutters the experiment summary screen. For agency-fund/evidential-be#231.

## Changes

- Removed the Power & Balance card from the summary; its content remains available via the Design Details dialog, now reachable from the Metrics card header.
- Treatment Arms: removed the per-arm "(balanced)" tags; a single "Balanced" badge (with a hover tooltip and info badges) appears in the card header when the primary metric and stratas are equally distributed in all arms. 
- Metrics: each metric now shows Target MDE with an Sufficient / Insufficient badge (right-aligned, from `sufficient_n`) on the first row, and Estimated MDE on a second row. The badges have explanatory hover tooltips with info badges. Sufficient means the chosen sample (missing values are assumed to be filled later) is large enough to meet the estimated MDE
- The Design Details dialog accepts precomputed metric displays and an optional schema so the summary screen can reuse it.
- Experiment details page: the "Viewing:" badge moved to the front of the Analysis header's left group and "Design Details" to the right slot, so the details button appears in the same place on both pages.

## Screenshots

<img width="1169" height="777" alt="Screenshot 2026-07-23 at 2 30 17 PM" src="https://github.com/user-attachments/assets/f61d26b7-57df-478a-ab80-24e1ade65c3d" />

<img width="1193" height="817" alt="Screenshot 2026-07-23 at 2 30 51 PM" src="https://github.com/user-attachments/assets/f684ec95-a3c9-42b9-9d5d-c35da876ab97" />

<img width="566" height="781" alt="Screenshot 2026-07-23 at 2 31 37 PM" src="https://github.com/user-attachments/assets/6c7955ee-1e5b-4b4c-8ea3-b9a17d48e006" />

<img width="1000" height="370" alt="ExperimentDetailsPage" src="https://github.com/user-attachments/assets/6583c449-98bb-4d3d-b31f-be482f0aa23d" />


## Open questions

**Negative Estimated MDE for boolean metrics.** The backend solves the detectable effect in the decreasing direction for binary metrics, so the badge shows e.g. -10.1%. This predates this PR. Show the magnitude instead?