### PR TITLE
Datasource form width fix

### DIFF
--- a/src/app/experiments/create/datasource-form/datasource-form-def.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-form-def.tsx
@@ -2,6 +2,7 @@ import { packScreen, WizardForm } from '@/services/wizard/wizard-types';
 import { SelectDatasourceScreen } from './select-datasource-screen';
 import { SelectTableScreen } from './select-table-screen';
 import { type ExperimentType } from '@/services/experiment-utils';
+import { type DatasourceMode } from './datasource-mode';
 
 export type DatasourceFormInputData = {
   datasourceId?: string;
@@ -23,7 +24,7 @@ export type DatasourceFormData = {
   // Experiment type context from the parent wizard (read-only)
   experimentType?: ExperimentType;
   // Selection mode: existing or create
-  selectionMode: 'existing' | 'create';
+  selectionMode: Exclude<DatasourceMode, 'none'>;
 };
 
 // Screen identifiers for the datasource wizard

--- a/src/app/experiments/create/datasource-form/datasource-form-def.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-form-def.tsx
@@ -1,12 +1,6 @@
 import { packScreen, WizardForm } from '@/services/wizard/wizard-types';
 import { SelectDatasourceScreen } from './select-datasource-screen';
 import { SelectTableScreen } from './select-table-screen';
-
-// Delegate to the existing datasource form reducer
-import {
-  DatasourceFormData as CreateDatasourceFormData,
-  defaultDatasourceFormData,
-} from '@/components/features/datasources/add-datasource-form';
 import { type ExperimentType } from '@/services/experiment-utils';
 
 export type DatasourceFormInputData = {
@@ -30,8 +24,6 @@ export type DatasourceFormData = {
   experimentType?: ExperimentType;
   // Selection mode: existing or create
   selectionMode: 'existing' | 'create';
-  // Create datasource form state (reuse existing interface)
-  createForm: CreateDatasourceFormData;
 };
 
 // Screen identifiers for the datasource wizard
@@ -42,7 +34,6 @@ const screen = packScreen<DatasourceFormData, DatasourceScreenId>();
 
 export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, DatasourceFormInputData> = {
   initialData: (inputData) => ({
-    createForm: defaultDatasourceFormData(),
     datasourceId: inputData?.datasourceId,
     tableName: inputData?.tableName,
     primaryKey: inputData?.primaryKey,
@@ -80,7 +71,6 @@ export const DatasourceForm: WizardForm<DatasourceFormData, DatasourceScreenId, 
             tableName: undefined,
             primaryKey: undefined,
             clusterKey: undefined,
-            createForm: defaultDatasourceFormData(),
           };
         }
         return data;

--- a/src/app/experiments/create/datasource-form/datasource-mode-selector.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-mode-selector.tsx
@@ -39,7 +39,7 @@ export const DatasourceModeSelector = ({
         )}
       </Flex>
     </RadioGroup.Root>
-    {mode === 'existing' && existingContent}
+    {hasDatasources && mode === 'existing' && existingContent}
     {mode === 'create' && createContent}
   </Flex>
 );

--- a/src/app/experiments/create/datasource-form/datasource-mode-selector.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-mode-selector.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { Flex, RadioGroup, Text } from '@radix-ui/themes';
+import { ReactNode } from 'react';
+
+export type DatasourceMode = 'existing' | 'create' | 'none';
+
+interface DatasourceModeSelectorProps {
+  mode: DatasourceMode;
+  onModeChange: (mode: DatasourceMode) => void;
+  hasDatasources: boolean;
+  showNoDwhOption?: boolean;
+  existingContent?: ReactNode;
+  createContent?: ReactNode;
+}
+
+export const DatasourceModeSelector = ({
+  mode,
+  onModeChange,
+  hasDatasources,
+  showNoDwhOption = false,
+  existingContent,
+  createContent,
+}: DatasourceModeSelectorProps) => (
+  <Flex direction="column" gap="3">
+    <RadioGroup.Root value={mode} onValueChange={(value) => onModeChange(value as DatasourceMode)}>
+      <Flex direction="column" gap="2">
+        {hasDatasources && (
+          <RadioGroup.Item value="existing">
+            <Text weight="bold">Use an existing datasource</Text>
+          </RadioGroup.Item>
+        )}
+        <RadioGroup.Item value="create">
+          <Text weight="bold">Create a new datasource</Text>
+        </RadioGroup.Item>
+        {showNoDwhOption && (
+          <RadioGroup.Item value="none">
+            <Text weight="bold">No data warehouse</Text>
+          </RadioGroup.Item>
+        )}
+      </Flex>
+    </RadioGroup.Root>
+    {mode === 'existing' && existingContent}
+    {mode === 'create' && createContent}
+  </Flex>
+);

--- a/src/app/experiments/create/datasource-form/datasource-mode-selector.tsx
+++ b/src/app/experiments/create/datasource-form/datasource-mode-selector.tsx
@@ -1,8 +1,7 @@
 'use client';
 import { Flex, RadioGroup, Text } from '@radix-ui/themes';
 import { ReactNode } from 'react';
-
-export type DatasourceMode = 'existing' | 'create' | 'none';
+import { DatasourceMode } from './datasource-mode';
 
 interface DatasourceModeSelectorProps {
   mode: DatasourceMode;

--- a/src/app/experiments/create/datasource-form/datasource-mode.ts
+++ b/src/app/experiments/create/datasource-form/datasource-mode.ts
@@ -1,0 +1,5 @@
+// How the datasource step sources outcome data: an existing datasource, a newly
+// created one, or (MAB only) no data warehouse at all. Lives in its own module so
+// type-only consumers (form defs, experiment-form-types) can share it without
+// depending on renderable components.
+export type DatasourceMode = 'existing' | 'create' | 'none';

--- a/src/app/experiments/create/datasource-form/select-datasource-screen.tsx
+++ b/src/app/experiments/create/datasource-form/select-datasource-screen.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { DatasourceFormData, DatasourceScreenId } from './datasource-form-def';
-import { Card, Flex, RadioGroup, Text } from '@radix-ui/themes';
+import { Card, Flex } from '@radix-ui/themes';
 import { useListOrganizationDatasources } from '@/api/admin';
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { XSpinner } from '@/components/ui/x-spinner';
-import { CreateDatasourceForm } from './create-datasource-form';
+import { CreateDatasourceForm } from '@/components/features/datasources/create-datasource-form';
 import { DatasourceCardsGrid } from '@/app/experiments/create/datasource-form/datasource-cards-grid';
+import { DatasourceModeSelector } from '@/app/experiments/create/datasource-form/datasource-mode-selector';
 import { DatasourceSummary } from '@/api/methods.schemas';
 import { isUsableDatasource } from '@/services/genapi-helpers';
 
@@ -61,40 +62,29 @@ export const SelectDatasourceScreen = ({
     );
   }
 
-  // Case 2: Has datasources - show RadioCards toggle
+  // Case 2: Has datasources - show mode toggle with the active option's content below
   return (
-    <Flex direction="column" gap="3">
-      <Flex direction={'column'} gap={'3'}>
-        <RadioGroup.Root
-          value={data.selectionMode}
-          onValueChange={(value) => dispatch({ type: 'set-mode', value: value as 'existing' | 'create' })}
-        >
-          <RadioGroup.Item value="existing">
-            <Text weight="bold">Use an existing datasource</Text>
-            {data.selectionMode === 'existing' && (
-              <DatasourceCardsGrid
-                datasources={availableDatasources}
-                selectedDatasourceId={data.datasourceId}
-                onSelect={(id) => dispatch({ type: 'set-datasource', value: id })}
-              />
-            )}
-          </RadioGroup.Item>
-
-          <RadioGroup.Item value="create">
-            <Text weight="bold">Create a new datasource</Text>
-            {data.selectionMode === 'create' && (
-              <Card>
-                <CreateDatasourceForm
-                  onDatasourceCreated={(id) => {
-                    dispatch({ type: 'datasource-created', datasourceId: id });
-                    navigateNext();
-                  }}
-                />
-              </Card>
-            )}
-          </RadioGroup.Item>
-        </RadioGroup.Root>
-      </Flex>
-    </Flex>
+    <DatasourceModeSelector
+      mode={data.selectionMode}
+      onModeChange={(mode) => dispatch({ type: 'set-mode', value: mode as 'existing' | 'create' })}
+      hasDatasources={hasDatasources}
+      existingContent={
+        <DatasourceCardsGrid
+          datasources={availableDatasources}
+          selectedDatasourceId={data.datasourceId}
+          onSelect={(id) => dispatch({ type: 'set-datasource', value: id })}
+        />
+      }
+      createContent={
+        <Card>
+          <CreateDatasourceForm
+            onDatasourceCreated={(id) => {
+              dispatch({ type: 'datasource-created', datasourceId: id });
+              navigateNext();
+            }}
+          />
+        </Card>
+      }
+    />
   );
 };

--- a/src/app/experiments/create/experiment-form/experiment-form-types.ts
+++ b/src/app/experiments/create/experiment-form/experiment-form-types.ts
@@ -14,6 +14,7 @@ import {
 } from '@/api/methods.schemas';
 import { ErrorType } from '@/services/orval-fetch';
 import { type ExperimentType, isMabExperimentType } from '@/services/experiment-utils';
+import { type DatasourceMode } from '@/app/experiments/create/datasource-form/datasource-mode';
 
 export type ContextVariableType = ContextType;
 
@@ -91,7 +92,7 @@ export type ExperimentFormData = {
   primaryKey?: string;
   clusterKey?: string;
   // mab-select-datasource-screen options
-  dwhMode?: 'none' | 'existing' | 'create';
+  dwhMode?: DatasourceMode;
   // mab-select-datasource-screen: the DWH column read as each participant's outcome. When set, a MAB
   // experiment is created as mab_online_dwh instead of mab_online. Left undefined for API-only MAB.
   targetFieldName?: string;

--- a/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
@@ -8,14 +8,13 @@ import { useListOrganizationDatasources } from '@/api/admin';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { DatasourceCardsGrid } from '../datasource-form/datasource-cards-grid';
 import { CreateDatasourceForm } from '@/components/features/datasources/create-datasource-form';
-import { DatasourceMode, DatasourceModeSelector } from '../datasource-form/datasource-mode-selector';
+import { DatasourceMode } from '../datasource-form/datasource-mode';
+import { DatasourceModeSelector } from '../datasource-form/datasource-mode-selector';
 import { SelectTableFields } from './select-table-fields';
 import { isUsableDatasource } from '@/services/genapi-helpers';
 
-export type DwhMode = DatasourceMode;
-
 export type ExperimentMabSelectDatasourceMessages =
-  | { type: 'set-dwh-mode'; value: DwhMode }
+  | { type: 'set-dwh-mode'; value: DatasourceMode }
   | { type: 'set-datasource'; datasourceId: string }
   | { type: 'set-table'; tableName: string }
   | { type: 'set-primary-key'; primaryKey?: string }
@@ -44,7 +43,7 @@ export const ExperimentMabSelectDatasourceScreen = ({
 
   const hasDatasources = availableDatasources.length > 0;
   // Default to connecting a warehouse; fall back to create when there are none yet.
-  const mode: DwhMode = data.dwhMode ?? (hasDatasources ? 'existing' : 'create');
+  const mode: DatasourceMode = data.dwhMode ?? (hasDatasources ? 'existing' : 'create');
 
   // The table/target picker, shown inside whichever datasource option is active once one is chosen.
   const datasourceId = data.datasourceId;

--- a/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
+++ b/src/app/experiments/create/experiment-form/experiment-mab-select-datasource-screen.tsx
@@ -2,16 +2,17 @@
 import { ScreenProps } from '@/services/wizard/wizard-types';
 import { ExperimentFormData, ExperimentScreenId } from '@/app/experiments/create/experiment-form/experiment-form-types';
 import { DataType } from '@/api/methods.schemas';
-import { Card, Flex, RadioGroup, Text } from '@radix-ui/themes';
+import { Card, Flex } from '@radix-ui/themes';
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { useListOrganizationDatasources } from '@/api/admin';
 import { XSpinner } from '@/components/ui/x-spinner';
 import { DatasourceCardsGrid } from '../datasource-form/datasource-cards-grid';
-import { CreateDatasourceForm } from '../datasource-form/create-datasource-form';
+import { CreateDatasourceForm } from '@/components/features/datasources/create-datasource-form';
+import { DatasourceMode, DatasourceModeSelector } from '../datasource-form/datasource-mode-selector';
 import { SelectTableFields } from './select-table-fields';
 import { isUsableDatasource } from '@/services/genapi-helpers';
 
-export type DwhMode = 'none' | 'existing' | 'create';
+export type DwhMode = DatasourceMode;
 
 export type ExperimentMabSelectDatasourceMessages =
   | { type: 'set-dwh-mode'; value: DwhMode }
@@ -23,7 +24,7 @@ export type ExperimentMabSelectDatasourceMessages =
 /**
  * Optional MAB step for binding the bandit to a data-warehouse target column. A single radio picks how
  * outcomes are recorded — no warehouse (API-only), an existing datasource, or a new one — and the
- * shared table / primary key / target-column picker appears inline once a datasource is chosen.
+ * shared table / primary key / target-column picker appears below the options once a datasource is chosen.
  */
 export const ExperimentMabSelectDatasourceScreen = ({
   data,
@@ -66,46 +67,33 @@ export const ExperimentMabSelectDatasourceScreen = ({
   return (
     <Flex direction="column" gap="3">
       <Card>
-        <RadioGroup.Root
-          value={mode}
-          onValueChange={(value) => dispatch({ type: 'set-dwh-mode', value: value as DwhMode })}
-        >
-          <Flex direction="column" gap="3">
-            {hasDatasources && (
-              <RadioGroup.Item value="existing">
-                <Text weight="bold">Use an existing datasource</Text>
-                {mode === 'existing' && (
-                  <Flex direction="column" gap="3">
-                    <DatasourceCardsGrid
-                      datasources={availableDatasources}
-                      selectedDatasourceId={data.datasourceId}
-                      onSelect={(id) => dispatch({ type: 'set-datasource', datasourceId: id })}
-                    />
-                    {picker}
-                  </Flex>
-                )}
-              </RadioGroup.Item>
-            )}
-
-            <RadioGroup.Item value="create">
-              <Text weight="bold">Create a new datasource</Text>
-              {mode === 'create' &&
-                (data.datasourceId ? (
-                  picker
-                ) : (
-                  <Card>
-                    <CreateDatasourceForm
-                      onDatasourceCreated={(id) => dispatch({ type: 'set-datasource', datasourceId: id })}
-                    />
-                  </Card>
-                ))}
-            </RadioGroup.Item>
-
-            <RadioGroup.Item value="none">
-              <Text weight="bold">No data warehouse</Text>
-            </RadioGroup.Item>
-          </Flex>
-        </RadioGroup.Root>
+        <DatasourceModeSelector
+          mode={mode}
+          onModeChange={(value) => dispatch({ type: 'set-dwh-mode', value })}
+          hasDatasources={hasDatasources}
+          showNoDwhOption
+          existingContent={
+            <Flex direction="column" gap="3">
+              <DatasourceCardsGrid
+                datasources={availableDatasources}
+                selectedDatasourceId={data.datasourceId}
+                onSelect={(id) => dispatch({ type: 'set-datasource', datasourceId: id })}
+              />
+              {picker}
+            </Flex>
+          }
+          createContent={
+            data.datasourceId ? (
+              picker
+            ) : (
+              <Card>
+                <CreateDatasourceForm
+                  onDatasourceCreated={(id) => dispatch({ type: 'set-datasource', datasourceId: id })}
+                />
+              </Card>
+            )
+          }
+        />
       </Card>
     </Flex>
   );

--- a/src/components/features/datasources/add-datasource-dialog.tsx
+++ b/src/components/features/datasources/add-datasource-dialog.tsx
@@ -4,15 +4,14 @@ import { useReducer, useState } from 'react';
 import { Button, Dialog, Flex, Text } from '@radix-ui/themes';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import { PlusIcon } from '@radix-ui/react-icons';
-import { BqDsn, PostgresDsn, RedshiftDsn } from '@/api/methods.schemas';
 import { mutate } from 'swr';
-import { PostgresSslModes } from '@/services/typehelper';
 import { ApiError } from '@/services/orval-fetch';
 import {
-  AddDatasourceForm,
+  AddDatasourceFormFields,
+  buildDsn,
   datasourceFormReducer,
   defaultDatasourceFormData,
-} from '@/components/features/datasources/add-datasource-form';
+} from '@/components/features/datasources/add-datasource-form-fields';
 
 export function AddDatasourceDialog({ organizationId }: { organizationId: string }) {
   const [open, setOpen] = useState(false);
@@ -40,45 +39,11 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    let dsn: PostgresDsn | RedshiftDsn | BqDsn;
-    if (formData.dwhType === 'postgres') {
-      dsn = {
-        type: 'postgres',
-        host: formData.host,
-        port: parseInt(formData.port),
-        dbname: formData.database,
-        user: formData.user,
-        password: { type: 'revealed', value: formData.password },
-        sslmode: formData.sslmode as PostgresSslModes,
-        search_path: formData.search_path || null,
-      };
-    } else if (formData.dwhType === 'redshift') {
-      dsn = {
-        type: 'redshift',
-        host: formData.host,
-        port: parseInt(formData.port),
-        dbname: formData.database,
-        user: formData.user,
-        password: { type: 'revealed', value: formData.password },
-        search_path: formData.search_path || null,
-      };
-    } else {
-      dsn = {
-        type: 'bigquery',
-        project_id: formData.project_id,
-        dataset_id: formData.dataset,
-        credentials: {
-          type: 'serviceaccountinfo',
-          content: formData.credentials_json,
-        },
-      };
-    }
-
     await trigger(
       {
         organization_id: organizationId,
         name: formData.name,
-        dsn,
+        dsn: buildDsn(formData),
       },
       {
         throwOnError: false,
@@ -113,7 +78,7 @@ export function AddDatasourceDialog({ organizationId }: { organizationId: string
           {error && !isDNSError && <GenericErrorCallout title="Failed to add datasource" error={error} />}
 
           <Flex direction="column" gap="3">
-            <AddDatasourceForm data={formData} dispatch={dispatch} isDNSError={isDNSError} />
+            <AddDatasourceFormFields data={formData} dispatch={dispatch} isDNSError={isDNSError} />
           </Flex>
 
           <Flex gap="3" mt="4" justify="end">

--- a/src/components/features/datasources/add-datasource-form-fields.tsx
+++ b/src/components/features/datasources/add-datasource-form-fields.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { Button, Flex, RadioGroup, Text, TextField } from '@radix-ui/themes';
 import { EyeClosedIcon, EyeOpenIcon, InfoCircledIcon } from '@radix-ui/react-icons';
-import { ApiOnlyDsn, Dsn, PostgresDsnSslmode } from '@/api/methods.schemas';
+import { ApiOnlyDsn, BqDsn, Dsn, PostgresDsn, PostgresDsnSslmode, RedshiftDsn } from '@/api/methods.schemas';
+import { PostgresSslModes } from '@/services/typehelper';
 import { ServiceAccountJsonField } from '@/components/features/datasources/service-account-json-field';
 
 const portMap: Record<string, string> = {
@@ -100,13 +101,48 @@ export function datasourceFormReducer(data: DatasourceFormData, msg: AddDatasour
   }
 }
 
-interface AddDatasourceFormProps {
+export function buildDsn(data: DatasourceFormData): PostgresDsn | RedshiftDsn | BqDsn {
+  if (data.dwhType === 'postgres') {
+    return {
+      type: 'postgres',
+      host: data.host,
+      port: parseInt(data.port),
+      dbname: data.database,
+      user: data.user,
+      password: { type: 'revealed', value: data.password },
+      sslmode: data.sslmode as PostgresSslModes,
+      search_path: data.search_path || null,
+    };
+  }
+  if (data.dwhType === 'redshift') {
+    return {
+      type: 'redshift',
+      host: data.host,
+      port: parseInt(data.port),
+      dbname: data.database,
+      user: data.user,
+      password: { type: 'revealed', value: data.password },
+      search_path: data.search_path || null,
+    };
+  }
+  return {
+    type: 'bigquery',
+    project_id: data.project_id,
+    dataset_id: data.dataset,
+    credentials: {
+      type: 'serviceaccountinfo',
+      content: data.credentials_json,
+    },
+  };
+}
+
+interface AddDatasourceFormFieldsProps {
   data: DatasourceFormData;
   dispatch: (msg: AddDatasourceFormMessage) => void;
   isDNSError?: boolean;
 }
 
-export function AddDatasourceForm({ data, dispatch, isDNSError }: AddDatasourceFormProps) {
+export function AddDatasourceFormFields({ data, dispatch, isDNSError }: AddDatasourceFormFieldsProps) {
   const { dwhType, showPassword } = data;
 
   return (

--- a/src/components/features/datasources/create-datasource-form.tsx
+++ b/src/components/features/datasources/create-datasource-form.tsx
@@ -2,16 +2,15 @@
 import { getListOrganizationDatasourcesKey, useCreateDatasource } from '@/api/admin';
 import { useCurrentOrganization } from '@/providers/organization-provider';
 import { Button, Flex } from '@radix-ui/themes';
-import { BqDsn, PostgresDsn, RedshiftDsn } from '@/api/methods.schemas';
 import { mutate } from 'swr';
-import { PostgresSslModes } from '@/services/typehelper';
 import { ApiError } from '@/services/orval-fetch';
 import { GenericErrorCallout } from '@/components/ui/generic-error';
 import {
-  AddDatasourceForm,
+  AddDatasourceFormFields,
+  buildDsn,
   datasourceFormReducer,
   defaultDatasourceFormData,
-} from '@/components/features/datasources/add-datasource-form';
+} from '@/components/features/datasources/add-datasource-form-fields';
 import { useReducer } from 'react';
 
 interface CreateDatasourceFormProps {
@@ -40,45 +39,11 @@ export const CreateDatasourceForm = ({ onDatasourceCreated }: CreateDatasourceFo
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
-    let dsn: PostgresDsn | RedshiftDsn | BqDsn;
-    if (formData.dwhType === 'postgres') {
-      dsn = {
-        type: 'postgres',
-        host: formData.host,
-        port: parseInt(formData.port),
-        dbname: formData.database,
-        user: formData.user,
-        password: { type: 'revealed', value: formData.password },
-        sslmode: formData.sslmode as PostgresSslModes,
-        search_path: formData.search_path || null,
-      };
-    } else if (formData.dwhType === 'redshift') {
-      dsn = {
-        type: 'redshift',
-        host: formData.host,
-        port: parseInt(formData.port),
-        dbname: formData.database,
-        user: formData.user,
-        password: { type: 'revealed', value: formData.password },
-        search_path: formData.search_path || null,
-      };
-    } else {
-      dsn = {
-        type: 'bigquery',
-        project_id: formData.project_id,
-        dataset_id: formData.dataset,
-        credentials: {
-          type: 'serviceaccountinfo',
-          content: formData.credentials_json,
-        },
-      };
-    }
-
     await trigger(
       {
         organization_id: organizationId,
         name: formData.name,
-        dsn,
+        dsn: buildDsn(formData),
       },
       {
         throwOnError: false,
@@ -89,7 +54,7 @@ export const CreateDatasourceForm = ({ onDatasourceCreated }: CreateDatasourceFo
   return (
     <form onSubmit={handleSubmit}>
       <Flex direction="column" gap="2">
-        <AddDatasourceForm data={formData} dispatch={dispatch} isDNSError={isDNSError} />
+        <AddDatasourceFormFields data={formData} dispatch={dispatch} isDNSError={isDNSError} />
       </Flex>
       {error && !isDNSError && <GenericErrorCallout title="Failed to add datasource" error={error} />}
       <Flex gap="3" mt="4" justify="end">


### PR DESCRIPTION
## Ticket
Craeted by Doug [here](https://idinsight.atlassian.net/browse/EVE-159?atlOrigin=eyJpIjoiNWM5YmI4Yzg5MWYxNGEyYzg5YmYwMjQ0Mzk4YTRmMTkiLCJwIjoiaiJ9)

## Related PRs

None, frontend only.

## Description

### Goal

The "Create Datasource" step rendered at different widths depending on experiment type: full width in the Online (freq) wizard but shrunk to fit-content in the MAB wizard. Make the datasource step render consistently across all experiment flows, and clean up the component duplication that caused the divergence.

### Changes

**Layout fix**

- Root cause: form content was nested inside Radix `RadioGroup.Item`, which renders as a fit-content `<label>`. This shrank the content, produced invalid nested-label HTML, and forwarded clicks on form fields to the radio.
- Added shared `DatasourceModeSelector`: a compact radio group (existing / create / optional "no data warehouse") with the active option's content rendered full width below the group.
- Both `select-datasource-screen.tsx` (Online) and `experiment-mab-select-datasource-screen.tsx` (MAB) now use it, replacing two hand-rolled radio layouts. Entry fields intentionally use the full card width.

**Refactor**

- Extracted `buildDsn()`: the form-state to DSN payload mapping was duplicated ~45 lines verbatim in `add-datasource-dialog.tsx` and `create-datasource-form.tsx`.
- Renamed `add-datasource-form.tsx` to `add-datasource-form-fields.tsx` (`AddDatasourceForm` to `AddDatasourceFormFields`): it is a fieldset with no form or submit, now distinguishable from `create-datasource-form.tsx`, the submitting form that wraps it.
- Moved `create-datasource-form.tsx` to `components/features/datasources/`: it is shared datasource UI used by both wizard flows, not wizard machinery.
- Removed dead `createForm` state from `datasource-form-def.tsx` (written on init/reset, never read).

## How has this been tested?

- Manually verified in the local app: the create-datasource form renders at the same full width in both Online and MAB datasource steps (org with and without existing datasources). See preview here for frequentist:
<img width="1153" height="846" alt="Screenshot 2026-08-04 at 12 38 32" src="https://github.com/user-attachments/assets/adca2a14-4c6b-4109-a4da-7f92a919dc20" />
And same for MAB:
<img width="1233" height="824" alt="Screenshot 2026-08-04 at 12 39 06" src="https://github.com/user-attachments/assets/25e190b6-84e3-48f7-b700-e4fb3c8e9794" />


## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

