### PR TITLE
Adjust pnpm behavior during install and start.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,7 +35,7 @@ tasks:
         echo "Tip: Run 'nvm install' from the repo root to install and then run 'nvm use' to switch to the correct version."
         exit 1
       fi
-      corepack pnpm install --frozen-lockfile
+      corepack pnpm install --frozen-lockfile --yes
   start:
     desc: 'Starts the development server'
     interactive: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,6 @@ ignoreScripts: true
 saveExact: true
 # min age is in minutes for pnpm; 5d=7200
 minimumReleaseAge: 7200
-
 publicHoistPattern:
 - "*import-in-the-middle*"
 - "*require-in-the-middle*"
@@ -14,3 +13,5 @@ allowBuilds:
   '@sentry/cli': true
   esbuild: true
   sharp: true
+
+updateNotifier: false


### PR DESCRIPTION
In the presence of an old node_modules directory, pnpm prompts to replace the existing deps in a way that is obscured by the version update (in some terminals). This PR allows it to proceed with reasonable defaults. 
